### PR TITLE
Fixed the icon placeholder position in FwbAvatar

### DIFF
--- a/src/components/FwbAvatar/FwbAvatar.vue
+++ b/src/components/FwbAvatar/FwbAvatar.vue
@@ -18,7 +18,7 @@
       </div>
       <svg
         v-else-if="!img && !initials"
-        :class="avatarPlaceholderClasses"
+        :class="avatarPlaceholderIconClasses"
         fill="currentColor"
         viewBox="0 0 20 20"
         xmlns="http://www.w3.org/2000/svg"
@@ -103,6 +103,7 @@ const {
   avatarClasses,
   avatarDotClasses,
   avatarPlaceholderClasses,
+  avatarPlaceholderIconClasses,
   avatarPlaceholderInitialsClasses,
   avatarPlaceholderWrapperClasses,
 } = useAvatarClasses(toRefs(props))

--- a/src/components/FwbAvatar/composables/useAvatarClasses.ts
+++ b/src/components/FwbAvatar/composables/useAvatarClasses.ts
@@ -40,7 +40,8 @@ const avatarStatusDotPositionClasses: Record<avatarDotIndicatorPositionClasses, 
   'bottom-left-default': '-bottom-1.5 left-0 transform -translate-x-1/2 ',
 }
 
-const avatarPlaceholderDefaultClasses = 'absolute w-auto h-auto text-gray-400'
+const avatarPlaceholderDefaultClasses = 'w-auto h-auto text-gray-400'
+const avatarPlaceholderDefaultIconClasses = 'absolute'
 const avatarPlaceholderWrapperDefaultClasses = 'flex overflow-hidden relative justify-center items-center'
 const avatarPlaceholderWrapperBackgroundClasses = 'bg-gray-100 dark:bg-gray-600'
 const avatarPlaceholderInitialsDefaultClasses = 'font-medium text-gray-600 dark:text-gray-300'
@@ -67,6 +68,7 @@ export function useAvatarClasses (props: UseAvatarClassesProps): {
   avatarClasses: Ref<string>
   avatarDotClasses: Ref<string>
   avatarPlaceholderClasses: Ref<string>
+  avatarPlaceholderIconClasses: Ref<string>
   avatarPlaceholderWrapperClasses: Ref<string>
   avatarPlaceholderInitialsClasses: Ref<string>
 } {
@@ -89,9 +91,17 @@ export function useAvatarClasses (props: UseAvatarClassesProps): {
   const avatarPlaceholderClasses = computed<string>(() =>
     useMergeClasses([
       avatarPlaceholderDefaultClasses,
+    ]),
+  )
+
+  const avatarPlaceholderIconClasses = computed<string>(() =>
+    useMergeClasses([
+      avatarPlaceholderDefaultClasses,
+      avatarPlaceholderDefaultIconClasses,
       avatarPlaceholderSizes[props.size.value],
     ]),
   )
+
   const avatarPlaceholderWrapperClasses = computed<string>(() =>
     useMergeClasses([
       avatarPlaceholderWrapperDefaultClasses,
@@ -111,6 +121,7 @@ export function useAvatarClasses (props: UseAvatarClassesProps): {
     avatarClasses,
     avatarDotClasses,
     avatarPlaceholderClasses,
+    avatarPlaceholderIconClasses,
     avatarPlaceholderInitialsClasses,
     avatarPlaceholderWrapperClasses,
   }


### PR DESCRIPTION
There is a problem with placeholder position in avatar component. There is an optical compensation for default placeholder, that moves the icon with absolute position and bottom property. But if there is a placeholder provided by user then this compensation causes strange display of the icon.

For example, this is how the custom placeholder looks in current implementation in different sizes:
![image](https://github.com/user-attachments/assets/08fce0a0-99af-4b26-8d0a-13db180790ef)
I added the blue border for the placeholder to show how it is positioned in the block.

I would expect that placeholder should be placed in the center of the avatar.

And this is how it is placed with my changes:
![image](https://github.com/user-attachments/assets/0bf5f3ad-0283-41fa-a9f8-fd256bc2c31b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of avatar placeholders to ensure a more distinct and consistent icon display when no image or initials are provided.

- **Refactor**
  - Streamlined the styling logic for avatars by separating icon-specific styles from the default placeholder, enhancing visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->