### PR TITLE
feat: inherit attrs to `Textarea` + fix `Input` label color

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -1,6 +1,8 @@
 <script setup>
 import FwbTextareaExample from './textarea/examples/FwbTextareaExample.vue'
 import FwbTextareaExampleComment from './textarea/examples/FwbTextareaExampleComment.vue'
+import FwbTextareaExampleDisabled from './textarea/examples/FwbTextareaExampleDisabled.vue'
+import FwbTextareaExampleFormId from './textarea/examples/FwbTextareaExampleFormId.vue'
 </script>
 
 # Vue Textarea - Flowbite
@@ -24,7 +26,7 @@ Get started with the default example of a textarea component below.
     v-model="message"
     :rows="4"
     label="Your message"
-    placeholder="Write you message..."
+    placeholder="Write your message..."
   />
 </template>
 
@@ -50,7 +52,7 @@ Most often the textarea component is used as the main text field input element i
         :rows="3"
         custom
         label="Your message"
-        placeholder="Write you message..."
+        placeholder="Write your message..."
       >
         <template #footer>
           <div class="flex items-center justify-between">
@@ -92,4 +94,56 @@ import { FwbA, FwbButton, FwbTextarea } from 'flowbite-vue'
 
 const message = ref('')
 </script>
+```
+
+## Disabled / Readonly Textarea
+
+<fwb-textarea-example-disabled />
+```vue
+<template>
+  <div>
+    <fwb-textarea
+      v-model="message"
+      label="Your message"
+      placeholder="Write your message..."
+      disabled
+    />
+    <fwb-textarea
+      v-model="message"
+      label="Your message"
+      placeholder="Write your message..."
+      readonly
+    />
+  </div>
+</template>
+```
+
+## Textarea with form ID
+
+<fwb-textarea-example-form-id />
+```vue
+<template>
+  <div>
+    <form id="my-form" @submit.prevent="handleSubmit">
+      <!-- Inside the form -->
+      <fwb-textarea
+        v-model="message"
+        label="Your message"
+        placeholder="Write your message..."
+      />
+      <fwb-button type="submit">
+        Submit
+      </fwb-button>
+    </form>
+
+    <!-- Outside the form -->
+    <fwb-textarea
+      v-model="message"
+      label="Your message"
+      placeholder="Write your message..."
+      form="my-form"
+      required
+    />
+  </div>
+</template>
 ```

--- a/docs/components/textarea/examples/FwbTextareaExample.vue
+++ b/docs/components/textarea/examples/FwbTextareaExample.vue
@@ -4,7 +4,7 @@
       v-model="message"
       :rows="4"
       label="Your message"
-      placeholder="Write you message..."
+      placeholder="Write your message..."
     />
   </div>
 </template>

--- a/docs/components/textarea/examples/FwbTextareaExampleComment.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleComment.vue
@@ -5,7 +5,7 @@
       :rows="3"
       custom
       label="Your message"
-      placeholder="Write you message..."
+      placeholder="Write your message..."
     >
       <template #footer>
         <div class="flex items-center justify-between">
@@ -84,7 +84,10 @@
     </fwb-textarea>
     <p class="ml-auto text-xs text-gray-500 dark:text-gray-400">
       Remember, contributions to this topic should follow our
-      <fwb-a href="#">
+      <fwb-a
+        class="underline"
+        href="#"
+      >
         Community Guidelines
       </fwb-a>.
     </p>

--- a/docs/components/textarea/examples/FwbTextareaExampleDisabled.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleDisabled.vue
@@ -1,0 +1,36 @@
+<template>
+  <form
+    class="vp-raw"
+    @submit.prevent
+  >
+    <fwb-textarea
+      v-model="message"
+      label="Textarea with minlength 10 and maxlength 20"
+      minlength="10"
+      maxlength="20"
+      required
+    />
+    <fwb-textarea
+      v-model="message"
+      label="Disabled textarea"
+      placeholder="Cannot be edited"
+      disabled
+    />
+    <fwb-textarea
+      v-model="message"
+      label="Readonly textarea"
+      placeholder="Cannot be edited"
+      readonly
+    />
+    <fwb-button type="submit">
+      Validate
+    </fwb-button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbButton, FwbTextarea } from '../../../../src/index'
+
+const message = ref('Edit me!')
+</script>

--- a/docs/components/textarea/examples/FwbTextareaExampleFormId.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleFormId.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="flex flex-col gap-y-4">
+    <form
+      id="fwb-textarea-example-form-id"
+      class="vp-raw"
+      @submit.prevent
+    >
+      <fwb-input
+        v-model="inputMessage"
+        label="Input inside the form"
+        placeholder="Write your message..."
+      />
+      <fwb-button
+        class="mt-2"
+        type="submit"
+      >
+        Validate
+      </fwb-button>
+    </form>
+    <fwb-textarea
+      v-model="textareaMessage"
+      label="Textarea outside the form"
+      form="fwb-textarea-example-form-id"
+      minlength="20"
+      required
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbButton, FwbInput, FwbTextarea } from '../../../../src/index'
+
+const inputMessage = ref('')
+const textareaMessage = ref('')
+</script>

--- a/src/components/FwbInput/composables/useInputClasses.ts
+++ b/src/components/FwbInput/composables/useInputClasses.ts
@@ -55,7 +55,7 @@ export function useInputClasses (props: UseInputClassesProps): {
       ? 'text-green-700 dark:text-green-500'
       : vs === validationStatusMap.Error
         ? 'text-red-700 dark:text-red-500'
-        : 'text-gray-900 dark:text-gray-300'
+        : 'text-gray-900 dark:text-white'
 
     return twMerge(baseLabelClasses, classByStatus)
   })

--- a/src/components/FwbTextarea/FwbTextarea.vue
+++ b/src/components/FwbTextarea/FwbTextarea.vue
@@ -4,16 +4,10 @@
     <span :class="wrapperClasses">
       <textarea
         v-model="model"
-        :rows="rows"
+        v-bind="$attrs"
         :class="textareaClasses"
+        :rows="rows"
         :placeholder="placeholder"
-        :form="form"
-        :disabled="disabled"
-        :maxlength="maxlength"
-        :minlength="minlength"
-        :required="required"
-        :readonly="readonly"
-        :wrap="wrap"
       />
       <span
         v-if="$slots.footer"
@@ -30,20 +24,16 @@ import { computed } from 'vue'
 import { useTextareaClasses } from './composables/useTextareaClasses'
 
 interface TextareaProps {
-  modelValue?: string;
-  label?: string;
-  rows?: number;
-  custom?: boolean;
-  placeholder?: string;
-  disabled?: boolean;
-  form?: string;
-  maxlength?: string | number;
-  minlength?: string | number;
-  required?: boolean;
-  readonly?: boolean;
-  /** Docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#wrap */
-  wrap?: 'hard' | 'soft' | 'off';
+  modelValue?: string
+  label?: string
+  rows?: number
+  custom?: boolean
+  placeholder?: string
 }
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<TextareaProps>(), {
   modelValue: '',
@@ -51,10 +41,6 @@ const props = withDefaults(defineProps<TextareaProps>(), {
   rows: 4,
   custom: false,
   placeholder: 'Write your message here...',
-  form: undefined,
-  maxlength: '',
-  minlength: '',
-  wrap: 'soft',
 })
 
 const emit = defineEmits(['update:modelValue'])
@@ -67,10 +53,5 @@ const model = computed({
   },
 })
 
-const {
-  textareaClasses,
-  labelClasses,
-  wrapperClasses,
-  footerClasses,
-} = useTextareaClasses(props.custom)
+const { textareaClasses, labelClasses, wrapperClasses, footerClasses } = useTextareaClasses(props.custom)
 </script>

--- a/src/components/FwbTextarea/FwbTextarea.vue
+++ b/src/components/FwbTextarea/FwbTextarea.vue
@@ -7,6 +7,13 @@
         :rows="rows"
         :class="textareaClasses"
         :placeholder="placeholder"
+        :form="form"
+        :disabled="disabled"
+        :maxlength="maxlength"
+        :minlength="minlength"
+        :required="required"
+        :readonly="readonly"
+        :wrap="wrap"
       />
       <span
         v-if="$slots.footer"
@@ -28,6 +35,14 @@ interface TextareaProps {
   rows?: number;
   custom?: boolean;
   placeholder?: string;
+  disabled?: boolean;
+  form?: string;
+  maxlength?: string | number;
+  minlength?: string | number;
+  required?: boolean;
+  readonly?: boolean;
+  /** Docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#wrap */
+  wrap?: 'hard' | 'soft' | 'off';
 }
 
 const props = withDefaults(defineProps<TextareaProps>(), {
@@ -36,6 +51,10 @@ const props = withDefaults(defineProps<TextareaProps>(), {
   rows: 4,
   custom: false,
   placeholder: 'Write your message here...',
+  form: undefined,
+  maxlength: '',
+  minlength: '',
+  wrap: 'soft',
 })
 
 const emit = defineEmits(['update:modelValue'])


### PR DESCRIPTION
<s>Added the following attributes to `Textarea`:
- `disabled`
- `form`
- `maxlength`
- `minlength`
- `required`
- `readonly`
- `wrap`
</s>

Update: used `inheritAttrs: false` in `defineOptions`

Other information:
The label text color of `Textarea` is different from `Input` in dark mode, with `text-gray-300` vs `text-white`. Is this by design?

<img width="586" alt="image" src="https://github.com/themesberg/flowbite-vue/assets/62269186/61a71cc8-6aa8-4f8b-9f6e-f0497b96b5c7">
