### PR TITLE
feat(list-group-item): add active prop

### DIFF
--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -42,7 +42,7 @@ import { FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 ```vue
 <template>
   <fwb-list-group>
-    <fwb-list-group-item hover>Item 1</fwb-list-group-item>
+    <fwb-list-group-item active hover>Item 1</fwb-list-group-item>
     <fwb-list-group-item hover>Item 2</fwb-list-group-item>
     <fwb-list-group-item hover>Item 3</fwb-list-group-item>
     <fwb-list-group-item hover>Item 4</fwb-list-group-item>

--- a/docs/components/listGroup/examples/FwbListGroupExampleHover.vue
+++ b/docs/components/listGroup/examples/FwbListGroupExampleHover.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="vp-raw flex flex-col">
     <fwb-list-group>
-      <fwb-list-group-item hover>
+      <fwb-list-group-item
+        active
+        hover
+      >
         Item 1
       </fwb-list-group-item>
       <fwb-list-group-item hover>

--- a/src/components/FwbListGroup/FwbListGroupItem.vue
+++ b/src/components/FwbListGroup/FwbListGroupItem.vue
@@ -30,6 +30,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  active: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const { itemClasses } = useListGroupItemClasses(toRefs(props))

--- a/src/components/FwbListGroup/composables/useListGroupItemClasses.ts
+++ b/src/components/FwbListGroup/composables/useListGroupItemClasses.ts
@@ -1,11 +1,11 @@
 import { computed, type Ref } from 'vue'
 
-import { simplifyTailwindClasses } from '@/utils/simplifyTailwindClasses'
+import { useMergeClasses } from '@/composables/useMergeClasses'
 
 const defaultItemClasses = 'inline-flex items-center w-full px-4 py-2 border-b border-gray-200 dark:border-gray-600'
 const hoverItemClasses = 'block w-full px-4 py-2 cursor-pointer hover:bg-gray-100 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700 focus:text-blue-700 dark:hover:bg-gray-600 dark:hover:text-white dark:focus:ring-gray-500 dark:focus:text-white'
 const disabledItemClasses = 'bg-gray-100 cursor-not-allowed dark:bg-gray-600 dark:text-gray-400'
-const activeItemClasses = 'cursor-pointer text-white bg-blue-700 dark:bg-gray-800'
+const activeItemClasses = 'text-white bg-blue-700 dark:bg-gray-800 hover:text-white hover:bg-blue-700 hover:dark:bg-gray-800'
 
 export type UseListGroupItemClassesProps = {
   hover: Ref<boolean>
@@ -16,14 +16,12 @@ export type UseListGroupItemClassesProps = {
 export function useListGroupItemClasses (props: UseListGroupItemClassesProps): {
   itemClasses: Ref<string>
 } {
-  const itemClasses = computed<string>(() => {
-    return simplifyTailwindClasses(
-      defaultItemClasses,
-      props.disabled.value ? disabledItemClasses : '',
-      !props.disabled.value && !props.active.value && props.hover.value ? hoverItemClasses : '',
-      !props.disabled.value && props.active.value ? activeItemClasses : '',
-    )
-  })
+  const itemClasses = computed(() => useMergeClasses([
+    defaultItemClasses,
+    props.disabled.value ? disabledItemClasses : '',
+    !props.disabled.value && props.hover.value ? hoverItemClasses : '',
+    !props.disabled.value && props.active.value ? activeItemClasses : '',
+  ]))
 
   return {
     itemClasses,

--- a/src/components/FwbListGroup/composables/useListGroupItemClasses.ts
+++ b/src/components/FwbListGroup/composables/useListGroupItemClasses.ts
@@ -5,10 +5,12 @@ import { simplifyTailwindClasses } from '@/utils/simplifyTailwindClasses'
 const defaultItemClasses = 'inline-flex items-center w-full px-4 py-2 border-b border-gray-200 dark:border-gray-600'
 const hoverItemClasses = 'block w-full px-4 py-2 cursor-pointer hover:bg-gray-100 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700 focus:text-blue-700 dark:hover:bg-gray-600 dark:hover:text-white dark:focus:ring-gray-500 dark:focus:text-white'
 const disabledItemClasses = 'bg-gray-100 cursor-not-allowed dark:bg-gray-600 dark:text-gray-400'
+const activeItemClasses = 'cursor-pointer text-white bg-blue-700 dark:bg-gray-800'
 
 export type UseListGroupItemClassesProps = {
   hover: Ref<boolean>
   disabled: Ref<boolean>
+  active: Ref<boolean>
 }
 
 export function useListGroupItemClasses (props: UseListGroupItemClassesProps): {
@@ -18,7 +20,8 @@ export function useListGroupItemClasses (props: UseListGroupItemClassesProps): {
     return simplifyTailwindClasses(
       defaultItemClasses,
       props.disabled.value ? disabledItemClasses : '',
-      !props.disabled.value && props.hover.value ? hoverItemClasses : '',
+      !props.disabled.value && !props.active.value && props.hover.value ? hoverItemClasses : '',
+      !props.disabled.value && props.active.value ? activeItemClasses : '',
     )
   })
 


### PR DESCRIPTION
The [active prop from list groups](https://flowbite.com/docs/components/list-group/#list-group-with-links) was missing so this PR adds it as a prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for marking list group items as "active," providing distinct visual styling for active items.
- **Documentation**
  - Updated examples and documentation to illustrate the new "active" state for list group items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->