### PR TITLE
Improved input layout to support proper positioning for right-to-left languages

### DIFF
--- a/docs/components/input/examples/FwbInputExampleSuffix.vue
+++ b/docs/components/input/examples/FwbInputExampleSuffix.vue
@@ -1,32 +1,100 @@
 <template>
   <div class="vp-raw">
-    <fwb-input
-      v-model="name"
-      label="Search"
-      placeholder="enter your search query"
-      size="lg"
-    >
-      <template #prefix>
-        <svg
-          aria-hidden="true"
-          class="w-5 h-5 text-gray-500 dark:text-gray-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </template>
-      <template #suffix>
-        <fwb-button>Search</fwb-button>
-      </template>
-    </fwb-input>
+    <div class="mb-4">
+      <fwb-input
+        v-model="name"
+        label="Search"
+        placeholder="enter your search query"
+        size="lg"
+      >
+        <template #prefix>
+          <svg
+            aria-hidden="true"
+            class="w-5 h-5 text-gray-500 dark:text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </template>
+        <template #suffix>
+          <fwb-button size="md">
+            Search
+          </fwb-button>
+        </template>
+      </fwb-input>
+    </div>
+
+    <div class="mb-4">
+      <fwb-input
+        v-model="name"
+        label="Search"
+        placeholder="enter your search query"
+        size="md"
+      >
+        <template #prefix>
+          <svg
+            aria-hidden="true"
+            class="w-5 h-5 text-gray-500 dark:text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </template>
+        <template #suffix>
+          <fwb-button size="sm">
+            Search
+          </fwb-button>
+        </template>
+      </fwb-input>
+    </div>
+
+    <div class="mb-4">
+      <fwb-input
+        v-model="name"
+        label="Search"
+        placeholder="enter your search query"
+        size="sm"
+      >
+        <template #prefix>
+          <svg
+            aria-hidden="true"
+            class="w-5 h-5 text-gray-500 dark:text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </template>
+        <template #suffix>
+          <fwb-button size="xs">
+            Search
+          </fwb-button>
+        </template>
+      </fwb-input>
+    </div>
   </div>
 </template>
 

--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="$slots.prefix"
-        class="flex items-center ms-3 pointer-events-none overflow-hidden flex-shrink-0"
+        class="flex items-center ms-2 flex-shrink-0"
       >
         <slot name="prefix" />
       </div>
@@ -25,7 +25,7 @@
       >
       <div
         v-if="$slots.suffix"
-        class="flex items-center me-3 flex-shrink-0"
+        class="flex items-center me-2 flex-shrink-0"
       >
         <slot name="suffix" />
       </div>

--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -4,10 +4,13 @@
       v-if="label"
       :class="labelClasses"
     >{{ label }}</label>
-    <div class="flex relative">
+    <div
+      class="flex relative items-center"
+      :class="[inputBlockClasses]"
+    >
       <div
         v-if="$slots.prefix"
-        class="w-10 flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none overflow-hidden"
+        class="flex items-center ms-3 pointer-events-none overflow-hidden flex-shrink-0"
       >
         <slot name="prefix" />
       </div>
@@ -18,11 +21,11 @@
         :type="type"
         :required="required"
         :autocomplete="autocomplete"
-        :class="[inputClasses, $slots.prefix ? 'pl-10' : '']"
+        :class="[inputClasses]"
       >
       <div
         v-if="$slots.suffix"
-        class="absolute right-2.5 bottom-2.5"
+        class="flex items-center me-3 flex-shrink-0"
       >
         <slot name="suffix" />
       </div>
