### PR TITLE
feat: add Autocomplete component with examples and documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -65,6 +65,7 @@ function getComponents () {
 
 function getFormComponents () {
   return [
+    { text: 'Autocomplete', link: '/components/autocomplete' },
     { text: 'Input', link: '/components/input' },
     { text: 'File Input', link: '/components/fileInput' },
     { text: 'Select', link: '/components/select' },

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -325,6 +325,7 @@ const countries = [
 | `label` | `string` | `undefined` | Label text for the input field |
 | `inputComponent` | `Component` | `FwbInput` | Vue component to use as the input field |
 | `inputProps` | `Record<string, any>` | `{}` | Additional props to pass to the input component |
+| `zIndex` | `number` | `100` | Z-index value for the dropdown overlay |
 
 ### Input Component Props
 

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -1,0 +1,293 @@
+<script setup>
+import FwbAutocompleteExample from './autocomplete/examples/FwbAutocompleteExample.vue'
+import FwbAutocompleteExampleRemote from './autocomplete/examples/FwbAutocompleteExampleRemote.vue'
+import FwbAutocompleteExampleCustom from './autocomplete/examples/FwbAutocompleteExampleCustom.vue'
+import FwbAutocompleteExampleValidation from './autocomplete/examples/FwbAutocompleteExampleValidation.vue'
+import FwbAutocompleteExampleSize from './autocomplete/examples/FwbAutocompleteExampleSize.vue'
+</script>
+
+# Vue Autocomplete - Flowbite
+
+Get started with the autocomplete component to allow users to search and select from a list of options with real-time filtering and keyboard navigation.
+
+---
+
+:::tip
+Based on the Flowbite design system: [https://flowbite.com/docs/forms/input-field/](https://flowbite.com/docs/forms/input-field/)
+:::
+
+The autocomplete component supports real-time filtering, keyboard navigation, remote data loading, and custom option rendering. Built with Tailwind CSS utility classes and fully compatible with dark mode.
+
+## Default
+
+<fwb-autocomplete-example />
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selectedCountry"
+    :options="countries"
+    search-fields="name"
+    display="name"
+    label="Select a country"
+    placeholder="Search countries..."
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selectedCountry = ref(null)
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+  { id: 4, name: 'Germany', code: 'DE' },
+  { id: 5, name: 'United Kingdom', code: 'UK' },
+]
+</script>
+```
+
+## Remote Data with Debounce
+
+<fwb-autocomplete-example-remote />
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selectedCountry"
+    :options="countries"
+    :loading="loading"
+    search-fields="name"
+    display="name"
+    label="Search countries"
+    placeholder="Type to search countries..."
+    remote
+    :min-chars="2"
+    :debounce="500"
+    @search="searchCountries"
+  >
+    <template #option="{ option }">
+      <div class="flex items-center space-x-3">
+        <span class="text-2xl">{{ option.flag }}</span>
+        <div>
+          <div class="font-medium">{{ option.name }}</div>
+          <div class="text-sm text-gray-500">{{ option.region }}</div>
+        </div>
+      </div>
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selectedCountry = ref(null)
+const countries = ref([])
+const loading = ref(false)
+
+const searchCountries = async (query) => {
+  loading.value = true
+  try {
+    const response = await fetch(`https://restcountries.com/v3.1/name/${query}`)
+    const data = await response.json()
+    
+    countries.value = data.slice(0, 10).map(country => ({
+      name: country.name.common,
+      capital: country.capital?.[0] || 'N/A',
+      region: country.region,
+      population: country.population,
+      flag: country.flag,
+    }))
+  } catch (err) {
+    countries.value = []
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+```
+
+## Custom Option Template
+
+<fwb-autocomplete-example-custom />
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selectedUser"
+    :options="users"
+    search-fields="name,email"
+    display="name"
+    label="Select user"
+    placeholder="Search users..."
+  >
+    <template #option="{ option }">
+      <div class="flex items-center">
+        <img
+          :src="option.avatar"
+          :alt="option.name"
+          class="w-8 h-8 rounded-full mr-3"
+        >
+        <div>
+          <div class="font-medium">{{ option.name }}</div>
+          <div class="text-sm text-gray-500">{{ option.email }}</div>
+        </div>
+      </div>
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selectedUser = ref(null)
+const users = [
+  {
+    id: 1,
+    name: 'John Doe',
+    email: 'john@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=1'
+  },
+  {
+    id: 2,
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=2'
+  },
+]
+</script>
+```
+
+## Validation
+
+<fwb-autocomplete-example-validation />
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selectedCountry"
+    :options="countries"
+    search-fields="name"
+    display="name"
+    label="Country *"
+    placeholder="Select a country..."
+    :validation-status="validationStatus"
+  >
+    <template #validationMessage>
+      Please select a country
+    </template>
+    <template #helper>
+      Choose the country where you reside
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selectedCountry = ref(null)
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+
+const validationStatus = computed(() => {
+  return selectedCountry.value ? 'success' : 'error'
+})
+</script>
+```
+
+## Sizes
+
+<fwb-autocomplete-example-size />
+```vue
+<template>
+  <div class="space-y-4">
+    <fwb-autocomplete
+      v-model="selected1"
+      :options="countries"
+      search-fields="name"
+      display="name"
+      label="Small"
+      size="sm"
+      placeholder="Small autocomplete..."
+    />
+    
+    <fwb-autocomplete
+      v-model="selected2"
+      :options="countries"
+      search-fields="name"
+      display="name"
+      label="Medium (default)"
+      size="md"
+      placeholder="Medium autocomplete..."
+    />
+    
+    <fwb-autocomplete
+      v-model="selected3"
+      :options="countries"
+      search-fields="name"
+      display="name"
+      label="Large"
+      size="lg"
+      placeholder="Large autocomplete..."
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selected1 = ref(null)
+const selected2 = ref(null)
+const selected3 = ref(null)
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+</script>
+```
+
+## API
+
+### Props
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `T \| null` | `null` | The selected option |
+| `options` | `T[]` | `[]` | Array of options to choose from |
+| `loading` | `boolean` | `false` | Show loading state |
+| `placeholder` | `string` | `'Search...'` | Input placeholder text |
+| `disabled` | `boolean` | `false` | Disable the input |
+| `valueField` | `string` | `undefined` | Field to use for option value |
+| `searchFields` | `string[]` | `[]` | Fields to search in options |
+| `loadingText` | `string` | `'Loading...'` | Text to show when loading |
+| `noResultsText` | `string` | `'No results found'` | Text to show when no results |
+| `minChars` | `number` | `0` | Minimum characters to start filtering |
+| `remote` | `boolean` | `false` | Whether to use remote data loading |
+| `debounce` | `number` | `300` | Debounce delay in ms for remote searches |
+| `display` | `string \| function` | `undefined` | Field or function to display option label |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Input size |
+| `validationStatus` | `'success' \| 'error'` | `undefined` | Validation status |
+| `label` | `string` | `undefined` | Label text |
+
+### Events
+
+| Name | Parameters | Description |
+|------|------------|-------------|
+| `update:modelValue` | `value: T \| null` | Emitted when selection changes |
+| `select` | `option: T` | Emitted when an option is selected |
+| `search` | `query: string` | Emitted when search query changes |
+
+### Slots
+
+| Name | Props | Description |
+|------|-------|-------------|
+| `option` | `{ option, index }` | Custom option template |
+| `validationMessage` | - | Validation message content |
+| `helper` | - | Helper text content | 

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -27,7 +27,7 @@ The autocomplete component supports real-time filtering, keyboard navigation, re
   <fwb-autocomplete
     v-model="selectedCountry"
     :options="countries"
-    search-fields="name"
+    :search-fields="['name']"
     display="name"
     label="Select a country"
     placeholder="Search countries..."
@@ -58,7 +58,7 @@ const countries = [
     v-model="selectedCountry"
     :options="countries"
     :loading="loading"
-    search-fields="name"
+    :search-fields="['name']"
     display="name"
     label="Search countries"
     placeholder="Type to search countries..."
@@ -160,7 +160,7 @@ The component automatically passes through standard props like `placeholder`, `d
   <fwb-autocomplete
     v-model="selectedUser"
     :options="users"
-    search-fields="name,email"
+    :search-fields="['name', 'email']"
     display="name"
     label="Select user"
     placeholder="Search users..."
@@ -211,7 +211,7 @@ const users = [
   <fwb-autocomplete
     v-model="selectedCountry"
     :options="countries"
-    search-fields="name"
+    :search-fields="['name']"
     display="name"
     label="Country *"
     placeholder="Select a country..."
@@ -252,7 +252,7 @@ const validationStatus = computed(() => {
     <fwb-autocomplete
       v-model="selected1"
       :options="countries"
-      search-fields="name"
+      :search-fields="['name']"
       display="name"
       label="Small"
       size="sm"
@@ -262,7 +262,7 @@ const validationStatus = computed(() => {
     <fwb-autocomplete
       v-model="selected2"
       :options="countries"
-      search-fields="name"
+      :search-fields="['name']"
       display="name"
       label="Medium (default)"
       size="md"
@@ -272,7 +272,7 @@ const validationStatus = computed(() => {
     <fwb-autocomplete
       v-model="selected3"
       :options="countries"
-      search-fields="name"
+      :search-fields="['name']"
       display="name"
       label="Large"
       size="lg"
@@ -366,7 +366,7 @@ You can also pass additional props via the `inputProps` prop or use a completely
 <fwb-autocomplete
   v-model="selected"
   :options="countries"
-  search-fields="name"
+  :search-fields="['name']"
   display="name"
   placeholder="Search countries..."
 />
@@ -378,7 +378,7 @@ You can also pass additional props via the `inputProps` prop or use a completely
   v-model="selected"
   :options="users"
   :loading="loading"
-  search-fields="name,email"
+  :search-fields="['name', 'email']"
   display="name"
   remote
   :debounce="500"

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -2,6 +2,7 @@
 import FwbAutocompleteExample from './autocomplete/examples/FwbAutocompleteExample.vue'
 import FwbAutocompleteExampleRemote from './autocomplete/examples/FwbAutocompleteExampleRemote.vue'
 import FwbAutocompleteExampleCustom from './autocomplete/examples/FwbAutocompleteExampleCustom.vue'
+import FwbAutocompleteExampleCustomInput from './autocomplete/examples/FwbAutocompleteExampleCustomInput.vue'
 import FwbAutocompleteExampleValidation from './autocomplete/examples/FwbAutocompleteExampleValidation.vue'
 import FwbAutocompleteExampleSize from './autocomplete/examples/FwbAutocompleteExampleSize.vue'
 </script>
@@ -107,6 +108,49 @@ const searchCountries = async (query) => {
 }
 </script>
 ```
+
+## Custom Input Components
+
+<fwb-autocomplete-example-custom-input />
+
+The autocomplete component provides maximum flexibility by allowing you to use any Vue input component through the `inputComponent` and `inputProps` props.
+
+### Using Custom Input Components
+
+```vue
+<template>
+  <!-- Use any Vue input component -->
+  <fwb-autocomplete
+    v-model="selected"
+    :options="options"
+    :input-component="CustomInput"
+    :input-props="{
+      prefixIcon: 'search',
+      theme: 'rounded',
+      class: 'custom-styling'
+    }"
+  />
+
+  <!-- Customize FwbInput with props -->
+  <fwb-autocomplete
+    v-model="selected"
+    :options="options"
+    :input-props="{
+      size: 'lg',
+      class: 'border-purple-300 focus:border-purple-500'
+    }"
+  />
+</template>
+```
+
+### Input Component Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `inputComponent` | `Component` | `FwbInput` | The Vue input component to use |
+| `inputProps` | `Record<string, any>` | `{}` | Additional props to pass to the input component |
+
+The component automatically passes through standard props like `placeholder`, `disabled`, `size`, `label`, etc., and you can provide additional props via `inputProps`.
 
 ## Custom Option Template
 
@@ -259,35 +303,99 @@ const countries = [
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `T \| null` | `null` | The selected option |
-| `options` | `T[]` | `[]` | Array of options to choose from |
-| `loading` | `boolean` | `false` | Show loading state |
-| `placeholder` | `string` | `'Search...'` | Input placeholder text |
-| `disabled` | `boolean` | `false` | Disable the input |
-| `valueField` | `string` | `undefined` | Field to use for option value |
-| `searchFields` | `string[]` | `[]` | Fields to search in options |
-| `loadingText` | `string` | `'Loading...'` | Text to show when loading |
-| `noResultsText` | `string` | `'No results found'` | Text to show when no results |
-| `minChars` | `number` | `0` | Minimum characters to start filtering |
-| `remote` | `boolean` | `false` | Whether to use remote data loading |
-| `debounce` | `number` | `300` | Debounce delay in ms for remote searches |
-| `display` | `string \| function` | `undefined` | Field or function to display option label |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Input size |
-| `validationStatus` | `'success' \| 'error'` | `undefined` | Validation status |
-| `label` | `string` | `undefined` | Label text |
+| `modelValue` | `T \| null` | `null` | The currently selected option |
+| `options` | `T[]` | `[]` | Array of options to display in dropdown |
+| `loading` | `boolean` | `false` | Shows loading indicator when true |
+| `placeholder` | `string` | `'Search...'` | Placeholder text for input field |
+| `disabled` | `boolean` | `false` | Disables the autocomplete component |
+| `valueField` | `string` | `undefined` | Field name to use as unique identifier for options |
+| `searchFields` | `string[]` | `[]` | Array of field names to search within each option |
+| `loadingText` | `string` | `'Loading...'` | Text to display when loading |
+| `noResultsText` | `string` | `'No results found'` | Text to display when no results match |
+| `minChars` | `number` | `0` | Minimum characters required before filtering |
+| `remote` | `boolean` | `false` | Whether to fetch data remotely (disables local filtering) |
+| `debounce` | `number` | `300` | Debounce delay in milliseconds for search events |
+| `display` | `string \| ((option: T) => string)` | `undefined` | Field name or function to generate display text for options |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of the input component |
+| `validationStatus` | `'success' \| 'error'` | `undefined` | Validation status for styling |
+| `class` | `string \| Record<string, boolean>` | `''` | Additional CSS classes for the component |
+| `wrapperClass` | `string \| Record<string, boolean>` | `''` | CSS classes for the wrapper element |
+| `labelClass` | `string \| Record<string, boolean>` | `''` | CSS classes for the label element |
+| `dropdownClass` | `string \| Record<string, boolean>` | `''` | CSS classes for the dropdown container |
+| `label` | `string` | `undefined` | Label text for the input field |
+| `inputComponent` | `Component` | `FwbInput` | Vue component to use as the input field |
+| `inputProps` | `Record<string, any>` | `{}` | Additional props to pass to the input component |
+
+### Input Component Props
+
+The autocomplete component uses `FwbInput` by default and passes through all standard input props. For a complete list of available input props, see the [Input component documentation](./input.md#input-component-api).
+
+Common input props that can be passed through:
+- `placeholder` - Input placeholder text
+- `disabled` - Disable the input
+- `size` - Input size (`'sm'` | `'md'` | `'lg'`)
+- `label` - Input label text
+- `class` - CSS classes for styling
+- `inputClass` - CSS classes for the input element
+- `wrapperClass` - CSS classes for the input wrapper
+- `labelClass` - CSS classes for the label
+
+You can also pass additional props via the `inputProps` prop or use a completely different input component via the `inputComponent` prop.
 
 ### Events
 
-| Name | Parameters | Description |
-|------|------------|-------------|
-| `update:modelValue` | `value: T \| null` | Emitted when selection changes |
+| Event | Parameters | Description |
+|-------|------------|-------------|
+| `update:modelValue` | `value: T \| null` | Emitted when the selected value changes |
 | `select` | `option: T` | Emitted when an option is selected |
-| `search` | `query: string` | Emitted when search query changes |
+| `search` | `query: string` | Emitted when the search query changes |
 
 ### Slots
 
-| Name | Props | Description |
+| Slot | Props | Description |
 |------|-------|-------------|
-| `option` | `{ option, index }` | Custom option template |
-| `validationMessage` | - | Validation message content |
-| `helper` | - | Helper text content | 
+| `option` | `{ option: T, index: number }` | Custom template for rendering dropdown options |
+| `suffix` | `{ loading: boolean, clear: () => void }` | Custom suffix content (overrides default loading/clear icons) |
+| `validationMessage` | - | Custom validation message content |
+| `helper` | - | Helper text content below the input |
+
+### Examples
+
+#### Basic Usage
+```vue
+<fwb-autocomplete
+  v-model="selected"
+  :options="countries"
+  search-fields="name"
+  display="name"
+  placeholder="Search countries..."
+/>
+```
+
+#### Remote Data with Custom Input Props
+```vue
+<fwb-autocomplete
+  v-model="selected"
+  :options="users"
+  :loading="loading"
+  search-fields="name,email"
+  display="name"
+  remote
+  :debounce="500"
+  :input-props="{
+    size: 'lg',
+    class: 'border-blue-300 focus:border-blue-500'
+  }"
+  @search="fetchUsers"
+/>
+```
+
+#### Custom Input Component
+```vue
+<fwb-autocomplete
+  v-model="selected"
+  :options="options"
+  :input-component="MyCustomInput"
+  :input-props="{ theme: 'rounded', prefixIcon: 'search' }"
+/>
+```

--- a/docs/components/autocomplete/examples/FwbAutocompleteExample.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExample.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selectedCountry"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Select a country"
+      placeholder="Search countries..."
+    />
+    <p
+      v-if="selectedCountry"
+      class="mt-2 text-sm text-gray-600"
+    >
+      Selected: {{ selectedCountry.name }} ({{ selectedCountry.code }})
+    </p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+  { id: 4, name: 'Germany', code: 'DE' },
+  { id: 5, name: 'United Kingdom', code: 'UK' },
+  { id: 6, name: 'Spain', code: 'ES' },
+  { id: 7, name: 'Italy', code: 'IT' },
+  { id: 8, name: 'Netherlands', code: 'NL' },
+]
+
+const selectedCountry = ref<typeof countries[0] | null>(null)
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleCustom.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleCustom.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selectedUser"
+      :options="users"
+      :search-fields="['name', 'email']"
+      display="name"
+      label="Select user"
+      placeholder="Search users..."
+    >
+      <template #option="{ option }">
+        <div class="flex items-center">
+          <img
+            :src="option.avatar"
+            :alt="option.name"
+            class="w-8 h-8 rounded-full mr-3"
+          >
+          <div>
+            <div class="font-medium">
+              {{ option.name }}
+            </div>
+            <div class="text-sm text-gray-500">
+              {{ option.email }}
+            </div>
+          </div>
+        </div>
+      </template>
+    </fwb-autocomplete>
+    <div
+      v-if="selectedUser"
+      class="mt-4 p-3 bg-gray-50 rounded"
+    >
+      <div class="flex items-center">
+        <img
+          :src="selectedUser.avatar"
+          :alt="selectedUser.name"
+          class="w-10 h-10 rounded-full mr-3"
+        >
+        <div>
+          <div class="font-medium">
+            {{ selectedUser.name }}
+          </div>
+          <div class="text-sm text-gray-500">
+            {{ selectedUser.email }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const selectedUser = ref(null)
+const users = [
+  {
+    id: 1,
+    name: 'John Doe',
+    email: 'john@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=1',
+  },
+  {
+    id: 2,
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=2',
+  },
+  {
+    id: 3,
+    name: 'Bob Johnson',
+    email: 'bob@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=3',
+  },
+  {
+    id: 4,
+    name: 'Alice Brown',
+    email: 'alice@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=4',
+  },
+]
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleCustomInput.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleCustomInput.vue
@@ -1,0 +1,273 @@
+<template>
+  <div class="vp-raw">
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold mb-4">
+        Custom Input Component
+      </h3>
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        Use any input component by passing it to the <code>inputComponent</code> prop.
+      </p>
+
+      <!-- Using custom input component -->
+      <fwb-autocomplete
+        v-model="selectedUser"
+        :options="users"
+        :search-fields="['name', 'email']"
+        :loading="loading"
+        :input-component="CustomInput"
+        :input-props="{
+          prefixIcon: 'search',
+          class: 'custom-search-input',
+          theme: 'rounded'
+        }"
+        display="name"
+        placeholder="Search users with custom input..."
+        class="mb-4"
+        @search="handleSearch"
+      >
+        <template #suffix="{ loading, clear }">
+          <div class="flex items-center space-x-2">
+            <div
+              v-if="loading"
+              class="w-4 h-4 border-2 border-purple-600 border-t-transparent rounded-full animate-spin"
+            />
+            <button
+              v-else-if="selectedUser"
+              class="text-gray-400 hover:text-purple-600 transition-colors"
+              @click="clear"
+            >
+              <svg
+                class="w-4 h-4"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
+        </template>
+
+        <template #option="{ option }">
+          <div class="flex items-center space-x-3">
+            <svg
+              class="w-8 h-8 text-gray-400"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <div>
+              <p class="text-sm font-medium text-gray-900 dark:text-white">
+                {{ option.name }}
+              </p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                {{ option.email }}
+              </p>
+            </div>
+          </div>
+        </template>
+      </fwb-autocomplete>
+    </div>
+
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold mb-4">
+        Customizing FwbInput with Props
+      </h3>
+
+      <!-- Using standard FwbInput with custom props -->
+      <div class="mb-4">
+        <label class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+          Standard FwbInput with custom styling:
+        </label>
+        <fwb-autocomplete
+          v-model="selectedProduct"
+          :options="products"
+          :search-fields="['name', 'category']"
+          :input-props="{
+            size: 'lg',
+            class: 'border-purple-300 focus:border-purple-500 focus:ring-purple-200'
+          }"
+          display="name"
+          placeholder="Search products..."
+        >
+          <template #suffix="{ loading }">
+            <div class="flex items-center">
+              <svg
+                v-if="loading"
+                class="w-5 h-5 text-purple-600 animate-spin"
+                fill="none"
+                viewBox="0 0 100 101"
+              >
+                <path
+                  d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C0 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                  fill="currentColor"
+                />
+                <path
+                  d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                  fill="currentFill"
+                />
+              </svg>
+              <svg
+                v-else
+                class="w-5 h-5 text-purple-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </div>
+          </template>
+
+          <template #option="{ option }">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center space-x-3">
+                <svg
+                  class="w-5 h-5 text-yellow-400"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+                <div>
+                  <p class="font-medium">
+                    {{ option.name }}
+                  </p>
+                  <p class="text-sm text-gray-500">
+                    {{ option.category }}
+                  </p>
+                </div>
+              </div>
+              <span class="text-lg font-bold text-green-600">${{ option.price }}</span>
+            </div>
+          </template>
+        </fwb-autocomplete>
+      </div>
+    </div>
+
+    <div class="mt-6 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg">
+      <h4 class="font-semibold mb-2">
+        Selected Values:
+      </h4>
+      <p><strong>User:</strong> {{ selectedUser?.name || 'None' }}</p>
+      <p><strong>Product:</strong> {{ selectedProduct?.name || 'None' }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineComponent, h, ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+// Custom input component example
+const CustomInput = defineComponent({
+  props: {
+    modelValue: String,
+    placeholder: String,
+    disabled: Boolean,
+    prefixIcon: String,
+    theme: String,
+    class: String,
+  },
+  emits: ['update:modelValue', 'input', 'focus', 'keydown'],
+  setup (props, { emit, attrs }) {
+    const handleInput = (event: Event) => {
+      const value = (event.target as HTMLInputElement).value
+      emit('update:modelValue', value)
+      emit('input', event)
+    }
+
+    const getIconPath = () => {
+      if (props.prefixIcon === 'search') {
+        return 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'
+      }
+      return ''
+    }
+
+    const inputClasses = [
+      'block w-full pl-10 pr-4 py-3 text-gray-900 bg-white border border-gray-300',
+      'focus:ring-2 focus:ring-purple-500 focus:border-purple-500',
+      'dark:bg-gray-700 dark:border-gray-600 dark:text-white',
+      props.theme === 'rounded' ? 'rounded-full' : 'rounded-lg',
+      props.class,
+    ].filter(Boolean).join(' ')
+
+    return () => h('div', { class: 'relative' }, [
+      // Prefix icon
+      props.prefixIcon && h('div', {
+        class: 'absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none',
+      }, [
+        h('svg', {
+          class: 'w-5 h-5 text-gray-400',
+          fill: 'none',
+          stroke: 'currentColor',
+          viewBox: '0 0 24 24',
+        }, [
+          h('path', {
+            'stroke-linecap': 'round',
+            'stroke-linejoin': 'round',
+            'stroke-width': '2',
+            'd': getIconPath(),
+          }),
+        ]),
+      ]),
+      // Input
+      h('input', {
+        ...attrs,
+        value: props.modelValue,
+        placeholder: props.placeholder,
+        disabled: props.disabled,
+        class: inputClasses,
+        onInput: handleInput,
+        onFocus: (e: Event) => emit('focus', e),
+        onKeydown: (e: KeyboardEvent) => emit('keydown', e),
+      }),
+    ])
+  },
+})
+
+// Sample data
+const users = ref([
+  { id: 1, name: 'John Doe', email: 'john@example.com' },
+  { id: 2, name: 'Jane Smith', email: 'jane@example.com' },
+  { id: 3, name: 'Bob Johnson', email: 'bob@example.com' },
+  { id: 4, name: 'Alice Brown', email: 'alice@example.com' },
+])
+
+const products = ref([
+  { id: 1, name: 'MacBook Pro', category: 'Laptops', price: 1999 },
+  { id: 2, name: 'iPhone 15', category: 'Phones', price: 999 },
+  { id: 3, name: 'iPad Air', category: 'Tablets', price: 599 },
+  { id: 4, name: 'AirPods Pro', category: 'Audio', price: 249 },
+])
+
+type User = { id: number, name: string, email: string }
+type Product = { id: number, name: string, category: string, price: number }
+
+const selectedUser = ref<User | null>(null)
+const selectedProduct = ref<Product | null>(null)
+const loading = ref(false)
+
+const handleSearch = (query: string) => {
+  if (!query) return
+
+  loading.value = true
+  setTimeout(() => {
+    loading.value = false
+  }, 500)
+}
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleRemote.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleRemote.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selectedCountry"
+      :options="countries"
+      :loading="loading"
+      :search-fields="['name']"
+      display="name"
+      label="Search countries"
+      placeholder="Type to search countries..."
+      remote
+      :min-chars="2"
+      :debounce="500"
+      @search="searchCountries"
+    >
+      <template #option="{ option }">
+        <div class="flex items-center space-x-3">
+          <span class="text-2xl">{{ option.flag }}</span>
+          <div>
+            <div class="font-medium">
+              {{ option.name }}
+            </div>
+            <div class="text-sm text-gray-500">
+              {{ option.region }}
+            </div>
+          </div>
+        </div>
+      </template>
+    </fwb-autocomplete>
+
+    <div
+      v-if="selectedCountry"
+      class="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg"
+    >
+      <div class="flex items-center space-x-3">
+        <span class="text-3xl">{{ selectedCountry.flag }}</span>
+        <div>
+          <div class="font-semibold">
+            {{ selectedCountry.name }}
+          </div>
+          <div class="text-sm text-gray-600">
+            Capital: {{ selectedCountry.capital }} • Population: {{ selectedCountry.population?.toLocaleString() }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <p
+      v-if="error"
+      class="mt-2 text-sm text-red-600"
+    >
+      {{ error }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+interface Country {
+  name: string
+  capital: string
+  region: string
+  population: number
+  flag: string
+}
+
+const selectedCountry = ref<Country | null>(null)
+const countries = ref<Country[]>([])
+const loading = ref(false)
+const error = ref('')
+
+const searchCountries = async (query: string) => {
+  if (query.length < 2) {
+    countries.value = []
+    error.value = ''
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+
+  try {
+    const response = await fetch(`https://restcountries.com/v3.1/name/${encodeURIComponent(query)}`)
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        countries.value = []
+        return
+      }
+      throw new Error('Failed to fetch countries')
+    }
+
+    const data = await response.json()
+
+    countries.value = data.slice(0, 10).map((country: any) => ({
+      name: country.name.common,
+      capital: country.capital?.[0] || 'N/A',
+      region: country.region,
+      population: country.population,
+      flag: country.flag,
+    }))
+  } catch (err) {
+    error.value = 'Failed to search countries. Please try again.'
+    countries.value = []
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleSize.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleSize.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="vp-raw">
+    <div class="space-y-4">
+      <fwb-autocomplete
+        v-model="selected1"
+        :options="countries"
+        :search-fields="['name']"
+        display="name"
+        label="Small"
+        size="sm"
+        placeholder="Small autocomplete..."
+      />
+
+      <fwb-autocomplete
+        v-model="selected2"
+        :options="countries"
+        :search-fields="['name']"
+        display="name"
+        label="Medium (default)"
+        size="md"
+        placeholder="Medium autocomplete..."
+      />
+
+      <fwb-autocomplete
+        v-model="selected3"
+        :options="countries"
+        :search-fields="['name']"
+        display="name"
+        label="Large"
+        size="lg"
+        placeholder="Large autocomplete..."
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+  { id: 4, name: 'Germany', code: 'DE' },
+  { id: 5, name: 'United Kingdom', code: 'UK' },
+]
+
+const selected1 = ref<typeof countries[0] | null>(null)
+const selected2 = ref<typeof countries[0] | null>(null)
+const selected3 = ref<typeof countries[0] | null>(null)
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleValidation.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleValidation.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selectedCountry"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Country *"
+      placeholder="Select a country..."
+      :validation-status="validationStatus"
+    >
+      <template #validationMessage>
+        <span v-if="!selectedCountry">Please select a country</span>
+        <span v-else-if="showValidation">This field is required for shipping</span>
+      </template>
+      <template #helper>
+        Choose the country where you reside
+      </template>
+    </fwb-autocomplete>
+
+    <div
+      v-if="selectedCountry"
+      class="mt-4 p-3 bg-green-50 border border-green-200 rounded-lg"
+    >
+      <p class="text-sm text-green-700">
+        ✓ Selected: {{ selectedCountry.name }} ({{ selectedCountry.code }})
+      </p>
+    </div>
+
+    <button
+      v-if="selectedCountry"
+      class="mt-2 px-3 py-1 text-xs bg-blue-500 text-white rounded hover:bg-blue-600"
+      @click="toggleValidationMessage"
+    >
+      {{ showValidation ? 'Hide' : 'Show' }} persistent validation
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+  { id: 4, name: 'Germany', code: 'DE' },
+  { id: 5, name: 'United Kingdom', code: 'UK' },
+]
+
+const selectedCountry = ref<typeof countries[0] | null>(null)
+const showValidation = ref(false)
+
+const validationStatus = computed(() => {
+  return selectedCountry.value ? 'success' : 'error'
+})
+
+const toggleValidationMessage = () => {
+  showValidation.value = !showValidation.value
+}
+</script>

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -5,7 +5,6 @@
         v-model="inputValue"
         :label="label"
         :label-class="labelClass"
-        :wrapper-class="''"
         :placeholder="placeholder"
         :disabled="disabled"
         :size="size"

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -1,13 +1,22 @@
 <template>
-  <div ref="rootEl" :class="wrapperClasses" data-testid="fwb-autocomplete-wrapper">
+  <div
+    ref="rootEl"
+    :class="wrapperClasses"
+    data-testid="fwb-autocomplete-wrapper"
+  >
     <div class="relative">
-      <fwb-input
+      <component
+        :is="inputComponent"
         v-model="inputValue"
-        :label="label"
+        v-bind="{
+          placeholder,
+          disabled,
+          size,
+          label,
+          ...inputProps,
+          ...$attrs,
+        }"
         :label-class="labelClass"
-        :placeholder="placeholder"
-        :disabled="disabled"
-        :size="size"
         :validation-status="validationStatus"
         data-testid="fwb-autocomplete-input"
         @input="handleInput"
@@ -15,49 +24,58 @@
         @keydown="handleKeydown"
       >
         <template #suffix>
-          <div class="flex items-center">
-            <div
-              v-if="loading"
-              class="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"
-              data-testid="fwb-autocomplete-loading-spinner"
-            />
-            <svg
-              v-else-if="inputValue"
-              class="w-5 h-5 cursor-pointer text-gray-400 hover:text-gray-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              data-testid="fwb-autocomplete-clear-button"
-              @click="clear"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
+          <slot
+            name="suffix"
+            :loading="loading"
+            :clear="clear"
+          >
+            <div class="flex items-center">
+              <div
+                v-if="loading"
+                class="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"
+                data-testid="fwb-autocomplete-loading-spinner"
               />
-            </svg>
-            <svg
-              v-else
-              class="w-5 h-5 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              data-testid="fwb-autocomplete-search-icon"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </div>
+              <svg
+                v-else-if="inputValue"
+                class="w-5 h-5 cursor-pointer text-gray-400 hover:text-gray-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                data-testid="fwb-autocomplete-clear-button"
+                @click="clear"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+              <svg
+                v-else
+                class="w-5 h-5 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                data-testid="fwb-autocomplete-search-icon"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </div>
+          </slot>
         </template>
-      </fwb-input>
+      </component>
 
       <div
-        v-if="dropdownOpen && (filteredOptions.length > 0 || loading || noResultsFound)"
+        v-if="
+          dropdownOpen &&
+            (filteredOptions.length > 0 || loading || noResultsFound)
+        "
         :class="dropdownClasses"
         data-testid="fwb-autocomplete-dropdown"
       >
@@ -121,36 +139,49 @@
 </template>
 
 <script setup lang="ts" generic="T extends Record<string, any>">
-import { computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
+import {
+  type Component,
+  computed,
+  onMounted,
+  onUnmounted,
+  ref,
+  toRefs,
+  watch,
+} from 'vue'
 
 import FwbInput from '../FwbInput/FwbInput.vue'
 
 import { useAutocompleteClasses } from './composables/useAutocompleteClasses'
 
-import type {
-  AutocompleteEmits,
-  AutocompleteProps,
-} from './types'
+import type { AutocompleteEmits, AutocompleteProps } from './types'
 
-defineOptions({
-  inheritAttrs: false,
-})
+defineOptions({ inheritAttrs: true })
 
-const props = withDefaults(defineProps<AutocompleteProps<T>>(), {
-  placeholder: 'Search...',
-  disabled: false,
-  searchFields: () => [],
-  loadingText: 'Loading...',
-  noResultsText: 'No results found',
-  minChars: 0,
-  remote: false,
-  debounce: 300,
-  size: 'md',
-  class: '',
-  wrapperClass: '',
-  labelClass: '',
-  dropdownClass: '',
-})
+const props = withDefaults(
+  defineProps<
+    AutocompleteProps<T> & {
+      inputComponent?: Component
+      inputProps?: Record<string, any>
+    }
+  >(),
+  {
+    placeholder: 'Search...',
+    disabled: false,
+    searchFields: () => [],
+    loadingText: 'Loading...',
+    noResultsText: 'No results found',
+    minChars: 0,
+    remote: false,
+    debounce: 300,
+    size: 'md',
+    class: '',
+    wrapperClass: '',
+    labelClass: '',
+    dropdownClass: '',
+    inputComponent: FwbInput,
+    inputProps: () => ({}),
+  },
+)
 
 const emit = defineEmits<AutocompleteEmits<T>>()
 

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="rootEl" :class="wrapperClasses">
+  <div ref="rootEl" :class="wrapperClasses" data-testid="fwb-autocomplete-wrapper">
     <div class="relative">
       <fwb-input
         v-model="inputValue"
@@ -9,6 +9,7 @@
         :disabled="disabled"
         :size="size"
         :validation-status="validationStatus"
+        data-testid="fwb-autocomplete-input"
         @input="handleInput"
         @focus="handleFocus"
         @keydown="handleKeydown"
@@ -18,6 +19,7 @@
             <div
               v-if="loading"
               class="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"
+              data-testid="fwb-autocomplete-loading-spinner"
             />
             <svg
               v-else-if="inputValue"
@@ -25,6 +27,7 @@
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              data-testid="fwb-autocomplete-clear-button"
               @click="clear"
             >
               <path
@@ -40,6 +43,7 @@
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              data-testid="fwb-autocomplete-search-icon"
             >
               <path
                 stroke-linecap="round"
@@ -55,10 +59,12 @@
       <div
         v-if="dropdownOpen && (filteredOptions.length > 0 || loading || noResultsFound)"
         :class="dropdownClasses"
+        data-testid="fwb-autocomplete-dropdown"
       >
         <div
           v-if="loading"
           :class="messageClasses"
+          data-testid="fwb-autocomplete-loading-message"
         >
           <div class="flex items-center justify-center gap-2">
             <div
@@ -71,6 +77,7 @@
         <div
           v-else-if="noResultsFound"
           :class="messageClasses"
+          data-testid="fwb-autocomplete-no-results"
         >
           {{ noResultsText }}
         </div>
@@ -80,6 +87,8 @@
           v-else
           :key="getOptionKey(option)"
           :class="getDropdownItemClasses(highlightedIndex === index)"
+          :data-testid="`fwb-autocomplete-option-${index}`"
+          class="fwb-autocomplete-option"
           @click="select(option)"
           @mouseenter="highlightedIndex = index"
         >
@@ -97,12 +106,14 @@
     <p
       v-if="$slots.validationMessage"
       class="mt-2 text-sm text-red-600 dark:text-red-500"
+      data-testid="fwb-autocomplete-validation-message"
     >
       <slot name="validationMessage" />
     </p>
     <p
       v-if="$slots.helper"
       class="mt-2 text-sm text-gray-500 dark:text-gray-400"
+      data-testid="fwb-autocomplete-helper-text"
     >
       <slot name="helper" />
     </p>

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -21,6 +21,7 @@
         data-testid="fwb-autocomplete-input"
         @input="handleInput"
         @focus="handleFocus"
+        @blur="handleBlur"
         @keydown="handleKeydown"
       >
         <template #suffix>
@@ -107,6 +108,9 @@
           :class="getDropdownItemClasses(highlightedIndex === index)"
           :data-testid="`fwb-autocomplete-option-${index}`"
           class="fwb-autocomplete-option"
+          @mousedown="isSelectingOption = true"
+          @mouseup="isSelectingOption = false"
+          @mouseleave="isSelectingOption = false"
           @click="select(option)"
           @mouseenter="highlightedIndex = index"
         >
@@ -190,6 +194,7 @@ const inputValue = ref('')
 const dropdownOpen = ref(false)
 const highlightedIndex = ref(-1)
 const debounceTimer = ref<ReturnType<typeof setTimeout> | null>(null)
+const isSelectingOption = ref(false)
 
 const {
   wrapperClasses,
@@ -258,6 +263,13 @@ const handleInput = () => {
 const handleFocus = () => {
   dropdownOpen.value = true
   emit('search', inputValue.value)
+}
+
+const handleBlur = () => {
+  if (!isSelectingOption.value) {
+    dropdownOpen.value = false
+    highlightedIndex.value = -1
+  }
 }
 
 const handleKeydown = (event: KeyboardEvent) => {

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -1,0 +1,298 @@
+<template>
+  <div :class="wrapperClasses">
+    <div class="relative">
+      <fwb-input
+        v-model="inputValue"
+        :label="label"
+        :label-class="labelClass"
+        :wrapper-class="''"
+        :placeholder="placeholder"
+        :disabled="disabled"
+        :size="size"
+        :validation-status="validationStatus"
+        @input="handleInput"
+        @focus="handleFocus"
+        @keydown="handleKeydown"
+      >
+        <template #suffix>
+          <div class="flex items-center">
+            <div
+              v-if="loading"
+              class="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"
+            />
+            <svg
+              v-else-if="inputValue"
+              class="w-5 h-5 cursor-pointer text-gray-400 hover:text-gray-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              @click="clear"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+            <svg
+              v-else
+              class="w-5 h-5 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          </div>
+        </template>
+      </fwb-input>
+
+      <div
+        v-if="dropdownOpen && (filteredOptions.length > 0 || loading || noResultsFound)"
+        :class="dropdownClasses"
+      >
+        <div
+          v-if="loading"
+          :class="messageClasses"
+        >
+          <div class="flex items-center justify-center gap-2">
+            <div
+              class="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"
+            />
+            {{ loadingText }}
+          </div>
+        </div>
+
+        <div
+          v-else-if="noResultsFound"
+          :class="messageClasses"
+        >
+          {{ noResultsText }}
+        </div>
+
+        <div
+          v-for="(option, index) in filteredOptions"
+          v-else
+          :key="getOptionKey(option)"
+          :class="getDropdownItemClasses(highlightedIndex === index)"
+          @click="select(option)"
+          @mouseenter="highlightedIndex = index"
+        >
+          <slot
+            name="option"
+            :option="option"
+            :index="index"
+          >
+            {{ getOptionLabel(option) }}
+          </slot>
+        </div>
+      </div>
+    </div>
+
+    <p
+      v-if="$slots.validationMessage"
+      class="mt-2 text-sm text-red-600 dark:text-red-500"
+    >
+      <slot name="validationMessage" />
+    </p>
+    <p
+      v-if="$slots.helper"
+      class="mt-2 text-sm text-gray-500 dark:text-gray-400"
+    >
+      <slot name="helper" />
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts" generic="T extends Record<string, any>">
+import { computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
+
+import FwbInput from '../FwbInput/FwbInput.vue'
+
+import { useAutocompleteClasses } from './composables/useAutocompleteClasses'
+
+import type {
+  AutocompleteEmits,
+  AutocompleteProps,
+} from './types'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(defineProps<AutocompleteProps<T>>(), {
+  placeholder: 'Search...',
+  disabled: false,
+  searchFields: () => [],
+  loadingText: 'Loading...',
+  noResultsText: 'No results found',
+  minChars: 0,
+  remote: false,
+  debounce: 300,
+  size: 'md',
+  class: '',
+  wrapperClass: '',
+  labelClass: '',
+  dropdownClass: '',
+})
+
+const emit = defineEmits<AutocompleteEmits<T>>()
+
+const rootEl = ref<HTMLElement | null>(null)
+const inputValue = ref('')
+const dropdownOpen = ref(false)
+const highlightedIndex = ref(-1)
+const debounceTimer = ref<ReturnType<typeof setTimeout> | null>(null)
+
+const {
+  wrapperClasses,
+  dropdownClasses,
+  getDropdownItemClasses,
+  messageClasses,
+} = useAutocompleteClasses(toRefs(props))
+
+const filteredOptions = computed(() => {
+  if (props.remote || inputValue.value.length < props.minChars) {
+    return props.options
+  }
+
+  const query = inputValue.value.toLowerCase()
+
+  if (!props.searchFields?.length) return props.options
+
+  return props.options.filter(opt =>
+    props.searchFields?.some(field =>
+      String(opt[field] ?? '')
+        .toLowerCase()
+        .includes(query),
+    ),
+  )
+})
+
+const noResultsFound = computed(
+  () =>
+    !props.loading
+    && inputValue.value.length >= props.minChars
+    && filteredOptions.value.length === 0,
+)
+
+const getOptionKey = (opt: T): string => {
+  return props.valueField && opt[props.valueField] !== undefined
+    ? String(opt[props.valueField])
+    : JSON.stringify(opt)
+}
+
+const getOptionLabel = (opt: T): string => {
+  if (typeof props.display === 'function') return props.display(opt)
+  if (props.display && typeof props.display === 'string') {
+    return String(opt[props.display])
+  }
+  return String(opt)
+}
+
+const handleInput = () => {
+  dropdownOpen.value = true
+  highlightedIndex.value = -1
+  emit('update:modelValue', null)
+
+  if (debounceTimer.value) {
+    clearTimeout(debounceTimer.value)
+  }
+
+  if (props.remote && props.debounce > 0) {
+    debounceTimer.value = setTimeout(() => {
+      emit('search', inputValue.value)
+    }, props.debounce)
+  } else {
+    emit('search', inputValue.value)
+  }
+}
+
+const handleFocus = () => {
+  dropdownOpen.value = true
+  emit('search', inputValue.value)
+}
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if (!dropdownOpen.value && event.key === 'ArrowDown') {
+    dropdownOpen.value = true
+    emit('search', inputValue.value)
+    if (filteredOptions.value.length > 0) highlightedIndex.value = 0
+    return
+  }
+
+  switch (event.key) {
+    case 'ArrowDown':
+      event.preventDefault()
+      if (filteredOptions.value.length > 0) {
+        highlightedIndex.value
+          = (highlightedIndex.value + 1) % filteredOptions.value.length
+      }
+      break
+    case 'ArrowUp':
+      event.preventDefault()
+      if (filteredOptions.value.length > 0) {
+        highlightedIndex.value
+          = (highlightedIndex.value - 1 + filteredOptions.value.length)
+          % filteredOptions.value.length
+      }
+      break
+    case 'Enter':
+      event.preventDefault()
+      if (highlightedIndex.value >= 0) {
+        select(filteredOptions.value[highlightedIndex.value])
+      }
+      break
+    case 'Escape':
+      dropdownOpen.value = false
+      highlightedIndex.value = -1
+      break
+  }
+}
+
+const select = (opt: T) => {
+  inputValue.value = getOptionLabel(opt)
+  dropdownOpen.value = false
+  highlightedIndex.value = -1
+  emit('update:modelValue', opt)
+  emit('select', opt)
+}
+
+const clear = () => {
+  inputValue.value = ''
+  dropdownOpen.value = false
+  emit('update:modelValue', null)
+}
+
+const handleClickOutside = (event: Event) => {
+  if (rootEl.value && !rootEl.value.contains(event.target as Node)) {
+    dropdownOpen.value = false
+    highlightedIndex.value = -1
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+  if (debounceTimer.value) {
+    clearTimeout(debounceTimer.value)
+  }
+})
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    inputValue.value = newVal ? getOptionLabel(newVal) : ''
+  },
+  { immediate: true },
+)
+</script>

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="wrapperClasses">
+  <div ref="rootEl" :class="wrapperClasses">
     <div class="relative">
       <fwb-input
         v-model="inputValue"

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -146,6 +146,7 @@
 import {
   type Component,
   computed,
+  nextTick,
   onMounted,
   onUnmounted,
   ref,
@@ -286,6 +287,7 @@ const handleKeydown = (event: KeyboardEvent) => {
       if (filteredOptions.value.length > 0) {
         highlightedIndex.value
           = (highlightedIndex.value + 1) % filteredOptions.value.length
+        scrollToHighlightedOption()
       }
       break
     case 'ArrowUp':
@@ -294,6 +296,7 @@ const handleKeydown = (event: KeyboardEvent) => {
         highlightedIndex.value
           = (highlightedIndex.value - 1 + filteredOptions.value.length)
           % filteredOptions.value.length
+        scrollToHighlightedOption()
       }
       break
     case 'Enter':
@@ -321,6 +324,22 @@ const clear = () => {
   inputValue.value = ''
   dropdownOpen.value = false
   emit('update:modelValue', null)
+}
+
+const scrollToHighlightedOption = async () => {
+  await nextTick()
+  if (highlightedIndex.value >= 0 && rootEl.value) {
+    const highlightedElement = rootEl.value.querySelector(
+      `[data-testid="fwb-autocomplete-option-${highlightedIndex.value}"]`,
+    ) as HTMLElement
+
+    if (highlightedElement && typeof highlightedElement.scrollIntoView === 'function') {
+      highlightedElement.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      })
+    }
+  }
 }
 
 const handleClickOutside = (event: Event) => {

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -185,6 +185,7 @@ const props = withDefaults(
     dropdownClass: '',
     inputComponent: FwbInput,
     inputProps: () => ({}),
+    zIndex: 100,
   },
 )
 

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -1,0 +1,53 @@
+import { twMerge } from 'tailwind-merge'
+import { computed, type Ref } from 'vue'
+
+import type { AutocompleteSize, ValidationStatus } from '../types'
+
+const baseWrapperClasses = 'relative w-full'
+const baseDropdownClasses = 'absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto'
+const baseDropdownItemClasses = 'px-4 py-3 cursor-pointer transition-colors duration-150 border-b border-gray-200 dark:border-gray-600 last:border-b-0'
+const highlightedDropdownItemClasses = 'bg-blue-50 dark:bg-blue-900/20'
+const hoverDropdownItemClasses = 'hover:bg-gray-50 dark:hover:bg-gray-700'
+const baseMessageClasses = 'px-4 py-3 text-center text-gray-500 dark:text-gray-400'
+
+export interface UseAutocompleteClassesProps {
+  size?: Ref<AutocompleteSize>
+  disabled?: Ref<boolean>
+  validationStatus?: Ref<ValidationStatus | undefined>
+  class?: Ref<string | Record<string, boolean> | undefined>
+  wrapperClass?: Ref<string | Record<string, boolean> | undefined>
+  labelClass?: Ref<string | Record<string, boolean> | undefined>
+  dropdownClass?: Ref<string | Record<string, boolean> | undefined>
+}
+
+export function useAutocompleteClasses (props: UseAutocompleteClassesProps) {
+  const wrapperClasses = computed(() => {
+    return twMerge(
+      baseWrapperClasses,
+      typeof props.wrapperClass?.value === 'string' ? props.wrapperClass.value : '',
+    )
+  })
+
+  const dropdownClasses = computed(() => {
+    return twMerge(
+      baseDropdownClasses,
+      typeof props.dropdownClass?.value === 'string' ? props.dropdownClass.value : '',
+    )
+  })
+
+  const getDropdownItemClasses = (isHighlighted: boolean) => {
+    return twMerge(
+      baseDropdownItemClasses,
+      isHighlighted ? highlightedDropdownItemClasses : hoverDropdownItemClasses,
+    )
+  }
+
+  const messageClasses = computed(() => baseMessageClasses)
+
+  return {
+    wrapperClasses,
+    dropdownClasses,
+    getDropdownItemClasses,
+    messageClasses,
+  }
+}

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -1,8 +1,6 @@
 import { twMerge } from 'tailwind-merge'
 import { computed, type Ref } from 'vue'
 
-import type { AutocompleteSize, ValidationStatus } from '../types'
-
 const baseWrapperClasses = 'relative w-full'
 const baseDropdownClasses = 'absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto'
 const baseDropdownItemClasses = 'px-4 py-3 cursor-pointer transition-colors duration-150 border-b border-gray-200 dark:border-gray-600 last:border-b-0'
@@ -11,9 +9,6 @@ const hoverDropdownItemClasses = 'hover:bg-gray-50 dark:hover:bg-gray-700'
 const baseMessageClasses = 'px-4 py-3 text-center text-gray-500 dark:text-gray-400'
 
 export interface UseAutocompleteClassesProps {
-  size?: Ref<AutocompleteSize>
-  disabled?: Ref<boolean>
-  validationStatus?: Ref<ValidationStatus | undefined>
   class?: Ref<string | Record<string, boolean> | undefined>
   wrapperClass?: Ref<string | Record<string, boolean> | undefined>
   labelClass?: Ref<string | Record<string, boolean> | undefined>

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -1,4 +1,4 @@
-import { twMerge } from 'tailwind-merge'
+import { useMergeClasses } from '@/composables/useMergeClasses'
 import { computed, type Ref } from 'vue'
 
 const baseWrapperClasses = 'relative w-full'
@@ -17,24 +17,24 @@ export interface UseAutocompleteClassesProps {
 
 export function useAutocompleteClasses (props: UseAutocompleteClassesProps) {
   const wrapperClasses = computed(() => {
-    return twMerge(
+    return useMergeClasses([
       baseWrapperClasses,
       typeof props.wrapperClass?.value === 'string' ? props.wrapperClass.value : '',
-    )
+    ])
   })
 
   const dropdownClasses = computed(() => {
-    return twMerge(
+    return useMergeClasses([
       baseDropdownClasses,
       typeof props.dropdownClass?.value === 'string' ? props.dropdownClass.value : '',
-    )
+    ])
   })
 
   const getDropdownItemClasses = (isHighlighted: boolean) => {
-    return twMerge(
+    return useMergeClasses([
       baseDropdownItemClasses,
       isHighlighted ? highlightedDropdownItemClasses : hoverDropdownItemClasses,
-    )
+    ])
   }
 
   const messageClasses = computed(() => baseMessageClasses)

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -1,8 +1,8 @@
-import { useMergeClasses } from '@/composables/useMergeClasses'
 import { computed, type Ref } from 'vue'
 
+import { useMergeClasses } from '@/composables/useMergeClasses'
+
 const baseWrapperClasses = 'relative w-full'
-const baseDropdownClasses = 'absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto'
 const baseDropdownItemClasses = 'px-4 py-3 cursor-pointer transition-colors duration-150 border-b border-gray-200 dark:border-gray-600 last:border-b-0'
 const highlightedDropdownItemClasses = 'bg-blue-50 dark:bg-blue-900/20'
 const hoverDropdownItemClasses = 'hover:bg-gray-50 dark:hover:bg-gray-700'
@@ -13,6 +13,7 @@ export interface UseAutocompleteClassesProps {
   wrapperClass?: Ref<string | Record<string, boolean> | undefined>
   labelClass?: Ref<string | Record<string, boolean> | undefined>
   dropdownClass?: Ref<string | Record<string, boolean> | undefined>
+  zIndex?: Ref<number | undefined>
 }
 
 export function useAutocompleteClasses (props: UseAutocompleteClassesProps) {
@@ -23,9 +24,13 @@ export function useAutocompleteClasses (props: UseAutocompleteClassesProps) {
     ])
   })
 
+  const baseDropdownClasses = computed(() =>
+    `absolute z-[${props.zIndex?.value}] w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto`,
+  )
+
   const dropdownClasses = computed(() => {
     return useMergeClasses([
-      baseDropdownClasses,
+      baseDropdownClasses.value,
       typeof props.dropdownClass?.value === 'string' ? props.dropdownClass.value : '',
     ])
   })

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -68,7 +68,7 @@ describe('FwbAutocomplete', () => {
     await input.trigger('focus')
     await nextTick()
 
-    expect(wrapper.find('.absolute.z-50').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(true)
   })
 
   it('selects option on click', async () => {
@@ -84,10 +84,10 @@ describe('FwbAutocomplete', () => {
     await input.trigger('focus')
     await nextTick()
 
-    // Find the first dropdown option
-    const dropdownItems = wrapper.findAll('.px-4.py-3.cursor-pointer')
-    if (dropdownItems.length > 0) {
-      await dropdownItems[0].trigger('click')
+    // Find the first dropdown option using the new test ID
+    const firstOption = wrapper.find('[data-testid="fwb-autocomplete-option-0"]')
+    if (firstOption.exists()) {
+      await firstOption.trigger('click')
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
       expect(wrapper.emitted('select')).toBeTruthy()
     }
@@ -122,10 +122,9 @@ describe('FwbAutocomplete', () => {
       },
     })
 
-    // Find the clear button (X icon) by looking for the specific SVG path
-    const clearButton = wrapper.find('svg path[d="M6 18L18 6M6 6l12 12"]').element.parentElement
-    if (clearButton) {
-      await wrapper.find('svg').trigger('click')
+    const clearButton = wrapper.find('[data-testid="fwb-autocomplete-clear-button"]')
+    if (clearButton.exists()) {
+      await clearButton.trigger('click')
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
       const emittedEvents = wrapper.emitted('update:modelValue') as Array<any>
       expect(emittedEvents[emittedEvents.length - 1][0]).toBe(null)
@@ -147,7 +146,8 @@ describe('FwbAutocomplete', () => {
     await nextTick()
 
     expect(wrapper.text()).toContain('Loading...')
-    expect(wrapper.find('.animate-spin').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-loading-spinner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-loading-message"]').exists()).toBe(true)
   })
 
   it('shows no results message', async () => {
@@ -165,6 +165,7 @@ describe('FwbAutocomplete', () => {
     await nextTick()
 
     expect(wrapper.text()).toContain('No results found')
+    expect(wrapper.find('[data-testid="fwb-autocomplete-no-results"]').exists()).toBe(true)
   })
 
   it('handles remote search with debounce', async () => {
@@ -205,7 +206,7 @@ describe('FwbAutocomplete', () => {
     })
 
     expect(wrapper.text()).toContain('This field is required')
-    expect(wrapper.find('.text-red-600').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-validation-message"]').exists()).toBe(true)
   })
 
   it('renders helper text slot', () => {
@@ -220,7 +221,7 @@ describe('FwbAutocomplete', () => {
     })
 
     expect(wrapper.text()).toContain('Choose your country')
-    expect(wrapper.find('.text-gray-500').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-helper-text"]').exists()).toBe(true)
   })
 
   it('handles different sizes', () => {
@@ -261,12 +262,12 @@ describe('FwbAutocomplete', () => {
     await input.trigger('focus')
     await nextTick()
 
-    expect(wrapper.find('.absolute.z-50').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(true)
 
     await input.trigger('keydown', { key: 'Escape' })
     await nextTick()
 
-    expect(wrapper.find('.absolute.z-50').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(false)
   })
 
   it('searches multiple fields', async () => {
@@ -356,13 +357,13 @@ describe('FwbAutocomplete', () => {
     await input.trigger('focus')
     await nextTick()
 
-    const dropdownItems = wrapper.findAll('.px-4.py-3.cursor-pointer')
-    if (dropdownItems.length > 0) {
-      await dropdownItems[1].trigger('mouseenter')
+    const secondOption = wrapper.find('[data-testid="fwb-autocomplete-option-1"]')
+    if (secondOption.exists()) {
+      await secondOption.trigger('mouseenter')
 
-      // Check that highlighting is updated (this would be internal state)
+      // Check that the option is highlighted (this would be internal state)
       // We can verify by checking classes or other visual indicators
-      expect(dropdownItems[1].classes()).toContain('cursor-pointer')
+      expect(secondOption.classes()).toContain('fwb-autocomplete-option')
     }
   })
 
@@ -379,9 +380,9 @@ describe('FwbAutocomplete', () => {
     await input.trigger('focus')
     await nextTick()
 
-    const dropdownItems = wrapper.findAll('.px-4.py-3.cursor-pointer')
-    if (dropdownItems.length > 0) {
-      await dropdownItems[0].trigger('click')
+    const firstOption = wrapper.find('[data-testid="fwb-autocomplete-option-0"]')
+    if (firstOption.exists()) {
+      await firstOption.trigger('click')
 
       // Input should show the selected option's display value
       expect(input.element.value).toBe('United States')

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -427,6 +427,29 @@ describe('FwbAutocomplete', () => {
     }
   })
 
+  it('closes dropdown on blur event', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(true)
+
+    // Blur to close dropdown
+    await input.trigger('blur')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(false)
+  })
+  
+
   it('passes inputProps to input component', () => {
     const wrapper = mount(FwbAutocomplete, {
       props: {

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -1,0 +1,390 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import FwbAutocomplete from '../FwbAutocomplete.vue'
+
+const mockOptions = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+  { id: 4, name: 'Germany', code: 'DE' },
+  { id: 5, name: 'United Kingdom', code: 'UK' },
+]
+
+describe('FwbAutocomplete', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders with basic props', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+        label: 'Select Country',
+        placeholder: 'Search countries...',
+      },
+    })
+
+    expect(wrapper.find('label').text()).toBe('Select Country')
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Search countries...')
+  })
+
+  it('filters options based on search input', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.setValue('United')
+    await input.trigger('input')
+    await nextTick()
+
+    expect(wrapper.text()).toContain('United States')
+    expect(wrapper.text()).toContain('United Kingdom')
+    expect(wrapper.text()).not.toContain('France')
+  })
+
+  it('shows dropdown when input is focused', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    expect(wrapper.find('.absolute.z-50').exists()).toBe(true)
+  })
+
+  it('selects option on click', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    // Find the first dropdown option
+    const dropdownItems = wrapper.findAll('.px-4.py-3.cursor-pointer')
+    if (dropdownItems.length > 0) {
+      await dropdownItems[0].trigger('click')
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      expect(wrapper.emitted('select')).toBeTruthy()
+    }
+  })
+
+  it('handles keyboard navigation', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    await input.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('select')).toBeTruthy()
+  })
+
+  it('clears selection when clear button is clicked', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        modelValue: mockOptions[0],
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    // Find the clear button (X icon) by looking for the specific SVG path
+    const clearButton = wrapper.find('svg path[d="M6 18L18 6M6 6l12 12"]').element.parentElement
+    if (clearButton) {
+      await wrapper.find('svg').trigger('click')
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      const emittedEvents = wrapper.emitted('update:modelValue') as Array<any>
+      expect(emittedEvents[emittedEvents.length - 1][0]).toBe(null)
+    }
+  })
+
+  it('shows loading state', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: [],
+        loading: true,
+        loadingText: 'Loading...',
+        searchFields: ['name'],
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Loading...')
+    expect(wrapper.find('.animate-spin').exists()).toBe(true)
+  })
+
+  it('shows no results message', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        noResultsText: 'No results found',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.setValue('xyz')
+    await input.trigger('input')
+    await nextTick()
+
+    expect(wrapper.text()).toContain('No results found')
+  })
+
+  it('handles remote search with debounce', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: [],
+        remote: true,
+        debounce: 300,
+        searchFields: ['name'],
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.setValue('test')
+    await input.trigger('input')
+
+    // Should not emit search immediately due to debounce
+    expect(wrapper.emitted('search')).toBeFalsy()
+
+    // Fast-forward time by debounce amount
+    vi.advanceTimersByTime(300)
+    await nextTick()
+
+    expect(wrapper.emitted('search')).toBeTruthy()
+    expect(wrapper.emitted('search')?.[0]?.[0]).toBe('test')
+  })
+
+  it('renders validation message slot', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        validationStatus: 'error',
+      },
+      slots: {
+        validationMessage: 'This field is required',
+      },
+    })
+
+    expect(wrapper.text()).toContain('This field is required')
+    expect(wrapper.find('.text-red-600').exists()).toBe(true)
+  })
+
+  it('renders helper text slot', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+      },
+      slots: {
+        helper: 'Choose your country',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Choose your country')
+    expect(wrapper.find('.text-gray-500').exists()).toBe(true)
+  })
+
+  it('handles different sizes', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        size: 'lg',
+      },
+    })
+
+    // Check that size prop is passed to FwbInput
+    const inputComponent = wrapper.getComponent({ name: 'FwbInput' })
+    expect(inputComponent.props('size')).toBe('lg')
+  })
+
+  it('works with disabled state', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        disabled: true,
+      },
+    })
+
+    expect(wrapper.find('input').attributes('disabled')).toBeDefined()
+  })
+
+  it('closes dropdown on escape key', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    expect(wrapper.find('.absolute.z-50').exists()).toBe(true)
+
+    await input.trigger('keydown', { key: 'Escape' })
+    await nextTick()
+
+    expect(wrapper.find('.absolute.z-50').exists()).toBe(false)
+  })
+
+  it('searches multiple fields', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name', 'code'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.setValue('US')
+    await input.trigger('input')
+    await nextTick()
+
+    expect(wrapper.text()).toContain('United States')
+  })
+
+  it('handles custom display function', async () => {
+    const displayFn = vi.fn((option: any) => `${option.name} (${option.code})`)
+
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: displayFn,
+        modelValue: mockOptions[0],
+      },
+    })
+
+    await nextTick()
+    expect(displayFn).toHaveBeenCalledWith(mockOptions[0])
+  })
+
+  it('generates correct option keys with valueField', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        valueField: 'id',
+      },
+    })
+
+    const vm = wrapper.vm as any
+    expect(vm.getOptionKey(mockOptions[0])).toBe('1')
+    expect(vm.getOptionKey(mockOptions[1])).toBe('2')
+  })
+
+  it('generates JSON keys when no valueField provided', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+      },
+    })
+
+    const vm = wrapper.vm as any
+    const key = vm.getOptionKey(mockOptions[0])
+    expect(key).toBe(JSON.stringify(mockOptions[0]))
+  })
+
+  it('emits search event on focus', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+
+    expect(wrapper.emitted('search')).toBeTruthy()
+  })
+
+  it('handles mouse enter on dropdown items', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    const dropdownItems = wrapper.findAll('.px-4.py-3.cursor-pointer')
+    if (dropdownItems.length > 0) {
+      await dropdownItems[1].trigger('mouseenter')
+
+      // Check that highlighting is updated (this would be internal state)
+      // We can verify by checking classes or other visual indicators
+      expect(dropdownItems[1].classes()).toContain('cursor-pointer')
+    }
+  })
+
+  it('maintains input value when selection is made', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    const dropdownItems = wrapper.findAll('.px-4.py-3.cursor-pointer')
+    if (dropdownItems.length > 0) {
+      await dropdownItems[0].trigger('click')
+
+      // Input should show the selected option's display value
+      expect(input.element.value).toBe('United States')
+    }
+  })
+})

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -484,4 +484,41 @@ describe('FwbAutocomplete', () => {
     const fwbInput = wrapper.findComponent({ name: 'FwbInput' })
     expect(fwbInput.exists()).toBe(true)
   })
