### PR TITLE
fixed wrong component names in the docs

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -46,25 +46,25 @@ import { FwbDropdown } from 'flowbite-vue'
 ```vue
 <template>
   <fwb-dropdown text="Menu">
-    <list-group>
-      <list-group-item>
+    <fwb-list-group>
+      <fwb-list-group-item>
         Profile
-      </list-group-item>
-      <list-group-item>
+      </fwb-list-group-item>
+      <fwb-list-group-item>
         Settings
-      </list-group-item>
-      <list-group-item>
+      </fwb-list-group-item>
+      <fwb-list-group-item>
         Messages
-      </list-group-item>
-      <list-group-item>
+      </fwb-list-group-item>
+      <fwb-list-group-item>
         Download
-      </list-group-item>
-    </list-group>
+      </fwb-list-group-item>
+    </fwb-list-group>
   </fwb-dropdown>
 </template>
 
 <script setup>
-import { FwbDropdown, ListGroup, ListGroupItem } from 'flowbite-vue'
+import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
 
@@ -73,28 +73,28 @@ import { FwbDropdown, ListGroup, ListGroupItem } from 'flowbite-vue'
 <fwb-dropdown-example-trigger />
 ```vue
 <template>
-  <fwb-dropdown text="Bottom">
+  <fwb-dropdown>
     <template #trigger>
       <span>Custom Trigger Element</span>
     </template>
-    <list-group>
-      <list-group-item>
+    <fwb-list-group>
+      <fwb-list-group-item>
         Profile
-      </list-group-item>
-      <list-group-item>
+      </fwb-list-group-item>
+      <fwb-list-group-item>
         Settings
-      </list-group-item>
-      <list-group-item>
+      </fwb-list-group-item>
+      <fwb-list-group-item>
         Messages
-      </list-group-item>
-      <list-group-item>
+      </fwb-list-group-item>
+      <fwb-list-group-item>
         Download
-      </list-group-item>
-    </list-group>
+      </fwb-list-group-item>
+    </fwb-list-group>
   </fwb-dropdown>
 </template>
 
 <script setup>
-import { FwbDropdown, ListGroup, ListGroupItem } from 'flowbite-vue'
+import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```


### PR DESCRIPTION
somehow I've missed updating component names in two of  the examples in the docs for the Dropdown component:

![image](https://github.com/themesberg/flowbite-vue/assets/2791138/74b6b55c-4b84-4160-ab61-3e3d614f1978)
![image](https://github.com/themesberg/flowbite-vue/assets/2791138/af23d22a-1745-4aad-b2d1-132589c393f6)

both are fixed by this PR