### PR TITLE
feature: FwbTextarea - validation, size, accessibility, and attr passthrough

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -1,8 +1,11 @@
 <script setup>
 import FwbTextareaExample from './textarea/examples/FwbTextareaExample.vue'
 import FwbTextareaExampleComment from './textarea/examples/FwbTextareaExampleComment.vue'
+import FwbTextareaExampleConstraints from './textarea/examples/FwbTextareaExampleConstraints.vue'
 import FwbTextareaExampleDisabled from './textarea/examples/FwbTextareaExampleDisabled.vue'
-import FwbTextareaExampleFormId from './textarea/examples/FwbTextareaExampleFormId.vue'
+import FwbTextareaExampleSize from './textarea/examples/FwbTextareaExampleSize.vue'
+import FwbTextareaExampleStyling from './textarea/examples/FwbTextareaExampleStyling.vue'
+import FwbTextareaExampleValidation from './textarea/examples/FwbTextareaExampleValidation.vue'
 </script>
 
 # Vue Textarea - Flowbite
@@ -11,20 +14,22 @@ import FwbTextareaExampleFormId from './textarea/examples/FwbTextareaExampleForm
 
 ---
 
-:::tip
+:::tip Textarea - Flowbite
 Original reference: [https://flowbite.com/docs/forms/textarea/](https://flowbite.com/docs/forms/textarea/)
 :::
+
+The textarea component is a multi-line text field that can be used to receive longer chunks of text from the user in the form of a comment box, description field, and more.
 
 ## Textarea example
 
 Get started with the default example of a textarea component below.
 
 <fwb-textarea-example />
+
 ```vue
 <template>
   <fwb-textarea
     v-model="message"
-    :rows="4"
     label="Your message"
     placeholder="Write your message..."
   />
@@ -38,119 +43,235 @@ const message = ref('')
 </script>
 ```
 
-## Comment box
+## Sizes
 
-Most often the textarea component is used as the main text field input element in comment sections. Use this example to also apply a helper text and buttons below the textarea itself.
+Use the `size` prop to control the padding and font size of the textarea.
 
-<fwb-textarea-example-comment />
+<fwb-textarea-example-size />
+
 ```vue
 <template>
-  <div>
-    <form>
-      <fwb-textarea
-        v-model="message"
-        :rows="3"
-        custom
-        label="Your message"
-        placeholder="Write your message..."
-      >
-        <template #footer>
-          <div class="flex items-center justify-between">
-            <fwb-button type="submit">
-              Post comment
-            </fwb-button>
-            <div class="flex">
-              <fwb-button class="rounded-lg hover:bg-gray-200 hover:dark:bg-gray-600" color square>
-                <svg class="w-6 h-6" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </fwb-button>
-              <fwb-button class="rounded-lg hover:bg-gray-200 hover:dark:bg-gray-600" color="" square >
-                <svg class="w-6 h-6" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" stroke-linecap="round" stroke-linejoin="round" />
-                  <path d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </fwb-button>
-              <fwb-button class="rounded-lg hover:bg-gray-200 hover:dark:bg-gray-600" color="" square>
-                <svg class="w-6 h-6" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </fwb-button>
-            </div>
-          </div>
-        </template>
-      </Textarea>
-    </form>
-    <p class="ml-auto text-xs text-gray-500 dark:text-gray-400">
-      Remember, contributions to this topic should follow our
-      <fwb-a href="#">Community Guidelines</fwb-a>.
-    </p>
+  <div class="flex flex-col gap-4">
+    <fwb-textarea v-model="message" size="sm" label="Small" placeholder="Small textarea..." />
+    <fwb-textarea v-model="message" size="md" label="Medium (default)" placeholder="Medium textarea..." />
+    <fwb-textarea v-model="message" size="lg" label="Large" placeholder="Large textarea..." />
+    <fwb-textarea v-model="message" size="xl" label="Extra large" placeholder="Extra large textarea..." />
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue'
-import { FwbA, FwbButton, FwbTextarea } from 'flowbite-vue'
+import { FwbTextarea } from 'flowbite-vue'
 
 const message = ref('')
 </script>
 ```
 
-## Disabled / Readonly Textarea / Max-Min Length
+## Disabled / Readonly
 
 <fwb-textarea-example-disabled />
+
 ```vue
 <template>
-  <div>
+  <div class="flex flex-col gap-4">
     <fwb-textarea
       v-model="message"
-      label="Textarea with minlength 10 and maxlength 20"
-      minlength="10"
-      maxlength="20"
-      required
-    />
-    <fwb-textarea
-      v-model="message"
-      label="Your message"
-      placeholder="Write your message..."
+      label="Disabled textarea"
+      placeholder="Cannot be edited"
       disabled
     />
     <fwb-textarea
       v-model="message"
-      label="Your message"
-      placeholder="Write your message..."
+      label="Readonly textarea"
+      placeholder="Cannot be edited"
       readonly
     />
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbTextarea } from 'flowbite-vue'
+
+const message = ref('Some content')
+</script>
 ```
 
-## Textarea with form ID
+## Validation
 
-<fwb-textarea-example-form-id />
+Set `validation-status` to `'success'` or `'error'` and use the `validationMessage` or `helper` slots to display contextual feedback.
+
+<fwb-textarea-example-validation />
+
 ```vue
 <template>
-  <div>
-    <form id="my-form" @submit.prevent="handleSubmit">
-      <!-- Inside the form -->
-      <fwb-textarea
-        v-model="message"
-        label="Your message"
-        placeholder="Write your message..."
-      />
-      <fwb-button type="submit">
-        Submit
-      </fwb-button>
-    </form>
-
-    <!-- Outside the form -->
+  <div class="flex flex-col gap-4">
     <fwb-textarea
       v-model="message"
+      validation-status="error"
       label="Your message"
       placeholder="Write your message..."
-      form="my-form"
-      required
-    />
+    >
+      <template #validationMessage>
+        This field is required.
+      </template>
+    </fwb-textarea>
+    <fwb-textarea
+      v-model="message"
+      validation-status="success"
+      label="Your message"
+      placeholder="Write your message..."
+    >
+      <template #helper>
+        Looks good!
+      </template>
+    </fwb-textarea>
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbTextarea } from 'flowbite-vue'
+
+const message = ref('')
+</script>
 ```
+
+## Native Constraints
+
+Use `required`, `minlength`, and `maxlength` as native attributes. Pair them with `validation-status` to surface feedback using the component's styled states.
+
+<fwb-textarea-example-constraints />
+
+```vue
+<template>
+  <form class="flex flex-col gap-4" @submit.prevent="submitted = true">
+    <fwb-textarea
+      v-model="message"
+      :validation-status="validationStatus"
+      label="Message (10–15 characters)"
+      minlength="10"
+      maxlength="15"
+      required
+    >
+      <template v-if="validationStatus === 'error'" #validationMessage>
+        {{ message.length === 0 ? 'This field is required.' : `Too short — ${message.length}/10 characters minimum.` }}
+      </template>
+      <template v-if="validationStatus === 'success'" #helper>
+        Looks good!
+      </template>
+    </fwb-textarea>
+    <fwb-button class="self-start" type="submit">Validate</fwb-button>
+  </form>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { FwbButton, FwbTextarea } from 'flowbite-vue'
+
+const message = ref('')
+const submitted = ref(false)
+
+const validationStatus = computed(() => {
+  if (!submitted.value) return undefined
+  return message.value.length >= 10 ? 'success' : 'error'
+})
+</script>
+```
+
+## Slot - Footer
+
+Use the `footer` slot to render actions or metadata below the textarea content — commonly used for submit buttons in comment forms.
+
+<fwb-textarea-example-comment />
+
+```vue
+<template>
+  <form>
+    <fwb-textarea
+      v-model="message"
+      :rows="3"
+      label="Your message"
+      placeholder="Write your message..."
+    >
+      <template #footer>
+        <div class="flex items-center justify-between">
+          <fwb-button type="submit">
+            Post comment
+          </fwb-button>
+        </div>
+      </template>
+    </fwb-textarea>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbButton, FwbTextarea } from 'flowbite-vue'
+
+const message = ref('')
+</script>
+```
+
+## Styling Textareas
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-textarea-example-styling />
+
+```vue
+<template>
+  <fwb-textarea
+    v-model="message"
+    label="Your story"
+    placeholder="Start typing something..."
+    class="bg-amber-100 dark:bg-green-900 border-2 border-amber-500 has-[textarea:focus]:border-amber-900 dark:border-green-600 dark:has-[textarea:focus]:border-green-400 has-[textarea:focus]:ring-amber-300 dark:has-[textarea:focus]:ring-green-800"
+    label-class="text-xl font-bold text-amber-900 dark:text-green-200"
+    :rows="3"
+    textarea-class="text-amber-900 dark:text-green-100 placeholder:text-amber-500 dark:placeholder:text-green-500"
+    wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3"
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbTextarea } from 'flowbite-vue'
+
+const message = ref('')
+</script>
+```
+
+## Textarea component API
+
+### FwbTextarea Props
+
+:::tip Native attribute passthrough
+`FwbTextarea` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `placeholder`, `readonly`, `minlength`, `maxlength`) directly to the `<textarea>` element.
+:::
+
+| Name             | Type                                  | Default     | Description                                           |
+| ---------------- | ------------------------------------- | ----------- | ----------------------------------------------------- |
+| autocomplete     | `String \| Autocomplete`              | `'off'`     | Sets the autocomplete attribute on the textarea.      |
+| class            | `String \| Object`                    | `''`        | Added to the wrapper `<div>` around the `<textarea>`. |
+| disabled         | `Boolean`                             | `false`     | Disables the textarea.                                |
+| footerClass      | `String \| Object`                    | `''`        | Added to the footer slot container.                   |
+| label            | `String`                              | `''`        | Label text rendered above the textarea.               |
+| labelClass       | `String \| Object`                    | `''`        | Added to the `<label>` element.                       |
+| required         | `Boolean`                             | `false`     | Marks the textarea as required.                       |
+| rows             | `Number`                              | `4`         | Number of visible text rows.                          |
+| size             | `'sm' \| 'md' \| 'lg' \| 'xl'`        | `'md'`      | Controls padding and font size.                       |
+| textareaClass    | `String \| Object`                    | `''`        | Added to the `<textarea>` element.                    |
+| validationStatus | `'success' \| 'error'`                | `undefined` | Sets the validation state of the textarea.            |
+| wrapperClass     | `String \| Object`                    | `''`        | Added to the outermost wrapper `<div>`.               |
+
+:::tip Accessibility
+`aria-invalid="true"` is set automatically on the native textarea when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
+:::
+
+### FwbTextarea Slots
+
+| Name              | Description                                                                            |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| footer            | Content rendered inside the textarea wrapper below the text area (e.g. submit button). |
+| validationMessage | Validation feedback shown below the wrapper. Linked via `aria-describedby`.            |
+| helper            | Helper text shown below the wrapper. Linked via `aria-describedby`.                    |