@@ -79,7 +82,7 @@ const props = withDefaults(defineProps<InputProps>(), {
 
 const model = useVModel(props, 'modelValue')
 
-const { inputClasses, labelClasses } = useInputClasses(toRefs(props))
+const { inputClasses, inputBlockClasses, labelClasses } = useInputClasses(toRefs(props))
 
 const validationWrapperClasses = computed(() => twMerge(
   'mt-2 text-sm',

--- a/src/components/FwbInput/composables/useInputClasses.ts
+++ b/src/components/FwbInput/composables/useInputClasses.ts
@@ -10,8 +10,12 @@ import {
 const baseLabelClasses = 'block mb-2 text-sm font-medium'
 
 // INPUT
-const defaultInputClasses =
-  'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500'
+const defaultInputClasses = 'block flex-grow w-full p-0 bg-transparent text-inherit ring-offset-0 ring-0 border-0 focus:ring-offset-0 focus:ring-0 focus:border-0'
+
+// BLOCK
+const defaultBlockClasses =
+  'focus-within:ring-offset-0 focus-within:ring-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus-within:ring-blue-500 focus-within:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus-within:ring-blue-500 dark:focus-within:border-blue-500'
+
 const disabledInputClasses = 'cursor-not-allowed bg-gray-100'
 const inputSizeClasses: Record<InputSize, string> = {
   lg: 'p-4',
@@ -19,8 +23,8 @@ const inputSizeClasses: Record<InputSize, string> = {
   sm: 'p-2 text-sm',
 }
 
-const successInputClasses = 'bg-green-50 border-green-500 dark:border-green-500 text-green-900 dark:text-green-400 placeholder-green-700 dark:placeholder-green-500 focus:ring-green-500 focus:border-green-500'
-const errorInputClasses = 'bg-red-50 border-red-500 text-red-900 placeholder-red-700 focus:ring-red-500 focus:border-red-500 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500'
+const successInputClasses = 'bg-green-50 border-green-500 dark:border-green-500 text-green-900 dark:text-green-400 placeholder-green-700 dark:placeholder-green-500 focus-within:ring-green-500 focus-within:border-green-500'
+const errorInputClasses = 'bg-red-50 border-red-500 text-red-900 placeholder-red-700 focus-within:ring-red-500 focus-within:border-red-500 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500'
 
 export type UseInputClassesProps = {
   size: Ref<InputSize>
@@ -29,10 +33,11 @@ export type UseInputClassesProps = {
 }
 
 export function useInputClasses (props: UseInputClassesProps): {
+  inputBlockClasses: Ref<string>
   inputClasses: Ref<string>
   labelClasses: Ref<string>
 } {
-  const inputClasses = computed(() => {
+  const inputBlockClasses = computed(() => {
     const vs = props.validationStatus.value
 
     const classByStatus = vs === validationStatusMap.Success
@@ -42,11 +47,14 @@ export function useInputClasses (props: UseInputClassesProps): {
         : ''
 
     return twMerge(
-      defaultInputClasses,
+      defaultBlockClasses,
       classByStatus,
-      inputSizeClasses[props.size.value],
       props.disabled.value ? disabledInputClasses : '',
     )
+  })
+
+  const inputClasses = computed(() => {
+    return twMerge(defaultInputClasses, inputSizeClasses[props.size.value])
   })
 
   const labelClasses = computed(() => {
@@ -61,6 +69,7 @@ export function useInputClasses (props: UseInputClassesProps): {
   })
 
   return {
+    inputBlockClasses,
     inputClasses,
     labelClasses,
   }

--- a/src/components/FwbInput/composables/useInputClasses.ts
+++ b/src/components/FwbInput/composables/useInputClasses.ts
@@ -14,7 +14,7 @@ const defaultInputClasses = 'block flex-grow w-full p-0 bg-transparent text-inhe
 
 // BLOCK
 const defaultBlockClasses =
-  'focus-within:ring-offset-0 focus-within:ring-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus-within:ring-blue-500 focus-within:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus-within:ring-blue-500 dark:focus-within:border-blue-500'
+  'has-[input:focus]:ring-offset-0 has-[input:focus]:ring-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg has-[input:focus]:ring-blue-500 has-[input:focus]:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:has-[input:focus]:ring-blue-500 dark:has-[input:focus]:border-blue-500'
 
 const disabledInputClasses = 'cursor-not-allowed bg-gray-100'
 const inputSizeClasses: Record<InputSize, string> = {
@@ -23,8 +23,8 @@ const inputSizeClasses: Record<InputSize, string> = {
   sm: 'p-2 text-sm',
 }
 
-const successInputClasses = 'bg-green-50 border-green-500 dark:border-green-500 text-green-900 dark:text-green-400 placeholder-green-700 dark:placeholder-green-500 focus-within:ring-green-500 focus-within:border-green-500'
-const errorInputClasses = 'bg-red-50 border-red-500 text-red-900 placeholder-red-700 focus-within:ring-red-500 focus-within:border-red-500 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500'
+const successInputClasses = 'bg-green-50 border-green-500 dark:border-green-500 text-green-900 dark:text-green-400 placeholder-green-700 dark:placeholder-green-500 has-[input:focus]:ring-green-500 has-[input:focus]:border-green-500'
+const errorInputClasses = 'bg-red-50 border-red-500 text-red-900 placeholder-red-700 has-[input:focus]:ring-red-500 has-[input:focus]:border-red-500 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500'
 
 export type UseInputClassesProps = {
   size: Ref<InputSize>


### PR DESCRIPTION
Current FwbInput implementation uses `position: absolute` for prefix and suffix. It causes some issues with positioning for `dir="rtl"` case.
This is how the input with prefix and suffix looks like in this case:
![image](https://github.com/user-attachments/assets/cf21177e-7e18-4182-9d3a-7bd7029ceb8f)

My idea is to switch from using absolute position to just display: flex for the input wrapper. This will enable the direction management out of the box and will simplify component sizes and positions management.

This is how result looks like:
![image](https://github.com/user-attachments/assets/2d111d84-5ae8-4612-94c3-a9971765df2c)

The next step with this implementation could be improvements for different sizes of the input. Now only `size="lg"` looks good with button as suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added multiple sizes for the `<fwb-input>` component, enhancing versatility with different suffix button sizes.
	- Improved layout and styling of the input fields for better visual alignment and responsiveness.

- **Bug Fixes**
	- Adjusted prefix and suffix slots to maintain size consistency regardless of input field width.

- **Refactor**
	- Simplified and modularized styling logic for input elements, improving clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->