+
+  it('applies custom z-index to dropdown', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+        zIndex: 200,
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    const dropdown = wrapper.find('[data-testid="fwb-autocomplete-dropdown"]')
+    expect(dropdown.exists()).toBe(true)
+    expect(dropdown.classes()).toContain('z-[200]')
+  })
+
+  it('uses default z-index when not specified', async () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        display: 'name',
+      },
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    const dropdown = wrapper.find('[data-testid="fwb-autocomplete-dropdown"]')
+    expect(dropdown.exists()).toBe(true)
+    expect(dropdown.classes()).toContain('z-[100]')
+  })
 })

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -426,4 +426,39 @@ describe('FwbAutocomplete', () => {
       expect(input.element.value).toBe('United States')
     }
   })
+
+  it('passes inputProps to input component', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+        inputProps: {
+          size: 'lg',
+          class: 'custom-styling',
+        },
+      },
+    })
+
+    // Since we're using default FwbInput, check if props are passed
+    const inputWrapper = wrapper.findComponent({ name: 'FwbInput' })
+    expect(inputWrapper.exists()).toBe(true)
+    // The class should be merged through inputProps
+    expect(inputWrapper.props()).toMatchObject({
+      size: 'lg',
+      class: 'custom-styling',
+    })
+  })
+
+  it('uses FwbInput as default input component', () => {
+    const wrapper = mount(FwbAutocomplete, {
+      props: {
+        options: mockOptions,
+        searchFields: ['name'],
+      },
+    })
+
+    // Should use FwbInput by default
+    const fwbInput = wrapper.findComponent({ name: 'FwbInput' })
+    expect(fwbInput.exists()).toBe(true)
+  })
 })

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -303,31 +303,69 @@ describe('FwbAutocomplete', () => {
     expect(displayFn).toHaveBeenCalledWith(mockOptions[0])
   })
 
