### PR TITLE
Close modal on esc keypress even when focusTrap is enabled

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -161,7 +161,7 @@ import { FwbModal } from 'flowbite-vue'
 
 ## Focus Trap
 
-You can enable focus trapping by setting the `focus-trap` prop to `true`. This keeps the focus within the modal, preventing users from tabbing to elements outside of it, which improves accessibility.
+You can enable focus trapping by setting the `focus-trap` prop to `true`. This keeps the focus within the modal, preventing users from tabbing to elements outside of it, which improves accessibility. esc key will still close the modal.
 
 <fwb-modal-example-focus-trap />
 ```vue

--- a/src/components/FwbModal/FwbModal.vue
+++ b/src/components/FwbModal/FwbModal.vue
@@ -128,6 +128,7 @@ const modalRef: Ref<HTMLElement | null> = ref(null)
 const { activate, deactivate } = useFocusTrap(modalRef, {
   immediate: false,
   initialFocus: () => modalRef.value?.querySelector('button[aria-label="close"]') || modalRef.value,
+  escapeDeactivates: false,
 })
 
 onMounted(async () => {


### PR DESCRIPTION
Fixes issue #404 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved modal focus handling: pressing Escape closes the modal without deactivating the focus trap prematurely, reducing unexpected focus escapes.
- Documentation
  - Clarified Focus Trap behavior, noting that pressing Escape will still close the modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->