### PR TITLE
#298 Adjust type of prop 'link' of FwbSidebarItem.vue

### DIFF
--- a/src/components/FwbSidebar/FwbSidebarItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarItem.vue
@@ -19,7 +19,7 @@
 import { resolveComponent } from 'vue'
 const props = withDefaults(
   defineProps<{
-    link?: string
+    link?: string | { name: string }
     tag?: string
   }>(),
   {


### PR DESCRIPTION
#298

In order to make the `<FwbSidebarItem>` work with named router links, I propose the following.

Now of course, the type `{ name: string }` could be extracted into an `interface` if you wish.

## Edit:

This could be adjusted to take route parameters in the `FwbSidebarItem`, so the input would not be just  `{ name: string }` instead `{ name: string, params ?: {[key: string]: string|number} }`

Of course the type for the `params` is more complex than this: `{[key: string]: string|number}`.


```vue
// Assuming that I have the path `/tool/foo/{baz}`
<FwbSidebarItem :to="{ name: 'tool-foo-name', params: {baz: 23}}">
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated sidebar item links to support both string URLs and named route objects for improved navigation flexibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->