--- a/docs/components/textarea/examples/FwbTextareaExampleComment.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleComment.vue
@@ -3,7 +3,6 @@
     <fwb-textarea
       v-model="message"
       :rows="3"
-      custom
       label="Your message"
       placeholder="Write your message..."
     >

--- a/docs/components/textarea/examples/FwbTextareaExampleConstraints.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleConstraints.vue
@@ -1,0 +1,50 @@
+<template>
+  <form
+    class="flex flex-col gap-4 vp-raw"
+    @submit.prevent="submitted = true"
+  >
+    <fwb-textarea
+      v-model="message"
+      :validation-status="validationStatus"
+      label="Message (10–15 characters)"
+      minlength="10"
+      maxlength="15"
+      required
+    >
+      <template
+        v-if="validationStatus === 'error'"
+        #validationMessage
+      >
+        {{ message.length === 0 ? 'This field is required.' : `Too short — ${message.length}/10 characters minimum.` }}
+      </template>
+      <template
+        v-if="validationStatus === 'success'"
+        #helper
+      >
+        Looks good!
+      </template>
+    </fwb-textarea>
+    <fwb-button
+      class="self-start"
+      type="submit"
+    >
+      Validate
+    </fwb-button>
+  </form>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import { FwbButton, FwbTextarea } from '../../../../src/index'
+
+import type { ValidationStatus } from '../../../../src/types/form'
+
+const message = ref('')
+const submitted = ref(false)
+
+const validationStatus = computed<ValidationStatus | undefined>(() => {
+  if (!submitted.value) return undefined
+  return message.value.length >= 10 ? 'success' : 'error'
+})
+</script>

