### PR TITLE
Allow for custom classes on Tabs

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -177,4 +177,5 @@ const handlePaneClick = () => { console.log('Click!') }
 |------------|--------------------------------|-----------|
 | directive  | `if`, `show`                   | `if`      |
 | modelValue | `string`                       | `''`      |
+| tabsClass  | `string`                       | `''`      |
 | variant    | `default`, `underline`, `pill` | `default` |

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -177,5 +177,6 @@ const handlePaneClick = () => { console.log('Click!') }
 |------------|--------------------------------|-----------|
 | directive  | `if`, `show`                   | `if`      |
 | modelValue | `string`                       | `''`      |
-| tabsClass  | `string`                       | `''`      |
+| ulClass    | `string`                       | `''`      |
+| divClass   | `string`                       | `''`      |
 | variant    | `default`, `underline`, `pill` | `default` |

--- a/docs/components/tabs/examples/FwbTabsExamplePills.vue
+++ b/docs/components/tabs/examples/FwbTabsExamplePills.vue
@@ -4,7 +4,6 @@
       v-model="activeTab"
       variant="pills"
       class="p-5"
-      tabsClass="m-1"
     >
       <fwb-tab
         name="first"

--- a/docs/components/tabs/examples/FwbTabsExamplePills.vue
+++ b/docs/components/tabs/examples/FwbTabsExamplePills.vue
@@ -4,6 +4,7 @@
       v-model="activeTab"
       variant="pills"
       class="p-5"
+      tabsClass="m-1"
     >
       <fwb-tab
         name="first"

--- a/src/components/FwbSelect/FwbSelect.vue
+++ b/src/components/FwbSelect/FwbSelect.vue
@@ -65,7 +65,8 @@ interface InputProps {
   underline?: boolean
   size?: InputSize
   autocomplete?: CommonAutoFill
-  validationStatus?: ValidationStatus
+  validationStatus?: ValidationStatus,
+  selectClass?: string
 }
 const props = withDefaults(defineProps<InputProps>(), {
   modelValue: '',
@@ -78,6 +79,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   size: 'md',
   autocomplete: 'off',
   validationStatus: undefined,
+  selectClass: ""
 })
 const emit = defineEmits(['update:modelValue'])
 
@@ -88,6 +90,6 @@ const { selectClasses, labelClasses } = useSelectClasses(toRefs(props))
 const validationWrapperClasses = computed(() => twMerge(
   'mt-2 text-sm',
   props.validationStatus === validationStatusMap.Success ? 'text-green-600 dark:text-green-500' : '',
-  props.validationStatus === validationStatusMap.Error ? 'text-red-600 dark:text-red-500' : '',
+  props.validationStatus === validationStatusMap.Error ? 'text-red-600 dark:text-red-500' : ''
 ))
 </script>

--- a/src/components/FwbSelect/composables/useSelectClasses.ts
+++ b/src/components/FwbSelect/composables/useSelectClasses.ts
@@ -28,6 +28,7 @@ export type UseSelectClassesProps = {
   disabled: Ref<boolean>
   underline: Ref<boolean>
   validationStatus: Ref<ValidationStatus | undefined>
+  selectClass:  Ref<string>
 }
 
 export function useSelectClasses (props: UseSelectClassesProps): {
@@ -56,6 +57,7 @@ export function useSelectClasses (props: UseSelectClassesProps): {
       props.disabled.value && disabledSelectClasses,
       props.underline.value ? underlineSelectClasses : 'border border-gray-300 rounded-lg',
       props.underline.value && underlineByStatus,
+      props.selectClass.value
     )
   })
 

--- a/src/components/FwbTabs/FwbTabPane.vue
+++ b/src/components/FwbTabs/FwbTabPane.vue
@@ -1,7 +1,7 @@
 <template>
   <li>
     <div
-      :class="twMerge(tabClasses, props?.class)"
+      :class="tabClasses"
       @click="tryActivateTab"
     >
       {{ title }}
@@ -19,7 +19,6 @@ import {
 } from './injection/config'
 
 import type { TabsVariant } from './types'
