### PR TITLE
Export TS types for data used by specific components

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
       "import": "./dist/flowbite-vue.js",
       "require": "./dist/flowbite-vue.umd.cjs"
     },
+    "./components/*/types": {
+      "types": "./dist/components/*/types.d.ts"
+    },
     "./index.css": "./dist/index.css"
   },
   "scripts": {


### PR DESCRIPTION
This allow to import and use type for data under specific components, like:

```ts
import { OptionsType } from 'flowbite-vue/components/FwbSelect/types'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component types are now publicly exported and can be imported directly from the package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->