### PR TITLE
refactor: expose `isOpen` to use in `arrow-icon` slot

### DIFF
--- a/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineExpose, ref } from 'vue'
+import { ref } from 'vue'
 const isOpen = ref(false)
 function toggleDropdown () {
   isOpen.value = !isOpen.value

--- a/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
@@ -64,13 +64,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineExpose } from 'vue'
+import { defineExpose, ref } from 'vue'
 const isOpen = ref(false)
 function toggleDropdown () {
   isOpen.value = !isOpen.value
 }
 
 defineExpose({
-	isOpen,
-});
+  isOpen,
+})
 </script>

--- a/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarDropdownItem.vue
@@ -64,9 +64,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, defineExpose } from 'vue'
 const isOpen = ref(false)
 function toggleDropdown () {
   isOpen.value = !isOpen.value
 }
+
+defineExpose({
+	isOpen,
+});
 </script>


### PR DESCRIPTION
# Description

When using the custom `arrow-icon` slot from `SidebarDropdownItem` component, it is not possible to use the `isOpen` `ref` value used in the official component in the Flowbite-Vue library.

# Suggested Fix

- expose the `isOpen` `ref` value with `defineExpose`
- add documentation for this