### PR TITLE
feat(dropdown): add show/hide events

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -257,3 +257,26 @@ import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 import { FwbDropdown, ListGroup, ListGroupItem } from 'flowbite-vue'
 </script>
 ```
+
+## API
+
+### Props
+| Name     | Values | Default |
+|----------|--------|---------|
+| placement | `DropdownPlacement` | `'bottom'`  |
+| text | `string` | `''` |
+| transition | `string` | `''` |
+| closeInside | `boolean` | `false` |
+| alignToEnd | `boolean` | `false` |
+
+### Events
+| Name | Description            |
+|------|------------------------|
+| show | the dropdown is opened |
+| hide | the dropdown is closed |
+
+### Slots
+| Name       | Description       |
+|------------|-------------------|
+| default    | dropdown content  |
+| suffix     | button suffix     |

--- a/src/components/FwbDropdown/FwbDropdown.vue
+++ b/src/components/FwbDropdown/FwbDropdown.vue
@@ -75,8 +75,8 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'show'): void,
-  (e: 'hide'): void,
+  'show': []
+  'hide': []
 }>()
 
 watch(

--- a/src/components/FwbDropdown/FwbDropdown.vue
+++ b/src/components/FwbDropdown/FwbDropdown.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, toRef } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { onClickOutside } from '@vueuse/core'
 import type { DropdownPlacement } from './types'
 import FwbButton from '@/components/FwbButton/FwbButton.vue'
@@ -71,6 +71,22 @@ const props = withDefaults(
     transition: '',
     closeInside: false,
     alignToEnd: false,
+  },
+)
+
+const emit = defineEmits<{
+  (e: 'show'): void,
+  (e: 'hide'): void,
+}>()
+
+watch(
+  visible,
+  (isVisible: boolean) => {
+    if (isVisible) {
+      emit('show')
+    } else {
+      emit('hide')
+    }
   },
 )
 


### PR DESCRIPTION
Add show/hide events when opening/closing the dropdown as it can be useful to perform actions when the dropdown is toggled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive API documentation for the dropdown component, detailing props, events, and slots.
  - Added new props for the dropdown component: `placement`, `text`, `transition`, `closeInside`, and `alignToEnd`.
  - Introduced `show` and `hide` events for improved interactivity of the dropdown component.
  - Added `default` and `suffix` slots to enhance dropdown customization.
  - Dropdown now emits 'show' and 'hide' events based on its visibility state for better parent component interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->