### PR TITLE
update nanoid to 5.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "floating-vue": "^5.2.2",
     "flowbite": "2.3.0",
     "lodash-es": "4.17.21",
-    "nanoid": "5.0.7",
+    "nanoid": "5.0.9",
     "tailwind-merge": "2.3.0",
     "tailwindcss": "^3"
   },


### PR DESCRIPTION
# npm audit report

nanoid  4.0.0 - 5.0.8
Severity: moderate
Predictable results in nanoid generation when given non-integer values - https://github.com/advisories/GHSA-mwcw-c2x4-8c55
fix available via `npm audit fix --force`
Will install flowbite-vue@0.0.7, which is a breaking change
node_modules/nanoid
  flowbite-vue  >=0.0.10
  Depends on vulnerable versions of nanoid
  node_modules/flowbite-vue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `nanoid` dependency to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->