### PR TITLE
Fix for Button Light Arrangement for Dark Mode #380

### DIFF
--- a/src/components/FwbButton/composables/useButtonClasses.ts
+++ b/src/components/FwbButton/composables/useButtonClasses.ts
@@ -24,7 +24,7 @@ const buttonColorClasses: ButtonClassMap<ButtonVariant> = {
     blue: 'hover:bg-blue-800 dark:hover:bg-blue-700',
     alternative: 'hover:bg-gray-100 hover:text-blue-700 dark:hover:text-white dark:hover:bg-gray-700',
     dark: 'hover:bg-gray-900 dark:hover:bg-gray-700',
-    light: 'hover:bg-gray-100 dark:hover:border-gray-600',
+    light: 'hover:bg-gray-100 dark:hover:border-gray-600 dark:hover:bg-gray-700',
     green: 'hover:bg-green-800 dark:hover:bg-green-700',
     red: 'hover:bg-red-800 dark:hover:bg-red-700',
     yellow: 'hover:bg-yellow-500',


### PR DESCRIPTION
#380 
fix: update light button class for improved dark mode styling in FwbButton 

Please check and combine @Sqrcz @cogor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dark mode hover appearance for "light" variant buttons by updating background color on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->