### PR TITLE
docs: add missing Button import

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -94,7 +94,7 @@ import { Input } from 'flowbite-vue'
 ## Slot - Suffix
 ```vue
 <script setup>
-import { Input } from 'flowbite-vue'
+import { Input, Button } from 'flowbite-vue'
 </script>
 <template>
   <Input size="lg" placeholder="enter your search query" label="Search">


### PR DESCRIPTION
Hi! 👋 

I was trying some examples and I noticed that an import (`Button`) was missing in the last code snippet of the inputs. Let me know your feedback!