### PR TITLE
fix(badge): dark mode badge colours to match flowbite

### DIFF
--- a/src/components/FwbBadge/composables/useBadgeClasses.ts
+++ b/src/components/FwbBadge/composables/useBadgeClasses.ts
@@ -7,25 +7,25 @@ const badgeLinkClasses = 'bg-blue-100 hover:bg-blue-200 text-blue-800 dark:text-
 const onlyIconClasses = 'p-1 rounded-full mr-2'
 
 const badgeTextClasses: Record<BadgeType, string> = {
-  default: 'text-blue-800 dark:text-blue-800',
+  default: 'text-blue-800 dark:text-blue-300',
   dark: 'text-gray-800 dark:text-gray-300',
-  red: 'text-red-800 dark:text-red-900',
-  green: 'text-green-800 dark:text-green-900',
-  yellow: 'text-yellow-800 dark:text-yellow-900',
-  indigo: 'text-indigo-800 dark:text-indigo-900',
-  purple: 'text-purple-800 dark:text-purple-900',
-  pink: 'text-pink-800 dark:text-pink-900',
+  red: 'text-red-800 dark:text-red-300',
+  green: 'text-green-800 dark:text-green-300',
+  yellow: 'text-yellow-800 dark:text-yellow-300',
+  indigo: 'text-indigo-800 dark:text-indigo-300',
+  purple: 'text-purple-800 dark:text-purple-300',
+  pink: 'text-pink-800 dark:text-pink-300',
 }
 
 const badgeTypeClasses: Record<BadgeType, string> = {
-  default: 'bg-blue-100 dark:bg-blue-200',
+  default: 'bg-blue-100 dark:bg-blue-900',
   dark: 'bg-gray-100 dark:bg-gray-700',
-  red: 'bg-red-100 dark:bg-red-200',
-  green: 'bg-green-100 dark:bg-green-200',
-  yellow: 'bg-yellow-100 dark:bg-yellow-200',
-  indigo: 'bg-indigo-100 dark:bg-indigo-200',
-  purple: 'bg-purple-100 dark:bg-purple-200',
-  pink: 'bg-pink-100 dark:bg-pink-200',
+  red: 'bg-red-100 dark:bg-red-900',
+  green: 'bg-green-100 dark:bg-green-900',
+  yellow: 'bg-yellow-100 dark:bg-yellow-900',
+  indigo: 'bg-indigo-100 dark:bg-indigo-900',
+  purple: 'bg-purple-100 dark:bg-purple-900',
+  pink: 'bg-pink-100 dark:bg-pink-900',
 }
 
 const badgeSizeClasses: Record<BadgeSize, string> = {


### PR DESCRIPTION
Most of the badge colours in dark mode don't match what [flowbite specifies](https://flowbite.com/docs/components/badge/). The dark type was fixed last year and this PR fixes the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated badge color schemes for different badge types
	- Adjusted dark mode text and background colors for badges
	- Refined visual appearance of badge components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->