### PR TITLE
feat: Add label and icon for first and last buttons in FwbPagination.vue

### DIFF
--- a/src/components/FwbPagination/FwbPagination.vue
+++ b/src/components/FwbPagination/FwbPagination.vue
@@ -44,7 +44,7 @@
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
-                d="m17 16-4-4 4-4m-6 8-4-4 4-4"
+                d="m17 14-4-4 4-4m-6 8-4-4 4-4"
               />
             </svg>
           </slot>
@@ -170,7 +170,7 @@
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
-                d="m7 16 4-4-4-4m6 8 4-4-4-4"
+                d="m7 14 4-4-4-4m6 8 4-4-4-4"
               />
             </svg>
           </slot>

--- a/src/components/FwbPagination/FwbPagination.vue
+++ b/src/components/FwbPagination/FwbPagination.vue
@@ -27,7 +27,30 @@
           :class="getNavigationButtonClasses(1)"
           @click="goToFirstPage"
         >
-          First
+          <slot name="first-icon">
+            <svg
+              stroke="currentColor"
+              fill="none"
+              stroke-width="0"
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+              class="h-5 w-5"
+              height="1em"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m17 16-4-4 4-4m-6 8-4-4 4-4"
+              />
+            </svg>
+          </slot>
+          <template v-if="showLabels">
+            {{ firstLabel }}
+          </template>
         </button>
       </slot>
 
@@ -127,7 +150,30 @@
           :class="getNavigationButtonClasses(computedTotalPages)"
           @click="goToLastPage"
         >
-          Last
+          <template v-if="showLabels">
+            {{ lastLabel }}
+          </template>
+          <slot name="last-icon">
+            <svg
+              stroke="currentColor"
+              fill="none"
+              stroke-width="0"
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+              class="h-5 w-5"
+              height="1em"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m7 16 4-4-4-4m6 8 4-4-4-4"
+              />
+            </svg>
+          </slot>
         </button>
       </slot>
 
@@ -155,6 +201,8 @@ interface IPaginationProps {
   sliceLength?: number
   previousLabel?: string
   nextLabel?: string
+  firstLabel?: string
+  lastLabel?: string
   enableFirstAndLastButtons?: boolean
   showLabels?: boolean
   large?: boolean
@@ -170,6 +218,8 @@ const props = withDefaults(defineProps<IPaginationProps>(), {
   sliceLength: 2,
   previousLabel: 'Prev',
   nextLabel: 'Next',
+  firstLabel: 'First',
+  lastLabel: 'Last',
   enableFirstAndLastButtons: false,
   showLabels: true,
   large: false,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/04c3dc96-9bd9-4cca-8de4-6e38f218b572)

- Added `first` and `last` button labels for pagination.
- Integrated SVG icons for the `first` and `last` pagination buttons.
- Updated the component props to accept labels and handle the display of first and last buttons.
