### PR TITLE
feat: add positioning options to FwbModal

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -3,6 +3,7 @@ import FwbModalExample from './modal/examples/FwbModalExample.vue'
 import FwbModalExampleSize from './modal/examples/FwbModalExampleSize.vue'
 import FwbModalExampleEscapable from './modal/examples/FwbModalExampleEscapable.vue'
 import FwbModalExamplePersistent from './modal/examples/FwbModalExamplePersistent.vue'
+import FwbModalExamplePosition from './modal/examples/FwbModalExamplePosition.vue'
 </script>
 # Vue Modal - Flowbite
 
@@ -84,6 +85,33 @@ The default value is: `2xl`
   <fwb-modal size="md" />
   <fwb-modal size="xl" />
   <fwb-modal size="5xl" />
+</template>
+
+<script setup>
+import { FwbModal } from 'flowbite-vue'
+</script>
+```
+
+## Position
+
+The `position` prop allows you to control the placement of the modal on the screen, taking into account RTL (Right-to-Left) mode. You can choose from the following options:
+
+`top-start`, `top-center`, `top-end`, `center-start`, `center`, `center-end`, `bottom-start`, `bottom-center`, `bottom-end`
+
+The default value is: `center`
+
+<fwb-modal-example-position />
+```vue
+<template>
+  <fwb-modal position="top-start" />
+  <fwb-modal position="top-center" />
+  <fwb-modal position="top-end" />
+  <fwb-modal position="center-start" />
+  <fwb-modal position="center" />
+  <fwb-modal position="center-end" />
+  <fwb-modal position="bottom-start" />
+  <fwb-modal position="bottom-center" />
+  <fwb-modal position="bottom-end" />
 </template>
 
 <script setup>

--- a/docs/components/modal/examples/FwbModalExample.vue
+++ b/docs/components/modal/examples/FwbModalExample.vue
@@ -8,6 +8,7 @@
       :not-escapable="notEscapable"
       :persistent="persistent"
       :size="size"
+      :position="position"
       @close="closeModal"
     >
       <template #header>