-import { twMerge } from 'tailwind-merge'
 
 const props = defineProps({
   name: {
@@ -64,5 +63,6 @@ const { tabClasses } = useTabClasses({
   active: toRef(props, 'active'),
   disabled: toRef(props, 'disabled'),
   variant,
+  class : props?.class
 })
 </script>

--- a/src/components/FwbTabs/FwbTabPane.vue
+++ b/src/components/FwbTabs/FwbTabPane.vue
@@ -63,6 +63,6 @@ const { tabClasses } = useTabClasses({
   active: toRef(props, 'active'),
   disabled: toRef(props, 'disabled'),
   variant,
-  class : props?.class
+  class: toRef(props, 'class')
 })
 </script>

--- a/src/components/FwbTabs/FwbTabPane.vue
+++ b/src/components/FwbTabs/FwbTabPane.vue
@@ -1,7 +1,7 @@
 <template>
   <li>
     <div
-      :class="tabClasses"
+      :class="twMerge(tabClasses, props?.class)"
       @click="tryActivateTab"
     >
       {{ title }}
@@ -19,6 +19,7 @@ import {
 } from './injection/config'
 
 import type { TabsVariant } from './types'
+import { twMerge } from 'tailwind-merge'
 
 const props = defineProps({
   name: {
@@ -36,6 +37,10 @@ const props = defineProps({
   active: {
     type: Boolean,
     default: false,
+  },
+  class: {
+    type: String,
+    default: '',
   },
 })
 

--- a/src/components/FwbTabs/FwbTabs.vue
+++ b/src/components/FwbTabs/FwbTabs.vue
@@ -9,6 +9,7 @@
         :name="item.props?.name"
         :title="item.props?.title"
         @click="emitClick"
+        :class="props.buttonClass"
       />
     </ul>
   </div>
@@ -41,6 +42,7 @@ interface ITabsProps {
   variant?: TabsVariant
   ulClass?: string
   divClass?: string
+  buttonClass?: string
   modelValue?: string
   directive?: 'if' | 'show'
 }
@@ -49,6 +51,7 @@ const props = withDefaults(defineProps<ITabsProps>(), {
   variant: 'default',
   ulClass: '',
   divClass: '',
+  buttonClass: '',
   modelValue: '',
   directive: 'if',
 })

--- a/src/components/FwbTabs/FwbTabs.vue
+++ b/src/components/FwbTabs/FwbTabs.vue
@@ -39,12 +39,14 @@ defineOptions({
 
 interface ITabsProps {
   variant?: TabsVariant
+  tabsClass?: string
   modelValue?: string
   directive?: 'if' | 'show'
 }
 
 const props = withDefaults(defineProps<ITabsProps>(), {
   variant: 'default',
+  tabsClass: '',
   modelValue: '',
   directive: 'if',
 })

--- a/src/components/FwbTabs/FwbTabs.vue
+++ b/src/components/FwbTabs/FwbTabs.vue
@@ -39,14 +39,16 @@ defineOptions({
 
 interface ITabsProps {
   variant?: TabsVariant
-  tabsClass?: string
+  ulClass?: string
+  divClass?: string
   modelValue?: string
   directive?: 'if' | 'show'
 }
 
 const props = withDefaults(defineProps<ITabsProps>(), {
   variant: 'default',
-  tabsClass: '',
+  ulClass: '',
+  divClass: '',
   modelValue: '',
   directive: 'if',
 })

--- a/src/components/FwbTabs/composables/useTabClasses.ts
+++ b/src/components/FwbTabs/composables/useTabClasses.ts
@@ -74,7 +74,7 @@ export function useTabClasses (props: UseTabClassesProps): {
       ])
     }
 
-    return twMerge(ret, props.class?.value)
+    return twMerge(ret, props?.class?.value)
   })
 
   return { tabClasses }

--- a/src/components/FwbTabs/composables/useTabClasses.ts
+++ b/src/components/FwbTabs/composables/useTabClasses.ts
@@ -17,7 +17,7 @@ export type UseTabClassesProps = {
   active: Ref<boolean>
   disabled: Ref<boolean>
   variant?: TabsVariant
-  class? : string
+  class? : Ref<string>
 }
 
 const defaultTabClasses: TabClassMap = {
@@ -74,7 +74,7 @@ export function useTabClasses (props: UseTabClassesProps): {
       ])
     }
 
-    return twMerge(ret, props?.class)
+    return twMerge(ret, props.class?.value)
   })
 
   return { tabClasses }

--- a/src/components/FwbTabs/composables/useTabClasses.ts
+++ b/src/components/FwbTabs/composables/useTabClasses.ts
@@ -5,6 +5,7 @@ import { useFlowbiteThemable } from '../../utils/FlowbiteThemable/composables/us
 import type { TabsVariant } from './../types'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
+import { twMerge } from 'tailwind-merge'
 
 export type TabClassMap = {
   active: string
@@ -16,6 +17,7 @@ export type UseTabClassesProps = {
   active: Ref<boolean>
   disabled: Ref<boolean>
   variant?: TabsVariant
+  class? : string
 }
 
 const defaultTabClasses: TabClassMap = {
@@ -41,6 +43,7 @@ export function useTabClasses (props: UseTabClassesProps): {
 
   const tabClasses = computed(() => {
     const isActiveTheme = theme.isActive.value
+    let ret = ""
 
     const tabClassType: keyof TabClassMap = props.active.value
       ? 'active'
@@ -49,21 +52,21 @@ export function useTabClasses (props: UseTabClassesProps): {
         : 'default'
 
     if (props.variant === 'default') {
-      return useMergeClasses([
+      ret = useMergeClasses([
         defaultTabClasses[tabClassType],
         (isActiveTheme && tabClassType === 'active')
           ? theme.textClasses.value
           : '',
       ])
     } else if (props.variant === 'underline') {
-      return useMergeClasses([
+      ret = useMergeClasses([
         underlineTabClasses[tabClassType],
         (isActiveTheme && tabClassType === 'active')
           ? `${theme.borderClasses.value} ${theme.textClasses.value}`
           : '',
       ])
     } else if (props.variant === 'pills') {
-      return useMergeClasses([
+      ret = useMergeClasses([
         pillsTabClasses[tabClassType],
         (isActiveTheme && tabClassType === 'active')
           ? `${theme.backgroundClasses.value} text-white`
@@ -71,7 +74,7 @@ export function useTabClasses (props: UseTabClassesProps): {
       ])
     }
 
-    return ''
+    return twMerge(ret, props?.class)
   })
 
   return { tabClasses }

--- a/src/components/FwbTabs/composables/useTabsClasses.ts
+++ b/src/components/FwbTabs/composables/useTabsClasses.ts
@@ -5,7 +5,8 @@ import type { TabsVariant } from '../types'
 
 export type UseTabsClassesProps = {
   variant: TabsVariant,
-  tabsClass: string
+  ulClass: string,
+  divClass: string
 }
 
 export function useTabsClasses (props: UseTabsClassesProps): {
@@ -19,16 +20,15 @@ export function useTabsClasses (props: UseTabsClassesProps): {
       baseClasses,
       props.variant === 'underline' && '-mb-px',
       props.variant === 'default' && 'border-b border-gray-200 dark:border-gray-700',
-      props.tabsClass
+      props.ulClass
     )
   })
 
   const divClasses = computed(() => {
-    if (props.variant === 'underline') {
-      return 'border-b border-gray-200 dark:border-gray-700 font-medium text-center text-gray-500 dark:text-gray-400 text-sm'
-    }
-
-    return ''
+    return twMerge(
+      props.variant === 'underline' && 'border-b border-gray-200 dark:border-gray-700 font-medium text-center text-gray-500 dark:text-gray-400 text-sm',
+      props.divClass
+    )
   })
 
   return {

--- a/src/components/FwbTabs/composables/useTabsClasses.ts
+++ b/src/components/FwbTabs/composables/useTabsClasses.ts
@@ -4,7 +4,8 @@ import { computed, type Ref } from 'vue'
 import type { TabsVariant } from '../types'
 
 export type UseTabsClassesProps = {
-  variant: TabsVariant
+  variant: TabsVariant,
+  tabsClass: string
 }
 
 export function useTabsClasses (props: UseTabsClassesProps): {
@@ -18,6 +19,7 @@ export function useTabsClasses (props: UseTabsClassesProps): {
       baseClasses,
       props.variant === 'underline' && '-mb-px',
       props.variant === 'default' && 'border-b border-gray-200 dark:border-gray-700',
+      props.tabsClass
     )
   })
 


### PR DESCRIPTION
Allow for custom classes on Tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabs now accept ulClass, divClass, and per-pane class overrides for easier custom styling.
  * The component correctly applies button styling to each tab pane for consistent appearance.

* **Documentation**
  * API docs updated to list the new styling props (defaults shown) and their placement in the props table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->