### PR TITLE
fix: remove h-auto from Modal class

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -9,7 +9,7 @@
         @click.self="clickOutside"
     >
       <div
-          class="relative p-4 w-full h-full md:h-auto"
+          class="relative p-4 w-full h-full"
           :class="`${modalSizeClasses[size]}`"
       >
         <!-- Modal content -->


### PR DESCRIPTION
Hello, the class md:h-auto creates a bug where the content that overflows the height of the page is not seen.
Of course the bug only happens if display window is larger than md.

You can try to put extra text in your [modal example](https://flowbite-vue.com/components/accordion) till it exceeds the window height. When removing md:h-auto, this problem disappears as the class is h-max