-  it('generates correct option keys with valueField', () => {
+  it('renders and selects options correctly with valueField', async () => {
     const wrapper = mount(FwbAutocomplete, {
       props: {
         options: mockOptions,
         searchFields: ['name'],
+        display: 'name',
         valueField: 'id',
       },
     })
 
-    const vm = wrapper.vm as any
-    expect(vm.getOptionKey(mockOptions[0])).toBe('1')
-    expect(vm.getOptionKey(mockOptions[1])).toBe('2')
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    // Verify all options render in dropdown
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-option-0"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-option-1"]').exists()).toBe(true)
+
+    // Verify option content is displayed correctly
+    expect(wrapper.text()).toContain('United States')
+    expect(wrapper.text()).toContain('Canada')
+
+    // Select an option and verify the selection works
+    const firstOption = wrapper.find('[data-testid="fwb-autocomplete-option-0"]')
+    await firstOption.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('select')).toBeTruthy()
+    const selectedValue = wrapper.emitted('update:modelValue')?.[0]?.[0]
+    expect(selectedValue).toEqual(mockOptions[0])
   })
 
-  it('generates JSON keys when no valueField provided', () => {
+  it('renders and selects options correctly without valueField', async () => {
     const wrapper = mount(FwbAutocomplete, {
       props: {
         options: mockOptions,
         searchFields: ['name'],
+        display: 'name',
       },
     })
 
-    const vm = wrapper.vm as any
-    const key = vm.getOptionKey(mockOptions[0])
-    expect(key).toBe(JSON.stringify(mockOptions[0]))
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await nextTick()
+
+    // Verify all options render in dropdown
+    expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-option-0"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="fwb-autocomplete-option-1"]').exists()).toBe(true)
+
+    // Verify option content is displayed correctly
+    expect(wrapper.text()).toContain('United States')
+    expect(wrapper.text()).toContain('Canada')
+
+    // Select an option and verify the selection works
+    const secondOption = wrapper.find('[data-testid="fwb-autocomplete-option-1"]')
+    await secondOption.trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('select')).toBeTruthy()
+    const selectedValue = wrapper.emitted('update:modelValue')?.[0]?.[0]
+    expect(selectedValue).toEqual(mockOptions[1])
   })
 
   it('emits search event on focus', async () => {

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -448,7 +448,6 @@ describe('FwbAutocomplete', () => {
 
     expect(wrapper.find('[data-testid="fwb-autocomplete-dropdown"]').exists()).toBe(false)
   })
-  
 
   it('passes inputProps to input component', () => {
     const wrapper = mount(FwbAutocomplete, {

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -1,4 +1,5 @@
 import type { InputSize, ValidationStatus } from '../FwbInput/types'
+import type { Component } from 'vue'
 
 export type AutocompleteSize = InputSize
 export type { ValidationStatus }
@@ -24,6 +25,8 @@ export interface AutocompleteProps<T = Record<string, any>> {
   label?: string
   labelClass?: string | Record<string, boolean>
   dropdownClass?: string | Record<string, boolean>
+  inputComponent?: Component
+  inputProps?: Record<string, any>
 }
 
 export interface AutocompleteEmits<T = Record<string, any>> {

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -27,6 +27,7 @@ export interface AutocompleteProps<T = Record<string, any>> {
   dropdownClass?: string | Record<string, boolean>
   inputComponent?: Component
   inputProps?: Record<string, any>
+  zIndex?: number
 }
 
 export interface AutocompleteEmits<T = Record<string, any>> {

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -1,0 +1,33 @@
+import type { InputSize, ValidationStatus } from '../FwbInput/types'
+
+export type AutocompleteSize = InputSize
+export type { ValidationStatus }
+
+export interface AutocompleteProps<T = Record<string, any>> {
+  modelValue?: T | null
+  options: T[]
+  loading?: boolean
+  placeholder?: string
+  disabled?: boolean
+  valueField?: string
+  searchFields?: string[]
+  loadingText?: string
+  noResultsText?: string
+  minChars?: number
+  remote?: boolean
+  debounce?: number
+  display?: string | ((option: T) => string)
+  size?: AutocompleteSize
+  validationStatus?: ValidationStatus
+  class?: string | Record<string, boolean>
+  wrapperClass?: string | Record<string, boolean>
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  dropdownClass?: string | Record<string, boolean>
+}
+
+export interface AutocompleteEmits<T = Record<string, any>> {
+  (e: 'update:modelValue', value: T | null): void
+  (e: 'select', option: T): void
+  (e: 'search', query: string): void
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { default as FwbAccordionContent } from '@/components/FwbAccordion/FwbAcc
 export { default as FwbAccordionHeader } from '@/components/FwbAccordion/FwbAccordionHeader.vue'
 export { default as FwbAccordionPanel } from '@/components/FwbAccordion/FwbAccordionPanel.vue'
 export { default as FwbAlert } from '@/components/FwbAlert/FwbAlert.vue'
+export { default as FwbAutocomplete } from '@/components/FwbAutocomplete/FwbAutocomplete.vue'
 export { default as FwbAvatar } from '@/components/FwbAvatar/FwbAvatar.vue'
 export { default as FwbAvatarStack } from '@/components/FwbAvatar/FwbAvatarStack.vue'
 export { default as FwbAvatarStackCounter } from '@/components/FwbAvatar/FwbAvatarStackCounter.vue'


### PR DESCRIPTION
Introduced the FwbAutocomplete component, enabling users to search and select options with real-time filtering. Added multiple examples demonstrating various functionalities, including remote data loading, custom option templates, and validation. Updated documentation to include the new component and its usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a fully featured, accessible autocomplete component with support for local and remote data, keyboard navigation, customizable display, validation states, and size variants.
  * Added comprehensive documentation for the autocomplete component, including multiple usage examples and detailed API references.
  * Provided several example Vue components demonstrating autocomplete usage with local options, remote data fetching, custom rendering, validation, custom input components, and size variations.

* **Tests**
  * Added a complete test suite covering all major functionalities and behaviors of the autocomplete component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->