### PR TITLE
fix: Fixed display of 0% inside label in progress bar

### DIFF
--- a/docs/components/progress/examples/FwbProgressExampleLabelInside.vue
+++ b/docs/components/progress/examples/FwbProgressExampleLabelInside.vue
@@ -6,6 +6,8 @@
     size="lg"
   />
 
+  <div class="mb-4" />
+
   <fwb-progress
     :progress="0"
     label-position="inside"

--- a/docs/components/progress/examples/FwbProgressExampleLabelInside.vue
+++ b/docs/components/progress/examples/FwbProgressExampleLabelInside.vue
@@ -5,6 +5,13 @@
     label-progress
     size="lg"
   />
+
+  <fwb-progress
+    :progress="0"
+    label-position="inside"
+    label-progress
+    size="lg"
+  />
 </template>
 
 <script setup>

--- a/docs/components/progress/examples/FwbProgressExampleLabelOutside.vue
+++ b/docs/components/progress/examples/FwbProgressExampleLabelOutside.vue
@@ -5,6 +5,15 @@
     label-progress
     label="Flowbite Vue 3"
   />
+
+  <div class="mb-4" />
+
+  <fwb-progress
+    :progress="0"
+    label-position="outside"
+    label-progress
+    label="Flowbite Vue 3"
+  />
 </template>
 
 <script setup>

--- a/src/components/FwbProgress/FwbProgress.vue
+++ b/src/components/FwbProgress/FwbProgress.vue
@@ -32,7 +32,7 @@
 
 <script lang="ts" setup>
 import { computed, toRefs } from 'vue'
-import { progressSafeSizes, useProgressClasses } from './composables/useProgressClasses'
+import { useProgressClasses } from './composables/useProgressClasses'
 import type { ProgressLabelPosition, ProgressSize, ProgressVariant } from './types'
 
 interface IProgressProps {
@@ -42,6 +42,13 @@ interface IProgressProps {
   labelProgress?: boolean
   progress?: number
   size?: ProgressSize
+}
+
+const progressSafeSizes: Record<ProgressSize, number> = {
+  sm: 1,
+  md: 2,
+  lg: 3,
+  xl: 4,
 }
 
 const props = withDefaults(defineProps<IProgressProps>(), {

--- a/src/components/FwbProgress/FwbProgress.vue
+++ b/src/components/FwbProgress/FwbProgress.vue
@@ -20,7 +20,7 @@
       <div
         :class="innerClasses"
         :style="{ width: progress + '%' }"
-        class="rounded-full font-medium text-blue-100 text-center p-0.5"
+        class="rounded-full font-medium text-blue-100 text-center p-0.5 min-w-max"
       >
         <template v-if="labelProgress && labelPosition === 'inside'">
           {{ progress }}%

--- a/src/components/FwbProgress/FwbProgress.vue
+++ b/src/components/FwbProgress/FwbProgress.vue
@@ -19,8 +19,8 @@
     >
       <div
         :class="innerClasses"
-        :style="{ width: progress + '%' }"
-        class="rounded-full font-medium text-blue-100 text-center p-0.5 min-w-max"
+        :style="{ width: safeProgress + '%' }"
+        class="rounded-full font-medium text-blue-100 text-center p-0.5 min-w-max box-border"
       >
         <template v-if="labelProgress && labelPosition === 'inside'">
           {{ progress }}%
@@ -31,8 +31,8 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
-import { useProgressClasses } from './composables/useProgressClasses'
+import { computed, toRefs } from 'vue'
+import { progressSafeSizes, useProgressClasses } from './composables/useProgressClasses'
 import type { ProgressLabelPosition, ProgressSize, ProgressVariant } from './types'
 
 interface IProgressProps {
@@ -51,6 +51,11 @@ const props = withDefaults(defineProps<IProgressProps>(), {
   labelProgress: false,
   progress: 0,
   size: 'md',
+})
+
+const safeProgress = computed(() => {
+  const size = progressSafeSizes[props.size]
+  return props.progress <= size ? size : props.progress
 })
 
 const {

--- a/src/components/FwbProgress/FwbProgress.vue
+++ b/src/components/FwbProgress/FwbProgress.vue
@@ -18,6 +18,7 @@
       class="w-full bg-gray-200 rounded-full dark:bg-gray-700"
     >
       <div
+        v-if="displayBar"
         :class="innerClasses"
         :style="{ width: safeProgress + '%' }"
         class="rounded-full font-medium text-blue-100 text-center p-0.5 min-w-max box-border"
@@ -63,6 +64,10 @@ const props = withDefaults(defineProps<IProgressProps>(), {
 const safeProgress = computed(() => {
   const size = progressSafeSizes[props.size]
   return props.progress <= size ? size : props.progress
+})
+
+const displayBar = computed(() => {
+  return props.labelPosition === 'inside' || props.progress > 0
 })
 
 const {

--- a/src/components/FwbProgress/composables/useProgressClasses.ts
+++ b/src/components/FwbProgress/composables/useProgressClasses.ts
@@ -31,13 +31,6 @@ const progressSizeClasses: Record<ProgressSize, string> = {
   xl: 'h-6 text-base leading-tight',
 }
 
-export const progressSafeSizes: Record<ProgressSize, number> = {
-  sm: 1,
-  md: 2,
-  lg: 3,
-  xl: 4,
-}
-
 export type UseProgressClassesProps = {
   color: Ref<ProgressVariant>
   size: Ref<ProgressSize>

--- a/src/components/FwbProgress/composables/useProgressClasses.ts
+++ b/src/components/FwbProgress/composables/useProgressClasses.ts
@@ -31,6 +31,13 @@ const progressSizeClasses: Record<ProgressSize, string> = {
   xl: 'h-6 text-base leading-tight',
 }
 
+export const progressSafeSizes: Record<ProgressSize, number> = {
+  sm: 1,
+  md: 2,
+  lg: 3,
+  xl: 4,
+}
+
 export type UseProgressClassesProps = {
   color: Ref<ProgressVariant>
   size: Ref<ProgressSize>


### PR DESCRIPTION
There is a bug with progress bar for small values. When the bar is too small, then the inside label is almost invisible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced progress bar component with improved progress value handling
	- Added new progress bar examples with different progress states (0% and 50%)

- **Documentation**
	- Updated example components to demonstrate progress bar variations with inside and outside label positions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->