### PR TITLE
Added HTML attribute: accept in FwbFileInput

### DIFF
--- a/src/components/FwbFileInput/FwbFileInput.vue
+++ b/src/components/FwbFileInput/FwbFileInput.vue
@@ -7,6 +7,7 @@
           :class="fileInpClasses"
           :multiple="multiple"
           type="file"
+          :accept="accept"
           @change="handleChange"
         >
       </label>
@@ -65,7 +66,8 @@ interface FileInputProps {
   label?: string
   modelValue?: File | File[] | null
   multiple?: boolean
-  size?: string
+  size?: string,
+  accept?:string,
 }
 
 const props = withDefaults(defineProps<FileInputProps>(), {
@@ -74,6 +76,7 @@ const props = withDefaults(defineProps<FileInputProps>(), {
   modelValue: null,
   multiple: false,
   size: 'sm',
+  accept: ''
 })
 
 const dropZoneText = computed(() => {

--- a/src/components/FwbFileInput/FwbFileInput.vue
+++ b/src/components/FwbFileInput/FwbFileInput.vue
@@ -49,6 +49,7 @@
         <input
           :multiple="multiple"
           type="file"
+          :accept="accept"
           class="hidden"
         >
       </label>


### PR DESCRIPTION
The input file type component was missing native html attribute accept so in this commit i have included that. So now the users can use it something like  `<fwb-file-input v-model="file" label="Upload file" accept="video/*"  />`