--- a/docs/components/textarea/examples/FwbTextareaExampleDisabled.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleDisabled.vue
@@ -1,15 +1,5 @@
 <template>
-  <form
-    class="gap-2 grid vp-raw"
-    @submit.prevent
-  >
-    <fwb-textarea
-      v-model="message"
-      label="Textarea with minlength 10 and maxlength 20"
-      minlength="10"
-      maxlength="20"
-      required
-    />
+  <div class="flex flex-col gap-4 vp-raw">
     <fwb-textarea
       v-model="message"
       label="Disabled textarea"
@@ -22,19 +12,13 @@
       placeholder="Cannot be edited"
       readonly
     />
-    <fwb-button
-      class="justify-self-start"
-      type="submit"
-    >
-      Validate
-    </fwb-button>
-  </form>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue'
 
-import { FwbButton, FwbTextarea } from '../../../../src/index'
+import { FwbTextarea } from '../../../../src/index'
 
-const message = ref('Edit me!')
+const message = ref('Some content')
 </script>

--- a/docs/components/textarea/examples/FwbTextareaExampleSize.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleSize.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="flex flex-col gap-4 vp-raw">
+    <fwb-textarea
+      v-model="message"
+      size="sm"
+      label="Small"
+      placeholder="Small textarea..."
+    />
+    <fwb-textarea
+      v-model="message"
+      size="md"
+      label="Medium (default)"
+      placeholder="Medium textarea..."
+    />
+    <fwb-textarea
+      v-model="message"
+      size="lg"
+      label="Large"
+      placeholder="Large textarea..."
+    />
+    <fwb-textarea
+      v-model="message"
+      size="xl"
+      label="Extra large"
+      placeholder="Extra large textarea..."
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbTextarea } from '../../../../src/index'
+
+const message = ref('')
+</script>

