### PR TITLE
fix: read `isMobile` computed value

### DIFF
--- a/src/components/FwbNavbar/FwbNavbar.vue
+++ b/src/components/FwbNavbar/FwbNavbar.vue
@@ -85,7 +85,7 @@ const navbarClasses = computed(() => useMergeClasses(
   ].join(' '),
 ))
 
-const isShowMenu = computed(() => (!isMobile)
+const isShowMenu = computed(() => (!isMobile.value)
   ? true
   : isShowMenuOnMobile.value,
 )


### PR DESCRIPTION
Currently `isShowMenu` does not function properly as is always `false` on Desktop screen, causing no links to be visible.

The problem is that `isMobile` is a computed reference and accessing to it's value requires `.value` notation to work properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navbar menu visibility detection on mobile and desktop layouts to ensure proper menu display behavior across different device sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->