### PR TITLE
add ability to override default dropzone placeholder

### DIFF
--- a/src/components/FwbFileInput/FwbFileInput.vue
+++ b/src/components/FwbFileInput/FwbFileInput.vue
@@ -43,8 +43,10 @@
           </svg>
           <div v-if="!model">
             <p :class="dropzoneTextClasses">
-              <span class="font-semibold">Click to upload</span>
-              or drag and drop
+              <slot name="dropzonePlaceholder">
+                <span class="font-semibold">Click to upload</span>
+                or drag and drop
+              </slot>
             </p>
             <slot />
           </div>


### PR DESCRIPTION
Added support for a customizable placeholder in the dropzone component using a named slot, while preserving default text for backward compatibility.

This allows parent components to inject custom instructional text or UI elements in the dropzone area via the placeholder named slot. If no custom slot is provided, the component falls back to the original default message: "Click to upload or drag and drop."

This enhances flexibility for different use cases (e.g., internationalization, branding, or richer UI) without breaking existing implementations.