--- a/docs/components/textarea/examples/FwbTextareaExampleStyling.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleStyling.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="vp-raw">
+    <fwb-textarea
+      v-model="message"
+      label="Your story"
+      placeholder="Start typing something..."
+      class="bg-amber-100 dark:bg-green-900 border-2 border-amber-500 has-[textarea:focus]:border-amber-900 dark:border-green-600 dark:has-[textarea:focus]:border-green-400 has-[textarea:focus]:ring-amber-300 dark:has-[textarea:focus]:ring-green-800"
+      label-class="text-xl font-bold text-amber-900 dark:text-green-200"
+      :rows="3"
+      textarea-class="text-amber-900 dark:text-green-100 placeholder:text-amber-500 dark:placeholder:text-green-500"
+      wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbTextarea } from '../../../../src/index'
+
+const message = ref('')
+</script>

--- a/docs/components/textarea/examples/FwbTextareaExampleValidation.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleValidation.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="flex flex-col gap-4 vp-raw">
+    <fwb-textarea
+      v-model="message"
+      validation-status="error"
+      label="Your message"
+      placeholder="Write your message..."
+    >
+      <template #validationMessage>
+        This field is required.
+      </template>
+    </fwb-textarea>
+    <fwb-textarea
+      v-model="message"
+      validation-status="success"
+      label="Your message"
+      placeholder="Write your message..."
+    >
+      <template #helper>
+        Looks good!
+      </template>
+    </fwb-textarea>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbTextarea } from '../../../../src/index'
+
+const message = ref('')
+</script>

--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -49,12 +49,14 @@
 
 <script lang="ts" setup>
 
-import { Comment, computed, Text, toRefs, useAttrs, useSlots } from 'vue'
+import { Comment, computed, Text, toRefs, useSlots } from 'vue'
 
 import { useInputAttributes } from './composables/useInputAttributes'
 import { useInputClasses } from './composables/useInputClasses'
 
 import type { InputProps } from './types'
