### PR TITLE
Fix FwbInput label/input connection

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -254,9 +254,10 @@ const name = ref('')
 ## Input component API
 
 ### FwbInput Props
-| Name         | Type             | Default | Description                                                  |
-| ------------ | ---------------- | ------- | ------------------------------------------------------------ |
-| wrapperClass | String \| Object | `''`    | Added to main component wrapper                              |
-| labelClass   | String \| Object | `''`    | Added to `<label>` element.                                  |
-| class        | String \| Object | `''`    | Added to wrapper around `<input>` element and prefix/suffix. |
-| inputClass   | String \| Object | `''`    | Added to `<input>` element.                                  |
+| Name         | Type                     | Default | Description                                                  |
+| ------------ | ------------------------ | ------- | ------------------------------------------------------------ |
+| autocomplete | String \| CommonAutoFill | 'off'   | Sets the autocomplete for forms.                             | 
+| wrapperClass | String \| Object         | `''`    | Added to main component wrapper                              |
+| labelClass   | String \| Object         | `''`    | Added to `<label>` element.                                  |
+| class        | String \| Object         | `''`    | Added to wrapper around `<input>` element and prefix/suffix. |
+| inputClass   | String \| Object         | `''`    | Added to `<input>` element.                                  |

--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -2,6 +2,7 @@
   <div :class="wrapperClass">
     <label
       v-if="label"
+      :for="inputId"
       :class="labelClass"
     >{{ label }}</label>
     <div :class="inputWrapperClass">
@@ -12,7 +13,7 @@
         <slot name="prefix" />
       </div>
       <input
-        v-bind="$attrs"
+        v-bind="inputAttributes"
         v-model="model"
         :autocomplete="autocomplete"
         :class="inputClass"
@@ -46,23 +47,10 @@
 
 import { toRefs } from 'vue'
 
+import { useInputAttributes } from './composables/useInputAttributes'
 import { useInputClasses } from './composables/useInputClasses'
 
-import type { CommonAutoFill, InputSize, InputType, ValidationStatus } from './types'
-
-interface InputProps {
-  autocomplete?: CommonAutoFill
-  class?: string | Record<string, boolean>
-  disabled?: boolean
-  inputClass?: string | Record<string, boolean>
-  label?: string
-  labelClass?: string | Record<string, boolean>
-  required?: boolean
-  size?: InputSize
-  type?: InputType
-  validationStatus?: ValidationStatus
-  wrapperClass?: string | Record<string, boolean>
-}
+import type { InputProps } from './types'
 
 defineOptions({
   inheritAttrs: false,
@@ -92,4 +80,6 @@ const {
   inputWrapperClass,
   inputClass,
 } = useInputClasses(toRefs(props))
+
+const { inputId, inputAttributes } = useInputAttributes(props)
 </script>

--- a/src/components/FwbInput/composables/useInputAttributes.ts
+++ b/src/components/FwbInput/composables/useInputAttributes.ts
@@ -1,0 +1,21 @@
+import { computed, useAttrs } from 'vue'
+
+import type { InputProps } from '../types'
+
+export const useInputAttributes = (props: InputProps) => {
+  const attrs = useAttrs()
+  const inputId = props?.label && props.label !== '' ? props.label.toLowerCase().trim().replace(/ /g, '-') : ''
+
+  const inputAttributes = computed(() => {
+    if (inputId !== '') {
+      return {
+        ...attrs,
+        id: inputId,
+      }
+    } else {
+      return attrs
+    }
+  })
+
+  return { inputId, inputAttributes }
+}

--- a/src/components/FwbInput/types.ts
+++ b/src/components/FwbInput/types.ts
@@ -5,6 +5,20 @@ export type InputType = 'button' | 'checkbox' | 'color' | 'date' | 'datetime-loc
 // A simplified version of AutFill, which is to complex for TypeScript to handle
 export type CommonAutoFill = 'on' | 'off' | 'email' | 'tel' | 'name' | 'username' | 'current-password' | 'country' | 'postal-code' | 'language' | 'bday'
 
+export interface InputProps {
+  autocomplete?: CommonAutoFill
+  class?: string | Record<string, boolean>
+  disabled?: boolean
+  inputClass?: string | Record<string, boolean>
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  required?: boolean
+  size?: InputSize
+  type?: InputType
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
+}
+
 export const validationStatusMap = {
   Error: 'error',
   Success: 'success',


### PR DESCRIPTION
The `FwbInput` input element is missing a `id`/`for` connection with the label element.
There are divs wrapping the input element, so the label can't be used to wrap.
As a side-effect this also fixes the `fwb-autocomplete` label as well.

Please let me know if/what changes I need to make. Thank you!

---
 `src/components/FwbInput/FwbInput.vue`
 - added a `:for` on the label element
 - changed the input `v-bind` to use `inputAttributes`
 - import  and use `useInputAttributes`
 - moved the `InputProps` interface the the types.ts file
 
 ---
 `src/components/FwbInput/composables/useInputAttributes.ts`
 - created useInputAttributes to:
   1. dynamically create an id for the input field based on the provided label
   2. preserve all attrs passed to the FwbInput component
   3. prevent a null/undefined id getting left on the input element. the simpler solution to this bug is to add an `:id` and `:for` on the input and label, but if no label is given there is a null/undefined id left on the input
   4. export the created inputId for use in the label `:for` attribute

---
`src/components/FwbInput/types.ts`
- moved the `InputProps` interface to be able to import it in `useInputAttributes`

---
`docs/components/input.md`
- added the `autocomplete` prop to the input component docs
 