### PR TITLE
add a notice about importing css

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -45,3 +45,11 @@ module.exports = {
 import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
+
+> Make sure you have tailwind css imported
+
+```
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```


### PR DESCRIPTION
I'm new to tailwind ecosystem and didn't know that I need to import css. I thought it might be good idea to notify user. Maybe not like I did. I'm open for suggestion. maybe add another optional step `install tailwind`.