### PR TITLE
fix: Fix `aria-controls` attribute in `fwb-sidebar-dropdown-item` component and add documentation to assess ARIA allowed attribute issue

### DIFF
--- a/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
@@ -3,7 +3,6 @@
     <button
       type="button"
       class="flex items-center w-full p-2 text-base text-gray-900 transition duration-75 rounded-lg group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700 z-10"
-      aria-controls="dropdown-example"
       @click="toggleDropdown"
     >
       <slot name="icon">

--- a/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
@@ -3,7 +3,7 @@
     <button
       type="button"
       class="flex items-center w-full p-2 text-base text-gray-900 transition duration-75 rounded-lg group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700 z-10"
-      aria-controls=""
+      aria-controls="dropdown-content"
       @click="toggleDropdown"
     >
       <slot name="icon">

--- a/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
@@ -3,6 +3,7 @@
     <button
       type="button"
       class="flex items-center w-full p-2 text-base text-gray-900 transition duration-75 rounded-lg group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700 z-10"
+      aria-controls=""
       @click="toggleDropdown"
     >
       <slot name="icon">


### PR DESCRIPTION
When using the `FwbSidebarDropdownItem` component together with Chromatic Storybook, it throws an Accessibility Test error due to ARIA attribute value as attached in the following screenshot:

![Screenshot 2023-12-12 at 13 47 25 (2)](https://github.com/themesberg/flowbite-vue/assets/72168158/a003e2f3-1f93-4743-9aeb-97c2260dda40)

# Suggested Fix

- rename `aria-controls="dropdown-example"` to `dropdown-content`
- add documentation to tell user to set `id` to `dropdown-content` in a wrapping `div` element when using the component