### PR TITLE
Fix: add required prop

### DIFF
--- a/src/components/FwbSelect/FwbSelect.vue
+++ b/src/components/FwbSelect/FwbSelect.vue
@@ -10,6 +10,7 @@
       <select
         v-model="model"
         :disabled="disabled"
+        :required="required"
         :class="selectClasses"
         :autocomplete="autocomplete"
       >
@@ -58,6 +59,7 @@ interface InputProps {
   options?: OptionsType[]
   placeholder?: string
   disabled?: boolean
+  required?: boolean
   underline?: boolean
   size?: InputSize
   autocomplete?: CommonAutoFill
@@ -69,6 +71,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   options: () => [],
   placeholder: 'Please select one',
   disabled: false,
+  required: false,
   underline: false,
   size: 'md',
   autocomplete: 'off',


### PR DESCRIPTION
Closes #328 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `required` property to the `FwbSelect` component, enabling HTML5 validation for mandatory selections.
	- Default value for the `required` property is set to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->