### PR TITLE
Fix FWBInput does not support v-model.number (#273)

### DIFF
--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -58,7 +58,7 @@ import {
 interface InputProps {
   disabled?: boolean
   label?: string
-  modelValue: string
+  modelValue: string | number
   required?: boolean
   size?: InputSize
   type?: InputType


### PR DESCRIPTION
This pull request enhances the modelValue prop to accept not only `string` types but also `number` types. This improvement provides more flexibility in handling diverse data inputs for the component especially when using `v-model.number` modifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `FwbInput` component to accept both string and numeric inputs for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->