### PR TITLE
Fix dark badge colors

### DIFF
--- a/src/components/FwbBadge/composables/useBadgeClasses.ts
+++ b/src/components/FwbBadge/composables/useBadgeClasses.ts
@@ -8,7 +8,7 @@ const onlyIconClasses = 'p-1 rounded-full mr-2'
 
 const badgeTextClasses: Record<BadgeType, string> = {
   default: 'text-blue-800 dark:text-blue-800',
-  dark: 'text-gray-800 dark:bg-gray-700',
+  dark: 'text-gray-800 dark:text-gray-300',
   red: 'text-red-800 dark:text-red-900',
   green: 'text-green-800 dark:text-green-900',
   yellow: 'text-yellow-800 dark:text-yellow-900',


### PR DESCRIPTION
The dark badge in dark mode has a dark background and dark text.

<img width="534" alt="Screenshot 2024-07-11 at 19 06 55" src="https://github.com/themesberg/flowbite-vue/assets/43420049/c4405a3e-3ed0-4e6b-b8d2-10f58ee96db8">

<img width="526" alt="Screenshot 2024-07-11 at 19 06 52" src="https://github.com/themesberg/flowbite-vue/assets/43420049/9c3eafd6-8e0a-4f51-ba79-bdc65ee30e2d">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the readability of dark mode badges by updating the text color to a lighter shade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->