### PR TITLE
Fix accordion component calculations and header classes

### DIFF
--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -134,7 +134,7 @@ import {
 ```
 
 ## Flush accordion
-Flush prop removes side borders, and rounded corners
+Flush prop removes background color, side borders, and rounded corners
 
 <fwb-accordion-example-flush />
 ```vue

--- a/src/components/FwbAccordion/FwbAccordionPanel.vue
+++ b/src/components/FwbAccordion/FwbAccordionPanel.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { nanoid } from 'nanoid'
 import { useAccordionState } from './composables/useAccordionState'
 
@@ -26,11 +26,16 @@ const accordionState = computed(() => {
 })
 
 onMounted(() => {
-  const panelsCount = Object.keys(accordionState?.value?.panels)?.length
+  const panelIndex = Array.from(panel.value.parentElement.children).indexOf(panel.value)
   accordionState.value.panels[panelId] = {
     id: panelId,
-    order: panelsCount,
-    isVisible: (accordionState.value.openFirstItem && panelsCount === 0) ?? false,
+    order: panelIndex,
+    isVisible: (accordionState.value.openFirstItem && panelIndex === 0) ?? false,
+  }
+})
+onUnmounted(() => {
+  if (accordionState.value.panels[panelId]) {
+    delete accordionState.value.panels[panelId]
   }
 })
 </script>

--- a/src/components/FwbAccordion/composables/useAccordionContentClasses.ts
+++ b/src/components/FwbAccordion/composables/useAccordionContentClasses.ts
@@ -4,7 +4,7 @@ import { twMerge } from 'tailwind-merge'
 
 const baseContentClasses = 'p-5 border border-gray-200 dark:border-gray-700 dark:bg-gray-900'
 
-export function useAccordionContentClasses(contentRef: Ref) {
+export function useAccordionContentClasses (contentRef: Ref) {
   const accordionId = computed(() => contentRef.value.parentElement.parentElement.dataset.accordionId)
   const panelId = computed(() => contentRef.value.parentElement.dataset.panelId)
   const { accordionsStates } = useAccordionState()

--- a/src/components/FwbAccordion/composables/useAccordionContentClasses.ts
+++ b/src/components/FwbAccordion/composables/useAccordionContentClasses.ts
@@ -4,20 +4,21 @@ import { twMerge } from 'tailwind-merge'
 
 const baseContentClasses = 'p-5 border border-gray-200 dark:border-gray-700 dark:bg-gray-900'
 
-export function useAccordionContentClasses (contentRef: Ref) {
+export function useAccordionContentClasses(contentRef: Ref) {
   const accordionId = computed(() => contentRef.value.parentElement.parentElement.dataset.accordionId)
   const panelId = computed(() => contentRef.value.parentElement.dataset.panelId)
   const { accordionsStates } = useAccordionState()
   const accordionState = computed(() => accordionsStates[accordionId.value])
   const panelState = computed(() => accordionsStates[accordionId.value].panels[panelId.value])
-  const panelsCount = computed(() => Object.keys(accordionsStates[accordionId.value].panels[panelId.value]).length)
+  const panelsCount = computed(() => Object.keys(accordionState.value.panels).length)
+  const isLastPanel = computed(() => panelState.value.order === panelsCount.value - 1)
 
   const contentClasses = computed(() => {
     return twMerge(
       baseContentClasses,
       !panelState.value.isVisible && 'hidden',
-      (panelState.value.order !== panelsCount.value - 1 || accordionState.value.flush) && 'border-b-0',
-      panelState.value.order === panelsCount.value - 1 && 'border-t-0',
+      (!isLastPanel.value || accordionState.value.flush) && 'border-b-0',
+      isLastPanel.value && 'border-t-0',
       accordionState.value.flush && 'border-x-0',
     )
   })

--- a/src/components/FwbAccordion/composables/useAccordionHeaderClasses.ts
+++ b/src/components/FwbAccordion/composables/useAccordionHeaderClasses.ts
@@ -20,7 +20,7 @@ export function useAccordionHeaderClasses (headerRef: Ref) {
   const headerClasses = computed(() => {
     return twMerge(
       baseHeaderClasses,
-      panelState.value.isVisible ? 'text-gray-900 dark:white' : 'text-gray-500 dark:text-gray-400',
+      panelState.value.isVisible ? 'text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400',
       panelState.value.isVisible && !accordionState.value.flush && 'bg-gray-100 dark:bg-gray-800',
       isFirstPanel.value && !accordionState.value.flush && 'rounded-t-xl',
       isFirstPanel.value && accordionState.value.flush && 'border-t-0',

--- a/src/components/FwbAccordion/composables/useAccordionHeaderClasses.ts
+++ b/src/components/FwbAccordion/composables/useAccordionHeaderClasses.ts
@@ -2,28 +2,30 @@ import { computed, type Ref } from 'vue'
 import { useAccordionState } from './useAccordionState'
 import { twMerge } from 'tailwind-merge'
 
-const baseHeaderClasses =
-  'flex items-center p-5 w-full font-medium text-left text-gray-500 border border-gray-200 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-800 dark:border-gray-700 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+const baseHeaderClasses = 'flex items-center p-5 w-full font-medium text-left border border-gray-200 dark:border-gray-700'
+const nonFlushHeaderClasses = 'hover:bg-gray-100 dark:hover:bg-gray-800 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-800'
+
 const baseArrowClasses = 'w-6 h-6 shrink-0'
 
-export function useAccordionHeaderClasses (headerRef: Ref) {
+export function useAccordionHeaderClasses(headerRef: Ref) {
   const accordionId = computed(() => headerRef.value.parentElement.parentElement.dataset.accordionId)
   const panelId = computed(() => headerRef.value.parentElement.dataset.panelId)
   const { accordionsStates } = useAccordionState()
   const accordionState = computed(() => accordionsStates[accordionId.value])
   const panelState = computed(() => accordionState.value.panels[panelId.value])
-  const panelsCount = computed(() => Object.keys(panelState.value).length)
-  const isPanelLast = computed(() => panelState.value.order !== panelsCount.value - 1)
-  const isBottomBorderVisibleForFlush = computed(() => isPanelLast.value || (accordionState.value.flush && panelState.value.order === panelsCount.value - 1 && !panelState.value.isVisible))
+  const panelsCount = computed(() => Object.keys(accordionState.value.panels).length)
+  const isFirstPanel = computed(() => panelState.value.order === 0)
+  const isLastPanel = computed(() => panelState.value.order === panelsCount.value - 1)
 
   const headerClasses = computed(() => {
     return twMerge(
       baseHeaderClasses,
-      panelState.value.isVisible && 'bg-gray-100 dark:bg-gray-800',
-      panelState.value.order === 0 && !accordionState.value.flush && 'rounded-t-xl',
-      panelState.value.order === 0 && accordionState.value.flush && 'border-t-0',
-      isBottomBorderVisibleForFlush.value && 'border-b-0',
-      accordionState.value.flush && 'border-x-0',
+      panelState.value.isVisible ? 'text-gray-900 dark:white' : 'text-gray-500 dark:text-gray-400',
+      panelState.value.isVisible && !accordionState.value.flush && 'bg-gray-100 dark:bg-gray-800',
+      isFirstPanel.value && !accordionState.value.flush && 'rounded-t-xl',
+      isFirstPanel.value && accordionState.value.flush && 'border-t-0',
+      accordionState.value.flush ? 'border-x-0' : nonFlushHeaderClasses,
+      !isLastPanel.value && 'border-b-0',
     )
   })
   const arrowClasses = computed(() => {

--- a/src/components/FwbAccordion/composables/useAccordionHeaderClasses.ts
+++ b/src/components/FwbAccordion/composables/useAccordionHeaderClasses.ts
@@ -7,7 +7,7 @@ const nonFlushHeaderClasses = 'hover:bg-gray-100 dark:hover:bg-gray-800 focus:ri
 
 const baseArrowClasses = 'w-6 h-6 shrink-0'
 
-export function useAccordionHeaderClasses(headerRef: Ref) {
+export function useAccordionHeaderClasses (headerRef: Ref) {
   const accordionId = computed(() => headerRef.value.parentElement.parentElement.dataset.accordionId)
   const panelId = computed(() => headerRef.value.parentElement.dataset.panelId)
   const { accordionsStates } = useAccordionState()


### PR DESCRIPTION
This is a fix for #238 

When accordion panels are rendered dynamically the order calculations won't work properly because the actual DOM render and FwbAccordionPanel.vue onMounted function order are reversed. So the last rendered element has the order 0. This happens when the key attribute is unique each time. For this reason, I have updated the order calculation to check the actual DOM index. I have explained this in detail below with screenshots.

I have added onUnmounted to delete panel references that are removed.

In the composable files, the panel count calculation is wrong because it checks the keys of the 'panel' object. It always has 3 props: id, isVisible, and order. So in the calculation, the panel count is always 3. I have updated this to check the keys of the 'panels' object.

Lastly, I have updated some classes to match flush accordion styles.

---

**Accordion Panel Render Issue**

To test this, I have added an input as the number of accordion panels. And made sure it's a full render each time, by updating the id. I have also passed the title as a prop to log the title.

![image](https://github.com/themesberg/flowbite-vue/assets/51010000/fa908a86-8ed7-47e2-8801-8ba29d832bf9)


Then I logged the calculated count and title (FwbAccordionPanel.vue)

![image](https://github.com/themesberg/flowbite-vue/assets/51010000/77e7c261-b0c1-4d3e-8308-6fc80a7a2a88)

Here is the result

![image](https://github.com/themesberg/flowbite-vue/assets/51010000/dde5d8d3-7851-4e8f-a843-df54d8387dba)

![image](https://github.com/themesberg/flowbite-vue/assets/51010000/8b04ebf7-58bd-47cf-8c38-6d962f6b3bf0)
