### PR TITLE
Fixed image sizing bug in avatar component

### DIFF
--- a/src/components/FwbAvatar/FwbAvatar.vue
+++ b/src/components/FwbAvatar/FwbAvatar.vue
@@ -6,6 +6,7 @@
       <img
         v-if="img && !imageError"
         :alt="alt"
+        class="object-cover"
         :class="avatarClasses"
         :src="img"
         @error="setImageError"


### PR DESCRIPTION
I found a small bug in FwbAvatar component. If the image is not square, then there it is displayed improperly.
Here is the example:
Avatar has width 150 and height 120 pixels
<img width="252" height="126" alt="image" src="https://github.com/user-attachments/assets/4b950d8c-3a9e-4cbc-92c8-61c206ca8178" />
By default img tag has `object-fit: fill`, so that's why images are displayed this way.

I added `object-cover` class for img tag in avatar component. And here is the same avatar with my fix:
<img width="289" height="144" alt="image" src="https://github.com/user-attachments/assets/8bc1c893-fd7c-40c9-a7a5-53f7de893b91" />

P.S. Is there any chance to get a new release of the library in npm? There were a number of fixes in main branch, but the latest version 0.2.1 was released in April 2025.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved avatar image presentation to consistently cover its container when a valid image is available, resulting in better cropping and visual balance.
  * Enhances UI polish by preventing letterboxing or awkward spacing in avatar thumbnails across layouts and sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->