### PR TITLE
Clarify relative path in quickstart

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -79,9 +79,11 @@ npm i flowbite flowbite-vue
 /* import Flowbite plugin */
 @plugin "flowbite/plugin";
 
-/* add Flowbite Vue directory using @source directive */
+/* add Flowbite Vue directory using @source directive. */
 @source "../node_modules/flowbite-vue";
 ```
+
+Make sure to update the relative path prefix (`../`) for the `@source` directive to your case.
 
 4. Now you can use **Flowbite Vue** anywhere in your project and build awesome interfaces:
 


### PR DESCRIPTION
Added a note that user should check the relative path prefix for the @source directive.

I had the same problem in getting started as https://github.com/themesberg/flowbite-vue/issues/406. This note would have allowed me to narrow down what the issue could be sooner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced the Vue setup guide with improved clarity and formatting.
  * Added explicit instructions guiding users to update relative path prefixes in their project configuration for proper setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->