### PR TITLE
fix: FwbCard: Removed hover on non-links cards

### DIFF
--- a/src/components/FwbCard/composables/useCardClasses.ts
+++ b/src/components/FwbCard/composables/useCardClasses.ts
@@ -11,22 +11,22 @@ export function useCardsClasses (props: UseCardsClassesProps): {
   horizontalImageClasses: Ref<string>
 } {
   const cardClasses = computed(() => {
-    let classes = ''
+    let computedClasses = ''
     if (props.variant.value === 'image') {
-      classes = 'max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700'
+      computedClasses = 'max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700'
     }
 
     if (props.variant.value === 'default') {
-      classes = 'block max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 '
+      computedClasses = 'block max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 '
     } else if (props.variant.value === 'horizontal') {
-      classes = 'flex flex-col items-center bg-white rounded-lg border shadow-md md:flex-row md:max-w-xl dark:border-gray-700 dark:bg-gray-800'
+      computedClasses = 'flex flex-col items-center bg-white rounded-lg border shadow-md md:flex-row md:max-w-xl dark:border-gray-700 dark:bg-gray-800'
     }
 
     if (props.href?.value) {
-      classes += ' hover:bg-gray-100 dark:hover:bg-gray-700'
+      computedClasses += ' hover:bg-gray-100 dark:hover:bg-gray-700'
     }
 
-    return classes
+    return computedClasses
   })
 
   const horizontalImageClasses = computed(() => (props.variant.value === 'horizontal')


### PR DESCRIPTION
Current implementation of card has hover effect for the case when the card is not a link.
And on the other hand it does not have hover effect for the case when the card contains image and has a link.
This PR fixes this behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced an optional `href` property to enhance the card component's functionality, allowing for hyperlinking capabilities.
	- Improved hover effects on the card component based on the presence of the `href` property, enhancing user interaction.

- **Refactor**
	- Updated the logic for generating class strings in the card component to accommodate the new `href` property and improve responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->