@@ -45,13 +46,14 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { FwbButton, FwbModal } from '../../../../src/index'
-import { type ModalSize } from '../../../../src/components/FwbModal/types'
+import { type ModalPosition, type ModalSize } from '../../../../src/components/FwbModal/types'
 
 interface ModalProps {
   size?: ModalSize,
   notEscapable?: boolean,
   persistent?: boolean,
   triggerText?: string
+  position?: ModalPosition
 }
 
 withDefaults(defineProps<ModalProps>(), {
@@ -59,6 +61,7 @@ withDefaults(defineProps<ModalProps>(), {
   notEscapable: false,
   persistent: false,
   triggerText: 'Open Modal',
+  position: 'center',
 })
 
 const isShowModal = ref(false)

--- a/docs/components/modal/examples/FwbModalExamplePosition.vue
+++ b/docs/components/modal/examples/FwbModalExamplePosition.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="flex flex-wrap justify-start gap-2 vp-raw">
+    <span>
+      <fwb-modal-example
+        position="top-start"
+        trigger-text="Top Start"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="top-center"
+        trigger-text="Top Center"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="top-end"
+        trigger-text="Top End"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="center-start"
+        trigger-text="Center Start"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="center"
+        trigger-text="Center"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="center-end"
+        trigger-text="Center End"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="bottom-start"
+        trigger-text="Bottom Start"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="bottom-center"
+        trigger-text="Bottom Center"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="bottom-end"
+        trigger-text="Bottom End"
+      />
+    </span>
+  </div>
+</template>
+
+<script setup>
+import FwbModalExample from './FwbModalExample.vue'
+</script>

--- a/src/components/FwbModal/FwbModal.vue
+++ b/src/components/FwbModal/FwbModal.vue
@@ -80,7 +80,7 @@ const props = withDefaults(defineProps<ModalProps>(), {
 })
 
 const emit = defineEmits(['close', 'click:outside'])
-const modalSizeClasses = {
+const modalSizeClasses: Record<ModalSize, string> = {
   xs: 'max-w-xs',
   sm: 'max-w-sm',
   md: 'max-w-md',
@@ -94,7 +94,7 @@ const modalSizeClasses = {
   '7xl': 'max-w-7xl',
 }
 
-const modalPositionClasses = {
+const modalPositionClasses: Record<ModalPosition, string> = {
   'top-start': 'self-start justify-self-start',
   'top-center': 'self-start justify-self-center',
   'top-end': 'self-start justify-self-end',

--- a/src/components/FwbModal/FwbModal.vue
+++ b/src/components/FwbModal/FwbModal.vue
@@ -23,7 +23,7 @@
             <button
               v-if="!persistent"
               aria-label="close"
-              class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
+              class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ms-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
               type="button"
               @click="closeModal"
             >

--- a/src/components/FwbModal/FwbModal.vue
+++ b/src/components/FwbModal/FwbModal.vue
@@ -3,14 +3,14 @@
     <div class="bg-gray-900 bg-opacity-50 dark:bg-opacity-80 fixed inset-0 z-40" />
     <div
       ref="modalRef"
-      class="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 w-full md:inset-0 h-modal md:h-full justify-center items-center flex"
+      class="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 w-full md:inset-0 h-modal md:h-full grid"
       tabindex="0"
       @click.self="clickOutside"
       @keyup.esc="closeWithEsc"
     >
       <div
-        :class="`${modalSizeClasses[size]}`"
-        class="relative p-4 w-full h-full"
+        :class="`${modalSizeClasses[size]} ${modalPositionClasses[position]}`"
+        class="relative p-4 w-full"
       >
         <!-- Modal content -->
         <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
@@ -63,18 +63,20 @@
 
 <script lang="ts" setup>
 import { onMounted, ref, type Ref } from 'vue'
-import type { ModalSize } from './types'
+import type { ModalPosition, ModalSize } from './types'
 
 interface ModalProps {
   notEscapable?: boolean,
   persistent?: boolean
   size?: ModalSize,
+  position?: ModalPosition
 }
 
 const props = withDefaults(defineProps<ModalProps>(), {
   notEscapable: false,
   persistent: false,
   size: '2xl',
+  position: 'center',
 })
 
 const emit = defineEmits(['close', 'click:outside'])
@@ -90,6 +92,18 @@ const modalSizeClasses = {
   '5xl': 'max-w-5xl',
   '6xl': 'max-w-6xl',
   '7xl': 'max-w-7xl',
+}
+
+const modalPositionClasses = {
+  'top-start': 'self-start justify-self-start',
+  'top-center': 'self-start justify-self-center',
+  'top-end': 'self-start justify-self-end',
+  'center-start': 'self-center justify-self-start',
+  center: 'self-center justify-self-center',
+  'center-end': 'self-center justify-self-end',
+  'bottom-start': 'self-end justify-self-start',
+  'bottom-center': 'self-end justify-self-center',
+  'bottom-end': 'self-end justify-self-end',
 }
 
 function closeModal () {

--- a/src/components/FwbModal/types.ts
+++ b/src/components/FwbModal/types.ts
@@ -1,2 +1,2 @@
-export type ModalPosition = 'bottom-left' | 'bottom-right' | 'bottom-center' | 'top-left' | 'top-center' | 'top-right' | 'center-left' | 'center' | 'center-right';
+export type ModalPosition = 'bottom-start' | 'bottom-end' | 'bottom-center' | 'top-start' | 'top-center' | 'top-end' | 'center-start' | 'center' | 'center-end';
 export type ModalSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl';


### PR DESCRIPTION
Currently `FwbModal` doesn't have position prop to control modal's placement on the screen. This PR adds this feature taking into consideration possible usage in RTL (Right-to-Left) mode. 

1. Modal's parent element is `display: block` and the `position` prop sets corresponding classes responsible for modal's alignment. Default position is `center`.
2. There's a small fix of close button alignment in RTL mode - usage of logical property `ms-auto` instead of `ml-auto`.
3. As was mentioned [here](https://github.com/themesberg/flowbite-vue/issues/279#issuecomment-2138002688) on current implementation click outside (on top/under a modal specifically) doesn't close a modal. Fixed with this PR as well.

Closes: #279 #235