### PR TITLE
fix: The gap problem in the Toggle component #388

### DIFF
--- a/src/components/FwbToggle/FwbToggle.vue
+++ b/src/components/FwbToggle/FwbToggle.vue
@@ -8,7 +8,7 @@
     >
     <span :class="[toggleClasses, toggleSize, toggleColor]" />
     <span
-      v-if="label" 
+      v-if="label"
       :class="[toggleBallClasses, toggleBallOrder]"
     >{{ label }}</span>
   </label>

--- a/src/components/FwbToggle/FwbToggle.vue
+++ b/src/components/FwbToggle/FwbToggle.vue
@@ -7,7 +7,10 @@
       type="checkbox"
     >
     <span :class="[toggleClasses, toggleSize, toggleColor]" />
-    <span v-if="label" :class="[toggleBallClasses, toggleBallOrder]">{{ label }}</span>
+    <span
+      v-if="label" 
+      :class="[toggleBallClasses, toggleBallOrder]"
+    >{{ label }}</span>
   </label>
 </template>
 

--- a/src/components/FwbToggle/FwbToggle.vue
+++ b/src/components/FwbToggle/FwbToggle.vue
@@ -7,7 +7,7 @@
       type="checkbox"
     >
     <span :class="[toggleClasses, toggleSize, toggleColor]" />
-    <span :class="[toggleBallClasses, toggleBallOrder]">{{ label }}</span>
+    <span v-if="label" :class="[toggleBallClasses, toggleBallOrder]">{{ label }}</span>
   </label>
 </template>
 


### PR DESCRIPTION
If there is no label with conditional rendering, label span was removed #388

Please check and give feedback. @Sqrcz @zoltanszogyenyi @cogor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented empty label spans from being rendered when no label is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->