### PR TITLE
Add disabled state to dropdown trigger button

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -241,7 +241,7 @@ import { FwbDropdown } from 'flowbite-vue'
 ```
 
 ## Dropdown - Disabled
-Please note that this has to be manually implemented when using a custom trigger (see below)
+Please note that when using a custom trigger (via the trigger slot), you'll need to also implement the disabled state manually by passing the disabled prop to your trigger element. You should still use the disabled prop here to ensure correct handling of the disabled state in the dropdown click handler.
 
 <fwb-dropdown-example-disabled />
 ```vue

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -3,6 +3,7 @@ import FwbDropdownExamplePlacement from './dropdown/examples/FwbDropdownExampleP
 import FwbDropdownExampleAlignment from './dropdown/examples/FwbDropdownExampleAlignment.vue'
 import FwbDropdownExampleListGroup from './dropdown/examples/FwbDropdownExampleListGroup.vue'
 import FwbDropdownExampleColors from './dropdown/examples/FwbDropdownExampleColors.vue'
+import FwbDropdownExampleDisabled from './dropdown/examples/FwbDropdownExampleDisabled.vue'
 import FwbDropdownExampleTrigger from './dropdown/examples/FwbDropdownExampleTrigger.vue'
 import FwbDropdownExampleCloseInside from './dropdown/examples/FwbDropdownExampleCloseInside.vue'
 </script>
@@ -231,6 +232,25 @@ import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
   </fwb-dropdown>
   <fwb-dropdown text="Pink" color="pink">
     ...
+  </fwb-dropdown>
+</template>
+
+<script setup>
+import { FwbDropdown } from 'flowbite-vue'
+</script>
+```
+
+## Dropdown - Disabled
+Please note that this has to be manually implemented when using a custom trigger (see below)
+
+<fwb-dropdown-example-disabled />
+```vue
+<template>
+  <fwb-dropdown text="Normal state">
+    Access this content by clicking the dropdown's trigger button
+  </fwb-dropdown>
+  <fwb-dropdown text="Disabled state" disabled>
+    You cannot access this content, since the dropdown's trigger button is disabled
   </fwb-dropdown>
 </template>
 

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -247,10 +247,10 @@ Please note that this has to be manually implemented when using a custom trigger
 ```vue
 <template>
   <fwb-dropdown text="Normal state">
-    Access this content by clicking the dropdown's trigger button
+    Dropdown content
   </fwb-dropdown>
   <fwb-dropdown text="Disabled state" disabled>
-    You cannot access this content, since the dropdown's trigger button is disabled
+    Disabled dropdown content
   </fwb-dropdown>
 </template>
 
@@ -327,6 +327,7 @@ import { FwbDropdown, ListGroup, ListGroupItem } from 'flowbite-vue'
 | placement   | `DropdownPlacement` | `'bottom'`  |
 | text        | `string`            | `''`        |
 | color       | `ButtonVariant`     | `'default'` |
+| disabled    | `boolean`           | `false`     |
 | transition  | `string`            | `''`        |
 | closeInside | `boolean`           | `false`     |
 | alignToEnd  | `boolean`           | `false`     |

--- a/docs/components/dropdown/examples/FwbDropdownExampleDisabled.vue
+++ b/docs/components/dropdown/examples/FwbDropdownExampleDisabled.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="vp-raw flex gap-2 flex-wrap">
+    <fwb-dropdown
+      text="Normal State"
+    >
+      <div class="w-52">
+        <p class="p-4">
+          Access this content by clicking the dropdown's trigger button
+        </p>
+      </div>
+    </fwb-dropdown>
+    <fwb-dropdown
+      text="Disabled State"
+      disabled
+    >
+      <div class="w-52">
+        <p class="p-4">
+          You cannot access this content, since the dropdown's trigger button is disabled
+        </p>
+      </div>
+    </fwb-dropdown>
+  </div>
+</template>
+
+<script setup>
+import { FwbDropdown } from '../../../../src/index'
+</script>

--- a/docs/components/dropdown/examples/FwbDropdownExampleDisabled.vue
+++ b/docs/components/dropdown/examples/FwbDropdownExampleDisabled.vue
@@ -5,7 +5,7 @@
     >
       <div class="w-52">
         <p class="p-4">
-          Access this content by clicking the dropdown's trigger button
+          Dropdown content
         </p>
       </div>
     </fwb-dropdown>
@@ -15,7 +15,7 @@
     >
       <div class="w-52">
         <p class="p-4">
-          You cannot access this content, since the dropdown's trigger button is disabled
+          Disabled dropdown content
         </p>
       </div>
     </fwb-dropdown>

--- a/src/components/FwbDropdown/FwbDropdown.vue
+++ b/src/components/FwbDropdown/FwbDropdown.vue
@@ -6,7 +6,7 @@
     <div class="inline-flex items-center">
       <fwb-slot-listener @click="onToggle">
         <slot name="trigger">
-          <fwb-button :color="color">
+          <fwb-button :disabled="disabled" :color="color">
             {{ text }}
             <template #suffix>
               <svg
@@ -66,6 +66,7 @@ const props = withDefaults(
     transition?: string
     closeInside?: boolean
     alignToEnd?: boolean
+    disabled?: boolean
   }>(),
   {
     placement: 'bottom',

--- a/src/components/FwbDropdown/FwbDropdown.vue
+++ b/src/components/FwbDropdown/FwbDropdown.vue
@@ -6,7 +6,10 @@
     <div class="inline-flex items-center">
       <fwb-slot-listener @click="onToggle">
         <slot name="trigger">
-          <fwb-button :disabled="disabled" :color="color">
+          <fwb-button
+            :disabled="disabled"
+            :color="color"
+          >
             {{ text }}
             <template #suffix>
               <svg
@@ -56,7 +59,10 @@ const visible = ref(false)
 const onHide = () => {
   if (props.closeInside) visible.value = false
 }
-const onToggle = () => (visible.value = !visible.value)
+const onToggle = () => {
+  if (props.disabled) return
+  visible.value = !visible.value
+}
 
 const props = withDefaults(
   defineProps<{


### PR DESCRIPTION
Introduce a disabled state for the dropdown trigger button, allowing users to indicate when the dropdown is not accessible. Update documentation and examples to reflect this new feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for disabled state in dropdown components.
	- Introduced documentation for dropdown's disabled functionality.

- **Documentation**
	- Created new documentation section explaining dropdown disabled state.
	- Added example component demonstrating dropdown disabled behavior.

- **Improvements**
	- Enhanced dropdown component with new `disabled` prop.
	- Implemented conditional disabling of dropdown trigger button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->