### PR TITLE
change linkClasses in FwbNavbarLink to be computed rather than only evaluated on mount to resolve #373

### DIFF
--- a/src/components/FwbNavbar/FwbNavbarLink.vue
+++ b/src/components/FwbNavbar/FwbNavbarLink.vue
@@ -37,10 +37,12 @@ const defaultClasses = 'block py-2 pr-4 pl-3 rounded md:p-0'
 const componentName = computed(() => {
   return props.component !== 'a' ? resolveComponent(props.component) : 'a'
 })
-const linkClasses = twMerge(
-  defaultClasses,
-  props.isActive ? currentPageClasses : defaultStateClasses,
-)
+const linkClasses = computed(() => {
+    return twMerge(
+        defaultClasses,
+	props.isActive ? currentPageClasses: defaultStateClasses,
+    )
+})
 const handleClick = (event: Event) => {
   if (props.disabled) {
     return

--- a/src/components/FwbNavbar/FwbNavbarLink.vue
+++ b/src/components/FwbNavbar/FwbNavbarLink.vue
@@ -37,12 +37,10 @@ const defaultClasses = 'block py-2 pr-4 pl-3 rounded md:p-0'
 const componentName = computed(() => {
   return props.component !== 'a' ? resolveComponent(props.component) : 'a'
 })
-const linkClasses = computed(() => {
-    return twMerge(
-        defaultClasses,
-	props.isActive ? currentPageClasses: defaultStateClasses,
-    )
-})
+const linkClasses = computed(() => twMerge(
+  defaultClasses,
+  props.isActive ? currentPageClasses : defaultStateClasses,
+))
 const handleClick = (event: Event) => {
   if (props.disabled) {
     return


### PR DESCRIPTION
The linkClasses const declared in FwbNavbarLink is just an ordinary constant. It should be reactive as it relies on the value of a prop. 

Fix changes it to a computed value such that it will change when the prop changes. I assume that would be expected behaviour.

Fixes #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved reactivity of navigation link styling to better reflect active state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->