### PR TITLE
fix: Fixed issue with AccordionPanel onUnmounted callback

### DIFF
--- a/src/components/FwbAccordion/FwbAccordionPanel.vue
+++ b/src/components/FwbAccordion/FwbAccordionPanel.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { nanoid } from 'nanoid'
 import { useAccordionState } from './composables/useAccordionState'
 
@@ -31,11 +31,6 @@ onMounted(() => {
     id: panelId,
     order: panelIndex,
     isVisible: (accordionState.value.openFirstItem && panelIndex === 0) ?? false,
-  }
-})
-onUnmounted(() => {
-  if (accordionState.value.panels[panelId]) {
-    delete accordionState.value.panels[panelId]
   }
 })
 </script>


### PR DESCRIPTION
https://github.com/themesberg/flowbite-vue/issues/294

The issue seems to be that when `onUnmounted` is called the `accordtionState` has already been deleted by this [onBeforeUnmount useAccordionState](https://github.com/themesberg/flowbite-vue/blob/main/src/components/FwbAccordion/composables/useAccordionState.ts#L28) callback so this was raising an error and if the state has already been deleted, no need to delete it here too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the `onUnmounted` lifecycle hook from accordion panels to streamline state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->