+
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
 
 defineOptions({
   inheritAttrs: false,
@@ -78,19 +80,9 @@ const props = withDefaults(defineProps<InputProps>(), {
 const model = defineModel<string | number>({ default: '' })
 
 const { inputId, inputAttributes } = useInputAttributes()
-const attrs = useAttrs()
 const slots = useSlots()
 
-const validationMessageId = computed(() => `${inputId.value}-validation`)
-const helperId = computed(() => `${inputId.value}-helper`)
-
-const ariaDescribedby = computed(() => {
-  const ids: string[] = []
-  if (attrs['aria-describedby']) ids.push(String(attrs['aria-describedby']))
-  if (slots.validationMessage) ids.push(validationMessageId.value)
-  if (slots.helper) ids.push(helperId.value)
-  return ids.length ? ids.join(' ') : undefined
-})
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(inputId)
 
 const isTextSlot = (name: string) => {
   const vnodes = slots[name]?.()

--- a/src/components/FwbTextarea/FwbTextarea.vue
+++ b/src/components/FwbTextarea/FwbTextarea.vue
@@ -1,42 +1,69 @@
 <template>
-  <label>
-    <span
+  <div :class="wrapperClass">
+    <label
       v-if="label"
-      :class="labelClasses"
-    >{{ label }}</span>
-    <span :class="wrapperClasses">
+      :for="textareaId"
+      :class="labelClass"
+    >{{ label }}</label>
+    <div :class="textareaWrapperClass">
       <textarea
+        v-bind="textareaAttributes"
         v-model="model"
-        v-bind="$attrs"
-        :class="textareaClasses"
-        :rows="rows"
-        :placeholder="placeholder"
+        :aria-describedby="ariaDescribedby"
+        :aria-invalid="validationStatus === 'error' ? true : undefined"
         :autocomplete="autocomplete"
+        :class="textareaClass"
+        :disabled="disabled"
+        :required="required"
+        :rows="rows"
       />
-      <span
+      <div
         v-if="$slots.footer"
-        :class="footerClasses"
+        :class="footerClass"
       >
         <slot name="footer" />
-      </span>
-    </span>
-  </label>
+      </div>
+    </div>
+    <p
+      v-if="$slots.validationMessage"
+      :id="validationMessageId"
+      :class="validationMessageClass"
+    >
+      <slot name="validationMessage" />
+    </p>
+    <p
+      v-if="$slots.helper"
+      :id="helperId"
+      :class="helperMessageClass"
+    >
+      <slot name="helper" />
+    </p>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { toRefs } from 'vue'
 
 import { useTextareaClasses } from './composables/useTextareaClasses'
 
-import type { Autocomplete } from '@/types/form'
+import type { Autocomplete, FormElementSize, ValidationStatus } from '@/types/form'
+
+import { useElementAttributes } from '@/composables/useElementAttributes'
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
 
 interface TextareaProps {
-  modelValue?: string
-  label?: string
-  rows?: number
-  custom?: boolean
-  placeholder?: string
   autocomplete?: Autocomplete
+  class?: string | Record<string, boolean>
+  disabled?: boolean
+  footerClass?: string | Record<string, boolean>
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  required?: boolean
+  rows?: number
+  size?: FormElementSize
+  textareaClass?: string | Record<string, boolean>
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
 }
 
 defineOptions({
@@ -44,23 +71,33 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<TextareaProps>(), {
-  modelValue: '',
-  label: '',
-  rows: 4,
-  custom: false,
-  placeholder: 'Write your message here...',
   autocomplete: 'off',
+  class: '',
+  disabled: false,
+  footerClass: '',
+  label: '',
+  labelClass: '',
+  required: false,
+  rows: 4,
+  size: 'md',
+  textareaClass: '',
+  validationStatus: undefined,
+  wrapperClass: '',
 })
 
-const emit = defineEmits(['update:modelValue'])
-const model = computed({
-  get () {
-    return props.modelValue
-  },
-  set (val) {
-    emit('update:modelValue', val)
-  },
-})
+const model = defineModel<string>({ default: '' })
 
-const { textareaClasses, labelClasses, wrapperClasses, footerClasses } = useTextareaClasses(props.custom)
+const { elementId: textareaId, elementAttributes: textareaAttributes } = useElementAttributes()
+
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(textareaId)
+
+const {
+  footerClass,
+  helperMessageClass,
+  labelClass,
+  textareaClass,
+  textareaWrapperClass,
+  validationMessageClass,
+  wrapperClass,
+} = useTextareaClasses(toRefs(props))
 </script>

--- a/src/components/FwbTextarea/composables/useTextareaClasses.ts
+++ b/src/components/FwbTextarea/composables/useTextareaClasses.ts
@@ -23,7 +23,7 @@ const textareaSizeClasses: Record<FormElementSize, string> = {
 const errorTextareaWrapperClasses = 'bg-rose-50 border-rose-200 has-[textarea:focus]:border-rose-500 dark:border-rose-500 has-[textarea:focus]:ring-rose-500 text-rose-900 dark:text-rose-500'
 const errorTextClasses = 'text-rose-900 dark:text-rose-500'
 const successTextareaWrapperClasses = 'bg-emerald-50 border-emerald-200 has-[textarea:focus]:border-emerald-500 dark:border-emerald-500 has-[textarea:focus]:ring-emerald-500 text-emerald-900 dark:text-emerald-400'
-const successTextClasses = 'text-emerald-900 dark:text-emerald-400'
+const successTextClasses = 'text-emerald-900 dark:text-emerald-500'
 const errorTextareaClasses = 'text-rose-900 placeholder:text-rose-900 dark:placeholder:text-rose-500'
 const successTextareaClasses = 'text-emerald-900 dark:text-emerald-400 placeholder:text-emerald-900 dark:placeholder:text-emerald-500'
 

--- a/src/components/FwbTextarea/composables/useTextareaClasses.ts
+++ b/src/components/FwbTextarea/composables/useTextareaClasses.ts
@@ -1,26 +1,99 @@
-import { computed } from 'vue'
+import { computed, type Ref } from 'vue'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type FormElementSize, type ValidationStatus, validationStatusMap } from '@/types/form'
 
-const textareaWrapperClasses = 'block w-full mb-4 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-700 dark:border-gray-600'
-const textareaDefaultClasses = 'block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-200 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50'
-const textareaLabelClasses = 'block mb-2 text-sm font-medium text-gray-900 dark:text-white'
-const textareaFooterClasses = 'block py-2 px-3 border-gray-200 dark:border-gray-600'
+const defaultWrapperClasses = ''
+const defaultLabelClasses = 'block mb-2 font-medium text-gray-900 dark:text-white text-sm'
+const defaultTextareaWrapperClasses = 'relative bg-gray-50 dark:bg-gray-700 shadow-xs border border-gray-300 has-[textarea:focus]:border-blue-500 dark:border-gray-600 dark:has-[textarea:focus]:border-blue-500 rounded-lg has-[textarea:focus]:ring-1 has-[textarea:focus]:ring-blue-500 dark:has-[textarea:focus]:ring-blue-500 text-gray-900 dark:text-white'
+const defaultTextareaClasses = 'block bg-transparent border-0 focus:border-0 focus:outline-none dark:focus:outline-none ring-0 focus:ring-0 dark:focus:ring-0 w-full text-inherit dark:placeholder:text-gray-400 placeholder:text-gray-400'
+const defaultFooterClasses = 'px-3.5 py-2 border-gray-300 dark:border-gray-600 border-t'
+const defaultHelperClasses = 'mt-2 text-gray-500 dark:text-gray-400 text-sm'
 
-export function useTextareaClasses (custom: boolean) {
-  const textareaClasses = computed(() => useMergeClasses([
-    textareaDefaultClasses,
-    custom ? 'bg-white dark:bg-gray-800 border-none' : 'border',
+const disabledTextareaWrapperClasses = 'bg-gray-100'
+const disabledTextareaClasses = 'cursor-not-allowed'
+
+const textareaSizeClasses: Record<FormElementSize, string> = {
+  sm: 'px-2.5 py-2 text-sm',
+  md: 'px-3 py-2.5 text-sm',
+  lg: 'px-3.5 py-3 text-base',
+  xl: 'px-4 py-3.5 text-base',
+}
+
+const errorTextareaWrapperClasses = 'bg-rose-50 border-rose-200 has-[textarea:focus]:border-rose-500 dark:border-rose-500 has-[textarea:focus]:ring-rose-500 text-rose-900 dark:text-rose-500'
+const errorTextClasses = 'text-rose-900 dark:text-rose-500'
+const successTextareaWrapperClasses = 'bg-emerald-50 border-emerald-200 has-[textarea:focus]:border-emerald-500 dark:border-emerald-500 has-[textarea:focus]:ring-emerald-500 text-emerald-900 dark:text-emerald-400'
+const successTextClasses = 'text-emerald-900 dark:text-emerald-400'
+const errorTextareaClasses = 'text-rose-900 placeholder:text-rose-900 dark:placeholder:text-rose-500'
+const successTextareaClasses = 'text-emerald-900 dark:text-emerald-400 placeholder:text-emerald-900 dark:placeholder:text-emerald-500'
+
+export type UseTextareaClassesProps = {
+  class: Ref<string | Record<string, boolean>>
+  disabled: Ref<boolean>
+  footerClass: Ref<string | Record<string, boolean>>
+  labelClass: Ref<string | Record<string, boolean>>
+  size: Ref<FormElementSize>
+  textareaClass: Ref<string | Record<string, boolean>>
+  validationStatus: Ref<ValidationStatus | undefined>
+  wrapperClass: Ref<string | Record<string, boolean>>
+}
+
+export function useTextareaClasses (props: UseTextareaClassesProps) {
+  const wrapperClass = computed(() => useMergeClasses([
+    defaultWrapperClasses,
+    props.wrapperClass.value,
   ]))
 
-  const labelClasses = computed(() => textareaLabelClasses)
-  const wrapperClasses = computed(() => (custom) ? textareaWrapperClasses : '')
-  const footerClasses = computed(() => textareaFooterClasses)
+  const labelClass = computed(() => useMergeClasses([
+    defaultLabelClasses,
+    props.labelClass.value,
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextClasses
+      : props.validationStatus.value === validationStatusMap.Error ? errorTextClasses : '',
+  ]))
+
+  const textareaWrapperClass = computed(() => useMergeClasses([
+    defaultTextareaWrapperClasses,
+    props.class.value,
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextareaWrapperClasses
+      : props.validationStatus.value === validationStatusMap.Error ? errorTextareaWrapperClasses : '',
+    props.disabled.value ? disabledTextareaWrapperClasses : '',
+  ]))
+
+  const textareaClass = computed(() => useMergeClasses([
+    defaultTextareaClasses,
+    textareaSizeClasses[props.size.value],
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextareaClasses
+      : props.validationStatus.value === validationStatusMap.Error ? errorTextareaClasses : '',
+    props.textareaClass.value,
+    props.disabled.value ? disabledTextareaClasses : '',
+  ]))
+
+  const validationMessageClass = computed(() => useMergeClasses([
+    defaultHelperClasses,
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextClasses
+      : props.validationStatus.value === validationStatusMap.Error ? errorTextClasses : '',
+  ]))
+
+  const footerClass = computed(() => useMergeClasses([
+    defaultFooterClasses,
+    props.footerClass.value,
+  ]))
+
+  const helperMessageClass = computed(() => useMergeClasses([
+    defaultHelperClasses,
+  ]))
 
   return {
-    textareaClasses,
-    labelClasses,
-    wrapperClasses,
-    footerClasses,
+    footerClass,
+    helperMessageClass,
+    labelClass,
+    textareaClass,
+    textareaWrapperClass,
+    validationMessageClass,
+    wrapperClass,
   }
 }

--- a/src/components/FwbTextarea/tests/Textarea.spec.ts
+++ b/src/components/FwbTextarea/tests/Textarea.spec.ts
@@ -1,0 +1,162 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbTextarea from '../FwbTextarea.vue'
+
+describe('FwbTextarea', () => {
+  describe('label/textarea linkage', () => {
+    it('links label for to textarea id', () => {
+      const wrapper = mount(FwbTextarea, { props: { label: 'Message' } })
+      const labelFor = wrapper.find('label').attributes('for')
+      const textareaId = wrapper.find('textarea').attributes('id')
+      expect(labelFor).toBeDefined()
+      expect(labelFor).toBe(textareaId)
+    })
+
+    it('uses a user-provided id for both the textarea and the label', () => {
+      const wrapper = mount(FwbTextarea, { props: { label: 'Message' }, attrs: { id: 'custom-id' } })
+      expect(wrapper.find('textarea').attributes('id')).toBe('custom-id')
+      expect(wrapper.find('label').attributes('for')).toBe('custom-id')
+    })
+
+    it('renders no label when label prop is empty', () => {
+      const wrapper = mount(FwbTextarea)
+      expect(wrapper.find('label').exists()).toBe(false)
+    })
+  })
+
+  describe('native attribute passthrough', () => {
+    it('disabled prop reaches the textarea', () => {
+      const wrapper = mount(FwbTextarea, { props: { disabled: true } })
+      expect(wrapper.find('textarea').attributes('disabled')).toBeDefined()
+    })
+
+    it('required prop reaches the textarea', () => {
+      const wrapper = mount(FwbTextarea, { props: { required: true } })
+      expect(wrapper.find('textarea').attributes('required')).toBeDefined()
+    })
+
+    it('rows prop reaches the textarea', () => {
+      const wrapper = mount(FwbTextarea, { props: { rows: 8 } })
+      expect(wrapper.find('textarea').attributes('rows')).toBe('8')
+    })
+
+    it('extra attrs land on the textarea, not on the root wrapper', () => {
+      const wrapper = mount(FwbTextarea, {
+        attrs: { placeholder: 'Write here...', maxlength: '200', readonly: '' },
+      })
+      const textarea = wrapper.find('textarea')
+      expect(textarea.attributes('placeholder')).toBe('Write here...')
+      expect(textarea.attributes('maxlength')).toBe('200')
+      expect(textarea.attributes('readonly')).toBeDefined()
+      expect(wrapper.element.getAttribute('placeholder')).toBeNull()
+    })
+  })
+
+  describe('v-model', () => {
+    it('reflects the model value in the textarea', () => {
+      const wrapper = mount(FwbTextarea, {
+        props: {
+          'modelValue': 'hello',
+          'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+        },
+      })
+      expect((wrapper.find('textarea').element as HTMLTextAreaElement).value).toBe('hello')
+    })
+
+    it('emits update:modelValue on user input', async () => {
+      const wrapper = mount(FwbTextarea)
+      await wrapper.find('textarea').setValue('typed value')
+      expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toBe('typed value')
+    })
+  })
+
+  describe('aria-invalid', () => {
+    it('is "true" when validationStatus is "error"', () => {
+      const wrapper = mount(FwbTextarea, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('textarea').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('is absent when validationStatus is "success"', () => {
+      const wrapper = mount(FwbTextarea, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('textarea').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('is absent when validationStatus is not set', () => {
+      const wrapper = mount(FwbTextarea)
+      expect(wrapper.find('textarea').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no helper or validationMessage slot is provided', () => {
+      const wrapper = mount(FwbTextarea)
+      expect(wrapper.find('textarea').attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('points to the helper paragraph id when the helper slot is provided', () => {
+      const wrapper = mount(FwbTextarea, { slots: { helper: 'Some help text' } })
+      const helperP = wrapper.find('p')
+      expect(wrapper.find('textarea').attributes('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbTextarea, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'This field is required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('textarea').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs space-joined when both slots are rendered', () => {
+      const wrapper = mount(FwbTextarea, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Help text' },
+      })
+      const describedby = wrapper.find('textarea').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+
+    it('merges a user-passed aria-describedby with the slot IDs', () => {
+      const wrapper = mount(FwbTextarea, {
+        attrs: { 'aria-describedby': 'external-id' },
+        slots: { helper: 'Help text' },
+      })
+      const ids = (wrapper.find('textarea').attributes('aria-describedby') ?? '').split(' ')
+      expect(ids).toContain('external-id')
+      expect(ids).toHaveLength(2)
+    })
+  })
+
+  describe('size classes', () => {
+    it('sm and xl apply different padding to the textarea', () => {
+      const sm = mount(FwbTextarea, { props: { size: 'sm' } })
+      const xl = mount(FwbTextarea, { props: { size: 'xl' } })
+      const smPadding = sm.find('textarea').classes().filter(c => /^p[xy]-/.test(c))
+      const xlPadding = xl.find('textarea').classes().filter(c => /^p[xy]-/.test(c))
+      expect(smPadding).not.toEqual(xlPadding)
+    })
+  })
+
+  describe('validation status classes', () => {
+    it('error state adds rose-colored classes to the textarea wrapper', () => {
+      const wrapper = mount(FwbTextarea, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('.relative').classes().join(' ')).toContain('rose')
+    })
+
+    it('success state adds emerald-colored classes to the textarea wrapper', () => {
+      const wrapper = mount(FwbTextarea, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('.relative').classes().join(' ')).toContain('emerald')
+    })
+
+    it('no validation state adds neither rose nor emerald classes', () => {
+      const wrapper = mount(FwbTextarea)
+      const classes = wrapper.find('.relative').classes().join(' ')
+      expect(classes).not.toContain('rose')
+      expect(classes).not.toContain('emerald')
+    })
+  })
+})

--- a/src/composables/useFormFieldIds.ts
+++ b/src/composables/useFormFieldIds.ts
@@ -1,0 +1,19 @@
+import { computed, type ComputedRef, useAttrs, useSlots } from 'vue'
+
+export const useFormFieldIds = (elementId: ComputedRef<string>) => {
+  const attrs = useAttrs()
+  const slots = useSlots()
+
+  const validationMessageId = computed(() => `${elementId.value}-validation`)
+  const helperId = computed(() => `${elementId.value}-helper`)
+
+  const ariaDescribedby = computed(() => {
+    const ids: string[] = []
+    if (attrs['aria-describedby']) ids.push(String(attrs['aria-describedby']))
+    if (slots.validationMessage) ids.push(validationMessageId.value)
+    if (slots.helper) ids.push(helperId.value)
+    return ids.length ? ids.join(' ') : undefined
+  })
+
+  return { ariaDescribedby, helperId, validationMessageId }
+}


### PR DESCRIPTION
## Summary

Brings `FwbTextarea` to full parity with `FwbInput`, adding validation states, size variants, accessibility wiring, and native attribute passthrough.

## What's new

**New `FwbTextarea` props**
- `size` — `sm | md | lg | xl` padding and font size variants
- `validationStatus` — `success | error` states with Flowbite-matched rose/emerald palette
- `wrapperClass`, `textareaClass`, `labelClass`, `footerClass` — per-element class passthrough
- `autocomplete` — typed `Autocomplete` prop

**New `FwbTextarea` slots**
- `validationMessage` — styled feedback message, linked via `aria-describedby`
- `helper` — helper text, linked via `aria-describedby`

**Accessibility**
- `inheritAttrs: false` — extra attrs forward to `<textarea>`, not the root wrapper
- `aria-invalid="true"` set automatically on `validationStatus="error"`
- `aria-describedby` wired to `validationMessage`/`helper` slot IDs, merged with any user-provided value

**New shared composable: `useFormFieldIds`**
- Extracted from `FwbInput` and `FwbTextarea` — derives `validationMessageId`, `helperId`, and `ariaDescribedby` from an element ID
- Will be reused by remaining form components (`FwbRange`, `FwbToggle`, `FwbSelect`, etc.)

## Tests

21 new tests covering label/textarea linkage, user-provided id, attr passthrough, v-model, `aria-invalid`, `aria-describedby` (including slot merging and external id merging), size classes, and validation status classes.

## Docs

Full rewrite aligned with the `FwbInput` docs structure and [Flowbite textarea reference](https://flowbite.com/docs/forms/textarea/): sizes, disabled/readonly, validation, native constraints, footer slot, styling, and complete API table.

## Breaking changes

**`placeholder` prop removed**
`placeholder` is no longer a declared prop and its default value (`'Write your message here...'`) has been dropped.
Pass it as a native attribute instead — it forwards directly to the `<textarea>` via attr passthrough:

```vue
<!-- before -->
<fwb-textarea placeholder="Write your message here..." />

<!-- after (identical at runtime, no prop declaration needed) -->
<fwb-textarea placeholder="Your custom placeholder" />
```

**`custom` prop removed**
The `custom` boolean has been removed. The new default layout uses a unified styled wrapper (previously the `custom: true` layout). For further customization use the `class`, `wrapper-class`, and `textarea-class` props.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Size variants (sm, md, lg, xl), validation states (success/error), footer/helper/validation slots, improved styling via wrapper/label/textarea/wrapper class props, and refined disabled/readonly behavior
  * Native constraints feedback (minlength/maxlength/required) and ARIA improvements (aria-invalid and aria-describedby)

* **Documentation**
  * Expanded textarea docs with structured demos (Sizes, Disabled/Readonly, Validation, Native Constraints, Styling) and an explicit component API + accessibility tip

* **Tests**
  * Added comprehensive textarea component test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->