### PR TITLE
refactor: Update disabledClasses in FwbPagination.vue

### DIFF
--- a/src/components/FwbPagination/FwbPagination.vue
+++ b/src/components/FwbPagination/FwbPagination.vue
@@ -279,7 +279,7 @@ function getPageButtonClasses (active: boolean) {
 function getNavigationButtonClasses (toPage: number) {
   const baseClasses =
     'flex items-center justify-center first:rounded-l-lg last:rounded-r-lg px-3 h-8 ml-0 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'
-  const disabledClasses = 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-white cursor-not-allowed'
+  const disabledClasses = 'disabled:opacity-50 disabled:cursor-not-allowed'
   const largeClasses = 'px-4 h-10'
   const tableClasses =
     'border-none text-white hover:text-white bg-gray-800 rounded-none first:rounded-l last:rounded-r hover:bg-gray-900 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'


### PR DESCRIPTION
Update for point 20. on https://github.com/themesberg/flowbite-vue/discussions/236

Flowbite React taken as an example.

The disabledClasses variable in FwbPagination.vue has been updated to use the `"disabled:opacity-50 disabled:cursor-not-allowed" `classes instead of the previous `"bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-white cursor-not-allowed" `classes. This change improves the consistency and readability of the code.

I hope it turned out the way you wanted. Please check it out and feel free to give feedback.

@cogor @Sqrcz 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of disabled pagination buttons for clearer user feedback.
- **Style**
	- Updated styling approach for disabled buttons using Tailwind CSS utility classes, improving maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->