### PR TITLE
fix: Omitting tailwind classes

### DIFF
--- a/src/utils/simplifyTailwindClasses.ts
+++ b/src/utils/simplifyTailwindClasses.ts
@@ -19,7 +19,7 @@ const getTypeFromClass = (_class: string, matchers: TailwindClassMatcherMap = cl
 }
 
 export function simplifyTailwindClasses(...classes: (string | string[])[]): string {
-    return classes.reduce((acc: { types: string[], classes: string[] }, value: string | string[]) => {
+    return classes.filter(_ => _).reduce((acc: { types: string[], classes: string[] }, value: string | string[]) => {
         const currentClasses = Array.isArray(value)
             ? Array.from(value).map(_ => _.split(' ')).flat() // to support args like ['text-white background-red', 'flex'] etc.
             : value.split(' ')


### PR DESCRIPTION
Fixes simplifyTailwindClasses omitting types when a second class of the type is present (e.g. `border` together with `border-gray-300`) and is called with an empty string argument (`simplifyTailwindClasses('border border-gray-300', '')`).

Fix is done by simply filtering empty strings before going on with the main functionality of the function.

This fixes the issue #181.