### PR TITLE
modelValue set to be optional in FwbInput

### DIFF
--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -61,7 +61,7 @@ import {
 interface InputProps {
   disabled?: boolean
   label?: string
-  modelValue: string | number
+  modelValue?: string | number
   required?: boolean
   size?: InputSize
   type?: InputType


### PR DESCRIPTION
Starting version 0.1.7 there is a problem with FwbInput component
![image](https://github.com/user-attachments/assets/7775f77b-d091-4c63-a6f8-f92edd84d150)
Seems like it is caused by this PR https://github.com/themesberg/flowbite-vue/pull/327
If `modelValue` has 2 possible types, then is it not optional anymore. It should be marked as optional explicitly in the type definition. I checked modelValue definitions in other components and all of them are optional.

Strange thing that I cannot reproduce this issue on the flowbite-vue code base. Only in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced input component flexibility by making `modelValue` an optional property
	- Added default empty string for `modelValue` when not explicitly provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->