### PR TITLE
Fixed a bug with model type in Input component

### DIFF
--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -57,7 +57,6 @@ interface InputProps {
   inputClass?: string | Record<string, boolean>
   label?: string
   labelClass?: string | Record<string, boolean>
-  modelValue?: string | number
   required?: boolean
   size?: InputSize
   type?: InputType
@@ -76,7 +75,6 @@ const props = withDefaults(defineProps<InputProps>(), {
   inputClass: '',
   label: '',
   labelClass: '',
-  modelValue: '',
   required: false,
   size: 'md',
   type: 'text',
@@ -84,7 +82,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   wrapperClass: '',
 })
 
-const model = defineModel({ type: String })
+const model = defineModel<string | number>({ default: '' })
 
 const {
   wrapperClass,


### PR DESCRIPTION
There is a problem with model definition in `FwbInput` component. The model should allow string, number or undefined. Right now it doesn't support numbers. It was fixed previously, by adding `defineModel` in this PR https://github.com/themesberg/flowbite-vue/pull/365 broke it.

Currently I'm getting the following error:
![image](https://github.com/user-attachments/assets/81468fb1-5af0-448a-b4c9-cddd79094df8)

This PR should fix the model definition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved input component model binding to support both string and number values with a default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->