### PR TITLE
refactor: FwbSelect - validation, size variants, accessibility, and attr passthrough

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -51,7 +51,7 @@ const countries = [
 
 ## Clearable
 
-Use the `clearable` prop to add an empty first option that resets the selection. Without `clearable`, the placeholder option is disabled and hidden once the user makes a choice.
+Use the `clearable` prop to add an empty first option that resets the selection. Without `clearable`, the placeholder option is always disabled and hidden.
 
 <fwb-select-example-clearable />
 ```vue

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -3,6 +3,7 @@ import FwbSelectExample from './select/examples/FwbSelectExample.vue'
 import FwbSelectExampleDisabled from './select/examples/FwbSelectExampleDisabled.vue'
 import FwbSelectExampleHelper from './select/examples/FwbSelectExampleHelper.vue'
 import FwbSelectExampleSize from './select/examples/FwbSelectExampleSize.vue'
+import FwbSelectExampleStyling from './select/examples/FwbSelectExampleStyling.vue'
 import FwbSelectExampleUnderlined from './select/examples/FwbSelectExampleUnderlined.vue'
 import FwbSelectExampleValidation from './select/examples/FwbSelectExampleValidation.vue'
 </script>
@@ -206,3 +207,58 @@ const countries = [
 ]
 </script>
 ```
+
+## Styling
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-select-example-styling />
+```vue
+<template>
+  <fwb-select
+    v-model="selected"
+    :options="countries"
+    class="rounded-none border-2 border-gray-900 dark:border-gray-200"
+    label="Select a country"
+    label-class="italic text-gray-900 dark:text-gray-200"
+    wrapper-class="bg-gray-100 dark:bg-gray-800 p-4"
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbSelect } from 'flowbite-vue'
+
+const selected = ref('')
+const countries = [
+  { value: 'us', name: 'United States' },
+  { value: 'ca', name: 'Canada' },
+  { value: 'fr', name: 'France' },
+]
+</script>
+```
+
+## FwbSelect Props
+
+| Name             | Type                     | Default               | Description                                  |
+|------------------|--------------------------|-----------------------|----------------------------------------------|
+| autocomplete     | String                   | `undefined`           | Sets the `autocomplete` attribute.           |
+| class            | String \| Object         | `''`                  | Added to the `<select>` element.             |
+| clearable        | Boolean                  | `false`               | Shows an empty option that clears the value. |
+| disabled         | Boolean                  | `false`               | Disables the select.                         |
+| label            | String                   | `''`                  | Label text rendered above the select.        |
+| labelClass       | String \| Object         | `''`                  | Added to the `<label>` element.              |
+| options          | OptionsType[]            | `[]`                  | Array of `{ value, name }` option objects.   |
+| placeholder      | String                   | `'Please select one'` | Placeholder option text.                     |
+| required         | Boolean                  | `false`               | Sets the `required` attribute.               |
+| size             | `'sm'\|'md'\|'lg'\|'xl'` | `'md'`                | Controls padding and font size.              |
+| underline        | Boolean                  | `false`               | Uses the underline style variant.            |
+| validationStatus | `'success'\|'error'`     | `undefined`           | Applies validation colour styles.            |
+| wrapperClass     | String \| Object         | `''`                  | Added to the outer root `<div>`.             |
+
+## FwbSelect Slots
+
+| Name              | Description                                   |
+|-------------------|-----------------------------------------------|
+| helper            | Help text rendered below the select.          |
+| validationMessage | Validation message rendered below the select. |

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -1,5 +1,7 @@
 <script setup>
 import FwbSelectExample from './select/examples/FwbSelectExample.vue'
+import FwbSelectExampleChevron from './select/examples/FwbSelectExampleChevron.vue'
+import FwbSelectExampleClearable from './select/examples/FwbSelectExampleClearable.vue'
 import FwbSelectExampleDisabled from './select/examples/FwbSelectExampleDisabled.vue'
 import FwbSelectExampleHelper from './select/examples/FwbSelectExampleHelper.vue'
 import FwbSelectExampleSize from './select/examples/FwbSelectExampleSize.vue'
@@ -8,7 +10,7 @@ import FwbSelectExampleUnderlined from './select/examples/FwbSelectExampleUnderl
 import FwbSelectExampleValidation from './select/examples/FwbSelectExampleValidation.vue'
 </script>
 
-# Vue Select - Flowbite
+# Select - Flowbite Vue
 
 #### Get started with the select component to allow the user to choose from one or more options from a dropdown list based on multiple styles, sizes, and variants
 
@@ -23,6 +25,7 @@ The select input component can be used to gather information from users based on
 ## Default
 
 <fwb-select-example />
+
 ```vue
 <template>
   <fwb-select
@@ -43,6 +46,81 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
+```
+
+## Clearable
+
+Use the `clearable` prop to add an empty first option that resets the selection. Without `clearable`, the placeholder option is disabled and hidden once the user makes a choice.
+
+<fwb-select-example-clearable />
+```vue
+<template>
+  <fwb-select
+    v-model="selected"
+    :options="countries"
+    clearable
+    label="Select a country"
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbSelect } from 'flowbite-vue'
+
+const selected = ref('')
+const countries = [
+  { value: 'us', name: 'United States' },
+  { value: 'ca', name: 'Canada' },
+  { value: 'fr', name: 'France' },
+]
+</script>
+
+```
+
+## Sizes
+
+<fwb-select-example-size />
+```vue
+<template>
+  <fwb-select
+    v-model="selected"
+    :options="countries"
+    label="Small"
+    size="sm"
+  />
+  <fwb-select
+    v-model="selected"
+    :options="countries"
+    label="Medium (default)"
+    size="md"
+  />
+  <fwb-select
+    v-model="selected"
+    :options="countries"
+    label="Large"
+    size="lg"
+  />
+  <fwb-select
+    v-model="selected"
+    :options="countries"
+    label="Extra Large"
+    size="xl"
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbSelect } from 'flowbite-vue'
+
+const selected = ref('')
+const countries = [
+  { value: 'us', name: 'United States' },
+  { value: 'ca', name: 'Canada' },
+  { value: 'fr', name: 'France' },
+]
+</script>
+
 ```
 
 ## Disabled
@@ -70,6 +148,7 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
 ```
 
 ## Underlined
@@ -96,31 +175,38 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
 ```
 
-## Size
+## Validation
 
-<fwb-select-example-size />
+- Set validation status via `validationStatus` prop, which accepts `'success'` or `'error'`.
+- Add validation message via `validationMessage` slot.
+
+<fwb-select-example-validation />
 ```vue
 <template>
   <fwb-select
     v-model="selected"
     :options="countries"
     label="Select a country"
-    size="sm"
-  />
+    validation-status="success"
+  >
+    <template #validationMessage>
+      <span class="font-medium">Well done!</span> Your selection looks good.
+    </template>
+  </fwb-select>
+  <hr class="mt-4 border-0">
   <fwb-select
     v-model="selected"
     :options="countries"
     label="Select a country"
-    size="md"
-  />
-  <fwb-select
-    v-model="selected"
-    :options="countries"
-    label="Select a country"
-    size="lg"
-  />
+    validation-status="error"
+  >
+    <template #validationMessage>
+      <span class="font-medium">Oh, snap!</span> Please select a country.
+    </template>
+  </fwb-select>
 </template>
 
 <script setup>
@@ -134,6 +220,7 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
 ```
 
 ## Slot - Helper
@@ -152,7 +239,7 @@ const countries = [
         Privacy Policy
       </fwb-a>.
     </template>
-  </fwb-input>
+  </fwb-select>
 </template>
 
 <script lang="ts" setup>
@@ -166,31 +253,35 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
 ```
 
-## Slot - Validation
+## Slot - Chevron
 
-- Set validation status via `validationStatus` prop, which accepts `'success'` or `'error'`.
-- Add validation message via `validationMessage` slot.
+Replace the default chevron icon by providing content in the `chevron` slot.
 
-<fwb-select-example-validation />
+<fwb-select-example-chevron />
 ```vue
 <template>
   <fwb-select
     v-model="selected"
     :options="countries"
     label="Select a country"
-    validation-status="success"
-  />
-  <hr class="mt-4 border-0">
-  <fwb-select
-    v-model="selected"
-    :options="countries"
-    label="Select a country"
-    validation-status="error"
   >
-    <template #validationMessage>
-      Please select a country
+    <template #chevron>
+      <svg
+        aria-hidden="true"
+        class="size-4 text-gray-500 dark:text-gray-400"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M12 2a1 1 0 0 1 .707.293l4 4a1 1 0 0 1-1.414 1.414L12 4.414 8.707 7.707a1 1 0 0 1-1.414-1.414l4-4A1 1 0 0 1 12 2Zm-4.707 9.293a1 1 0 0 1 1.414 0L12 14.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z"
+          fill-rule="evenodd"
+        />
+      </svg>
     </template>
   </fwb-select>
 </template>
@@ -206,6 +297,7 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
 ```
 
 ## Styling
@@ -236,29 +328,42 @@ const countries = [
   { value: 'fr', name: 'France' },
 ]
 </script>
+
 ```
 
-## FwbSelect Props
+## Select component API
 
-| Name             | Type                     | Default               | Description                                  |
-|------------------|--------------------------|-----------------------|----------------------------------------------|
-| autocomplete     | String                   | `undefined`           | Sets the `autocomplete` attribute.           |
-| class            | String \| Object         | `''`                  | Added to the `<select>` element.             |
-| clearable        | Boolean                  | `false`               | Shows an empty option that clears the value. |
-| disabled         | Boolean                  | `false`               | Disables the select.                         |
-| label            | String                   | `''`                  | Label text rendered above the select.        |
-| labelClass       | String \| Object         | `''`                  | Added to the `<label>` element.              |
-| options          | OptionsType[]            | `[]`                  | Array of `{ value, name }` option objects.   |
-| placeholder      | String                   | `'Please select one'` | Placeholder option text.                     |
-| required         | Boolean                  | `false`               | Sets the `required` attribute.               |
-| size             | `'sm'\|'md'\|'lg'\|'xl'` | `'md'`                | Controls padding and font size.              |
-| underline        | Boolean                  | `false`               | Uses the underline style variant.            |
-| validationStatus | `'success'\|'error'`     | `undefined`           | Applies validation colour styles.            |
-| wrapperClass     | String \| Object         | `''`                  | Added to the outer root `<div>`.             |
+### FwbSelect Props
 
-## FwbSelect Slots
+:::tip Native attribute passthrough
+`FwbSelect` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `form`, `autofocus`) directly to the `<select>` element.
+:::
 
-| Name              | Description                                   |
-|-------------------|-----------------------------------------------|
-| helper            | Help text rendered below the select.          |
-| validationMessage | Validation message rendered below the select. |
+| Name             | Type                           | Default               | Description                                      |
+| ---------------- | ------------------------------ | --------------------- | ------------------------------------------------ |
+| autocomplete     | `String \| Autocomplete`       | `undefined`           | Sets the `autocomplete` attribute on the select. |
+| chevronClass     | `String \| Object`             | `''`                  | Added to the chevron icon container.             |
+| class            | `String \| Object`             | `''`                  | Added to the `<select>` element.                 |
+| clearable        | `Boolean`                      | `false`               | Shows an empty option that clears the value.     |
+| disabled         | `Boolean`                      | `false`               | Disables the select.                             |
+| label            | `String`                       | `''`                  | Label text rendered above the select.            |
+| labelClass       | `String \| Object`             | `''`                  | Added to the `<label>` element.                  |
+| options          | `OptionsType[]`                | `[]`                  | Array of `{ value, name }` option objects.       |
+| placeholder      | `String`                       | `'Please select one'` | Placeholder option text.                         |
+| required         | `Boolean`                      | `false`               | Sets the `required` attribute.                   |
+| size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`                | Controls padding and font size.                  |
+| underline        | `Boolean`                      | `false`               | Uses the underline style variant.                |
+| validationStatus | `'success' \| 'error'`         | `undefined`           | Applies success or error colour styles.          |
+| wrapperClass     | `String \| Object`             | `''`                  | Added to the outer root `<div>`.                 |
+
+:::tip Accessibility
+`aria-invalid="true"` is set automatically on the native select when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
+:::
+
+### FwbSelect Slots
+
+| Name              | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| chevron           | Replaces the default chevron icon inside the select.                          |
+| helper            | Helper text rendered below the select.                                        |
+| validationMessage | Validation feedback rendered below the select (styled by `validationStatus`). |

--- a/docs/components/select/examples/FwbSelectExampleChevron.vue
+++ b/docs/components/select/examples/FwbSelectExampleChevron.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="vp-raw">
+    <fwb-select
+      v-model="selected"
+      :options="countries"
+      label="Select a country"
+    >
+      <template #chevron>
+        <svg
+          aria-hidden="true"
+          class="size-4 text-gray-500 dark:text-gray-400"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M12 2a1 1 0 0 1 .707.293l4 4a1 1 0 0 1-1.414 1.414L12 4.414 8.707 7.707a1 1 0 0 1-1.414-1.414l4-4A1 1 0 0 1 12 2Zm-4.707 9.293a1 1 0 0 1 1.414 0L12 14.586l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </template>
+    </fwb-select>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbSelect } from '../../../../src/index'
+
+const selected = ref('')
+const countries = [
+  { value: 'us', name: 'United States' },
+  { value: 'ca', name: 'Canada' },
+  { value: 'fr', name: 'France' },
+]
+</script>

--- a/docs/components/select/examples/FwbSelectExampleClearable.vue
+++ b/docs/components/select/examples/FwbSelectExampleClearable.vue
@@ -3,6 +3,7 @@
     <fwb-select
       v-model="selected"
       :options="countries"
+      clearable
       label="Select a country"
     />
   </div>

--- a/docs/components/select/examples/FwbSelectExampleSize.vue
+++ b/docs/components/select/examples/FwbSelectExampleSize.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vp-raw grid gap-2">
+  <div class="gap-2 grid vp-raw">
     <fwb-select
       v-model="selected"
       :options="countries"
@@ -17,6 +17,12 @@
       :options="countries"
       label="Select a country"
       size="lg"
+    />
+    <fwb-select
+      v-model="selected"
+      :options="countries"
+      label="Select a country"
+      size="xl"
     />
   </div>
 </template>

--- a/docs/components/select/examples/FwbSelectExampleSize.vue
+++ b/docs/components/select/examples/FwbSelectExampleSize.vue
@@ -3,25 +3,25 @@
     <fwb-select
       v-model="selected"
       :options="countries"
-      label="Select a country"
+      label="Small"
       size="sm"
     />
     <fwb-select
       v-model="selected"
       :options="countries"
-      label="Select a country"
+      label="Medium (default)"
       size="md"
     />
     <fwb-select
       v-model="selected"
       :options="countries"
-      label="Select a country"
+      label="Large"
       size="lg"
     />
     <fwb-select
       v-model="selected"
       :options="countries"
-      label="Select a country"
+      label="Extra Large"
       size="xl"
     />
   </div>

--- a/docs/components/select/examples/FwbSelectExampleStyling.vue
+++ b/docs/components/select/examples/FwbSelectExampleStyling.vue
@@ -1,15 +1,12 @@
 <template>
-  <div class="gap-2 grid vp-raw">
+  <div class="vp-raw">
     <fwb-select
       v-model="selected"
       :options="countries"
+      class="border-2 border-gray-900 dark:border-gray-200 rounded-none"
       label="Select a country"
-    />
-    <fwb-select
-      v-model="selected"
-      :options="countries"
-      label="Select a country"
-      clearable
+      label-class="italic text-gray-900 dark:text-gray-200"
+      wrapper-class="bg-gray-100 dark:bg-gray-800 p-4"
     />
   </div>
 </template>

--- a/docs/components/select/examples/FwbSelectExampleValidation.vue
+++ b/docs/components/select/examples/FwbSelectExampleValidation.vue
@@ -5,7 +5,11 @@
       :options="countries"
       label="Select a country"
       validation-status="success"
-    />
+    >
+      <template #validationMessage>
+        <span class="font-medium">Well done!</span> Your selection looks good.
+      </template>
+    </fwb-select>
     <hr class="mt-4 border-0">
     <fwb-select
       v-model="selected"
@@ -14,7 +18,7 @@
       validation-status="error"
     >
       <template #validationMessage>
-        Please select a country
+        <span class="font-medium">Oh, snap!</span> Please select a country.
       </template>
     </fwb-select>
   </div>

--- a/src/components/FwbSelect/FwbSelect.vue
+++ b/src/components/FwbSelect/FwbSelect.vue
@@ -1,22 +1,23 @@
 <template>
-  <div>
-    <label>
-      <span
-        v-if="label"
-        :class="labelClasses"
-      >
-        {{ label }}
-      </span>
+  <div :class="wrapperClass">
+    <label
+      v-if="label"
+      :class="labelClass"
+      :for="selectId"
+    >{{ label }}</label>
+    <div class="relative">
       <select
+        v-bind="selectAttributes"
         v-model="model"
+        :autocomplete="autocomplete"
+        :class="selectClass"
         :disabled="disabled"
         :required="required"
-        :class="selectClasses"
-        :autocomplete="autocomplete"
       >
         <option
-          disabled
-          selected
+          :disabled="!clearable"
+          :hidden="!clearable"
+          class="text-gray-500 dark:text-gray-400"
           value=""
         >
           {{ placeholder }}
@@ -29,16 +30,38 @@
           {{ option.name }}
         </option>
       </select>
-    </label>
+      <div
+        class="pointer-events-none absolute inset-y-0 right-3 flex items-center"
+        :class="chevronClass"
+      >
+        <slot name="chevron">
+          <svg
+            aria-hidden="true"
+            class="size-2.5"
+            fill="none"
+            viewBox="0 0 10 6"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m1 1 4 4 4-4"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </slot>
+      </div>
+    </div>
     <p
       v-if="$slots.validationMessage"
-      :class="validationWrapperClasses"
+      :class="validationMessageClass"
     >
       <slot name="validationMessage" />
     </p>
     <p
       v-if="$slots.helper"
-      class="mt-2 text-sm text-gray-500 dark:text-gray-400"
+      :class="helperMessageClass"
     >
       <slot name="helper" />
     </p>
@@ -46,48 +69,42 @@
 </template>
 
 <script lang="ts" setup>
-import { useVModel } from '@vueuse/core'
-import { twMerge } from 'tailwind-merge'
-import { computed, toRefs } from 'vue'
+import { toRefs } from 'vue'
 
+import { useSelectAttributes } from './composables/useSelectAttributes'
 import { useSelectClasses } from './composables/useSelectClasses'
-import { type OptionsType, type ValidationStatus, validationStatusMap } from './types'
 
-import type { Autocomplete, FormElementSize } from '@/types/form'
+import type { SelectProps } from './types'
 
-interface InputProps {
-  modelValue?: string
-  label?: string
-  options?: OptionsType[]
-  placeholder?: string
-  disabled?: boolean
-  required?: boolean
-  underline?: boolean
-  size?: FormElementSize
-  autocomplete?: Autocomplete
-  validationStatus?: ValidationStatus
-}
-const props = withDefaults(defineProps<InputProps>(), {
-  modelValue: '',
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(defineProps<SelectProps>(), {
+  chevronClass: '',
+  class: '',
+  clearable: false,
+  disabled: false,
   label: '',
+  labelClass: '',
   options: () => [],
   placeholder: 'Please select one',
-  disabled: false,
   required: false,
-  underline: false,
   size: 'md',
-  autocomplete: 'off',
+  underline: false,
   validationStatus: undefined,
+  wrapperClass: '',
 })
-const emit = defineEmits(['update:modelValue'])
 
-const model = useVModel(props, 'modelValue', emit)
+const model = defineModel<string>({ default: '' })
+const { selectId, selectAttributes } = useSelectAttributes()
 
-const { selectClasses, labelClasses } = useSelectClasses(toRefs(props))
-
-const validationWrapperClasses = computed(() => twMerge(
-  'mt-2 text-sm',
-  props.validationStatus === validationStatusMap.Success ? 'text-green-600 dark:text-green-500' : '',
-  props.validationStatus === validationStatusMap.Error ? 'text-red-600 dark:text-red-500' : '',
-))
+const {
+  chevronClass,
+  wrapperClass,
+  labelClass,
+  selectClass,
+  validationMessageClass,
+  helperMessageClass,
+} = useSelectClasses(toRefs(props))
 </script>

--- a/src/components/FwbSelect/FwbSelect.vue
+++ b/src/components/FwbSelect/FwbSelect.vue
@@ -9,6 +9,8 @@
       <select
         v-bind="selectAttributes"
         v-model="model"
+        :aria-describedby="ariaDescribedby"
+        :aria-invalid="validationStatus === 'error' ? true : undefined"
         :autocomplete="autocomplete"
         :class="selectClass"
         :disabled="disabled"
@@ -31,7 +33,7 @@
         </option>
       </select>
       <div
-        class="pointer-events-none absolute inset-y-0 right-3 flex items-center"
+        class="right-3 absolute inset-y-0 flex items-center pointer-events-none"
         :class="chevronClass"
       >
         <slot name="chevron">
@@ -55,12 +57,14 @@
     </div>
     <p
       v-if="$slots.validationMessage"
+      :id="validationMessageId"
       :class="validationMessageClass"
     >
       <slot name="validationMessage" />
     </p>
     <p
       v-if="$slots.helper"
+      :id="helperId"
       :class="helperMessageClass"
     >
       <slot name="helper" />
@@ -75,6 +79,8 @@ import { useSelectAttributes } from './composables/useSelectAttributes'
 import { useSelectClasses } from './composables/useSelectClasses'
 
 import type { SelectProps } from './types'
+
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
 
 defineOptions({
   inheritAttrs: false,
@@ -98,6 +104,7 @@ const props = withDefaults(defineProps<SelectProps>(), {
 
 const model = defineModel<string>({ default: '' })
 const { selectId, selectAttributes } = useSelectAttributes()
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(selectId)
 
 const {
   chevronClass,

--- a/src/components/FwbSelect/composables/useSelectAttributes.ts
+++ b/src/components/FwbSelect/composables/useSelectAttributes.ts
@@ -1,0 +1,10 @@
+import { useElementAttributes } from '@/composables/useElementAttributes'
+
+export const useSelectAttributes = () => {
+  const {
+    elementId: selectId,
+    elementAttributes: selectAttributes,
+  } = useElementAttributes()
+
+  return { selectId, selectAttributes }
+}

--- a/src/components/FwbSelect/composables/useSelectClasses.ts
+++ b/src/components/FwbSelect/composables/useSelectClasses.ts
@@ -7,9 +7,9 @@ const defaultWrapperClasses = ''
 const defaultLabelClasses = 'block mb-2 font-medium text-gray-900 dark:text-white text-sm'
 const defaultHelperClasses = 'mt-2 text-gray-500 dark:text-gray-400 text-sm'
 
-const defaultSelectClasses = 'w-full appearance-none bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white shadow-xs focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-500 dark:focus:border-blue-500'
+const defaultSelectClasses = 'w-full appearance-none bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white shadow-xs focus:outline-hidden focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-500 dark:focus:border-blue-500'
 const borderSelectClasses = 'border border-gray-300 dark:border-gray-600 rounded-lg'
-const underlineSelectClasses = 'bg-transparent dark:bg-transparent border-b-2 border-gray-200 dark:border-gray-700 focus:outline-none focus:ring-0 focus:border-gray-200 peer'
+const underlineSelectClasses = 'bg-transparent dark:bg-transparent border-b-2 border-gray-200 dark:border-gray-700 focus:outline-hidden focus:ring-0 focus:border-gray-200 peer'
 const disabledSelectClasses = 'cursor-not-allowed bg-gray-100'
 
 const selectSizeClasses: Record<FormElementSize, string> = {

--- a/src/components/FwbSelect/composables/useSelectClasses.ts
+++ b/src/components/FwbSelect/composables/useSelectClasses.ts
@@ -1,74 +1,117 @@
-import { twMerge } from 'tailwind-merge'
 import { computed, type Ref } from 'vue'
 
+import { useMergeClasses } from '@/composables/useMergeClasses'
 import { type FormElementSize, type ValidationStatus, validationStatusMap } from '@/types/form'
 
-// LABEL
-const baseLabelClasses = 'block mb-2 text-sm font-medium'
+const defaultWrapperClasses = ''
+const defaultLabelClasses = 'block mb-2 font-medium text-gray-900 dark:text-white text-sm'
+const defaultHelperClasses = 'mt-2 text-gray-500 dark:text-gray-400 text-sm'
 
-// INPUT
-const defaultSelectClasses = 'w-full text-gray-900 bg-gray-50 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500'
+const defaultSelectClasses = 'w-full appearance-none bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white shadow-xs focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-500 dark:focus:border-blue-500'
+const borderSelectClasses = 'border border-gray-300 dark:border-gray-600 rounded-lg'
+const underlineSelectClasses = 'bg-transparent dark:bg-transparent border-b-2 border-gray-200 dark:border-gray-700 focus:outline-none focus:ring-0 focus:border-gray-200 peer'
 const disabledSelectClasses = 'cursor-not-allowed bg-gray-100'
-const underlineSelectClasses = 'bg-transparent dark:bg-transparent dark:text-gray-500 border-b-2 border-gray-200 dark:border-gray-700 focus:outline-none focus:ring-0 focus:border-gray-200 peer'
+
 const selectSizeClasses: Record<FormElementSize, string> = {
-  sm: 'p-2 text-sm',
-  md: 'p-2.5 text-sm',
-  lg: 'p-4',
-  xl: 'p-5 text-base',
+  sm: 'pl-2.5 pr-8 py-2 text-sm',
+  md: 'pl-3 pr-8 py-2.5 text-sm',
+  lg: 'pl-3.5 pr-8 py-3 text-base',
+  xl: 'pl-4 pr-8 py-3.5 text-base',
 }
 
-const successInputClasses = 'bg-green-50 border-green-500 dark:border-green-500 text-green-900 dark:text-green-400 placeholder-green-700 dark:placeholder-green-500 focus:ring-green-500 focus:border-green-500'
-const errorInputClasses = 'bg-red-50 border-red-500 text-red-900 placeholder-red-700 focus:ring-red-500 focus:border-red-500 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500'
+const errorSelectClasses = 'bg-red-50 border-rose-200 focus:ring-rose-500 focus:border-rose-500 dark:border-rose-500 dark:focus:ring-rose-500 text-rose-900 dark:text-rose-500'
+const errorTextClasses = 'text-rose-900 dark:text-rose-500'
+const successSelectClasses = 'bg-green-50 border-emerald-200 focus:ring-emerald-500 focus:border-emerald-500 dark:border-emerald-500 dark:focus:ring-emerald-500 text-emerald-900 dark:text-emerald-400'
+const successTextClasses = 'text-emerald-900 dark:text-emerald-500'
+
+const errorUnderlineClasses = 'focus:border-rose-500'
+const successUnderlineClasses = 'focus:border-emerald-500'
 
 export type UseSelectClassesProps = {
-  size: Ref<FormElementSize>
+  chevronClass: Ref<string | Record<string, boolean>>
+  class: Ref<string | Record<string, boolean>>
   disabled: Ref<boolean>
+  labelClass: Ref<string | Record<string, boolean>>
+  size: Ref<FormElementSize>
   underline: Ref<boolean>
   validationStatus: Ref<ValidationStatus | undefined>
+  wrapperClass: Ref<string | Record<string, boolean>>
 }
 
 export function useSelectClasses (props: UseSelectClassesProps): {
-  selectClasses: Ref<string>
-  labelClasses: Ref<string>
+  chevronClass: Ref<string>
+  helperMessageClass: Ref<string>
+  labelClass: Ref<string>
+  selectClass: Ref<string>
+  validationMessageClass: Ref<string>
+  wrapperClass: Ref<string>
 } {
-  const selectClasses = computed(() => {
+  const wrapperClass = computed(() => useMergeClasses([
+    defaultWrapperClasses,
+    props.wrapperClass.value,
+  ]))
+
+  const labelClass = computed(() => useMergeClasses([
+    defaultLabelClasses,
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextClasses
+      : props.validationStatus.value === validationStatusMap.Error
+        ? errorTextClasses
+        : '',
+    props.labelClass.value,
+  ]))
+
+  const selectClass = computed(() => {
     const vs = props.validationStatus.value
-
     const classByStatus = vs === validationStatusMap.Success
-      ? successInputClasses
-      : vs === validationStatusMap.Error
-        ? errorInputClasses
-        : ''
-
+      ? successSelectClasses
+      : vs === validationStatusMap.Error ? errorSelectClasses : ''
     const underlineByStatus = vs === validationStatusMap.Success
-      ? 'focus:border-green-500'
-      : vs === validationStatusMap.Error
-        ? 'focus:border-red-500'
-        : ''
+      ? successUnderlineClasses
+      : vs === validationStatusMap.Error ? errorUnderlineClasses : ''
 
-    return twMerge(
+    return useMergeClasses([
       defaultSelectClasses,
-      classByStatus,
       selectSizeClasses[props.size.value],
-      props.disabled.value && disabledSelectClasses,
-      props.underline.value ? underlineSelectClasses : 'border border-gray-300 rounded-lg',
-      props.underline.value && underlineByStatus,
-    )
+      props.underline.value ? underlineSelectClasses : borderSelectClasses,
+      classByStatus,
+      props.underline.value ? underlineByStatus : '',
+      props.disabled.value ? disabledSelectClasses : '',
+      props.class.value,
+    ])
   })
 
-  const labelClasses = computed(() => {
-    const vs = props.validationStatus.value
-    const classByStatus = vs === validationStatusMap.Success
-      ? 'text-green-700 dark:text-green-500'
-      : vs === validationStatusMap.Error
-        ? 'text-red-700 dark:text-red-500'
-        : 'text-gray-900 dark:text-white'
+  const validationMessageClass = computed(() => useMergeClasses([
+    defaultHelperClasses,
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextClasses
+      : props.validationStatus.value === validationStatusMap.Error
+        ? errorTextClasses
+        : '',
+  ]))
 
-    return twMerge(baseLabelClasses, classByStatus)
+  const chevronClass = computed(() => {
+    const stateClass = props.disabled.value
+      ? 'text-gray-400 dark:text-gray-500'
+      : props.validationStatus.value === validationStatusMap.Success
+        ? successTextClasses
+        : props.validationStatus.value === validationStatusMap.Error
+          ? errorTextClasses
+          : 'text-gray-900 dark:text-white'
+
+    return useMergeClasses([stateClass, props.chevronClass.value])
   })
+
+  const helperMessageClass = computed(() => useMergeClasses([
+    defaultHelperClasses,
+  ]))
 
   return {
-    selectClasses,
-    labelClasses,
+    chevronClass,
+    helperMessageClass,
+    labelClass,
+    selectClass,
+    validationMessageClass,
+    wrapperClass,
   }
 }

--- a/src/components/FwbSelect/tests/Select.spec.ts
+++ b/src/components/FwbSelect/tests/Select.spec.ts
@@ -1,0 +1,203 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbSelect from '../FwbSelect.vue'
+
+const countries = [
+  { value: 'us', name: 'United States' },
+  { value: 'ca', name: 'Canada' },
+]
+
+describe('FwbSelect', () => {
+  describe('label/select linkage', () => {
+    it('links label for to select id', () => {
+      const wrapper = mount(FwbSelect, { props: { label: 'Country', options: countries } })
+      const labelFor = wrapper.find('label').attributes('for')
+      const selectId = wrapper.find('select').attributes('id')
+      expect(labelFor).toBeDefined()
+      expect(labelFor).toBe(selectId)
+    })
+
+    it('uses a user-provided id for both the select and the label', () => {
+      const wrapper = mount(FwbSelect, {
+        props: { label: 'Country', options: countries },
+        attrs: { id: 'custom-id' },
+      })
+      expect(wrapper.find('select').attributes('id')).toBe('custom-id')
+      expect(wrapper.find('label').attributes('for')).toBe('custom-id')
+    })
+
+    it('renders no label when label prop is empty', () => {
+      const wrapper = mount(FwbSelect)
+      expect(wrapper.find('label').exists()).toBe(false)
+    })
+  })
+
+  describe('native attribute passthrough', () => {
+    it('disabled prop reaches the select', () => {
+      const wrapper = mount(FwbSelect, { props: { disabled: true } })
+      expect(wrapper.find('select').attributes('disabled')).toBeDefined()
+    })
+
+    it('required prop reaches the select', () => {
+      const wrapper = mount(FwbSelect, { props: { required: true } })
+      expect(wrapper.find('select').attributes('required')).toBeDefined()
+    })
+
+    it('extra attrs land on the select, not on the root wrapper', () => {
+      const wrapper = mount(FwbSelect, { attrs: { name: 'country', form: 'my-form' } })
+      expect(wrapper.find('select').attributes('name')).toBe('country')
+      expect(wrapper.find('select').attributes('form')).toBe('my-form')
+      expect(wrapper.element.getAttribute('name')).toBeNull()
+    })
+  })
+
+  describe('options', () => {
+    it('renders all options from the options prop plus the placeholder', () => {
+      const wrapper = mount(FwbSelect, { props: { options: countries } })
+      const options = wrapper.findAll('option')
+      expect(options).toHaveLength(3)
+      expect(options[1]!.text()).toBe('United States')
+      expect(options[2]!.text()).toBe('Canada')
+    })
+  })
+
+  describe('v-model', () => {
+    it('reflects the model value in the select', () => {
+      const wrapper = mount(FwbSelect, {
+        props: {
+          'modelValue': 'ca',
+          'onUpdate:modelValue': (v: string) => wrapper.setProps({ modelValue: v }),
+          'options': countries,
+        },
+      })
+      expect((wrapper.find('select').element as HTMLSelectElement).value).toBe('ca')
+    })
+
+    it('emits update:modelValue on change', async () => {
+      const wrapper = mount(FwbSelect, { props: { options: countries } })
+      await wrapper.find('select').setValue('us')
+      expect(wrapper.emitted('update:modelValue')?.[0]?.[0]).toBe('us')
+    })
+  })
+
+  describe('clearable', () => {
+    it('placeholder option is disabled and hidden by default', () => {
+      const wrapper = mount(FwbSelect)
+      const placeholder = wrapper.find('option[value=""]')
+      expect(placeholder.attributes('disabled')).toBeDefined()
+      expect(placeholder.attributes('hidden')).toBeDefined()
+    })
+
+    it('placeholder option is enabled and visible when clearable', () => {
+      const wrapper = mount(FwbSelect, { props: { clearable: true } })
+      const placeholder = wrapper.find('option[value=""]')
+      expect(placeholder.attributes('disabled')).toBeUndefined()
+      expect(placeholder.attributes('hidden')).toBeUndefined()
+    })
+  })
+
+  describe('aria-invalid', () => {
+    it('is "true" when validationStatus is "error"', () => {
+      const wrapper = mount(FwbSelect, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('select').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('is absent when validationStatus is "success"', () => {
+      const wrapper = mount(FwbSelect, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('select').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('is absent when validationStatus is not set', () => {
+      const wrapper = mount(FwbSelect)
+      expect(wrapper.find('select').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no helper or validationMessage slot is provided', () => {
+      const wrapper = mount(FwbSelect)
+      expect(wrapper.find('select').attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('points to the helper paragraph id when the helper slot is provided', () => {
+      const wrapper = mount(FwbSelect, { slots: { helper: 'Some help text' } })
+      const helperP = wrapper.find('p')
+      expect(wrapper.find('select').attributes('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbSelect, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Please select a country' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('select').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs space-joined when both slots are rendered', () => {
+      const wrapper = mount(FwbSelect, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Help text' },
+      })
+      const describedby = wrapper.find('select').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+
+    it('merges a user-passed aria-describedby with the slot IDs', () => {
+      const wrapper = mount(FwbSelect, {
+        attrs: { 'aria-describedby': 'external-id' },
+        slots: { helper: 'Help text' },
+      })
+      const ids = (wrapper.find('select').attributes('aria-describedby') ?? '').split(' ')
+      expect(ids).toContain('external-id')
+      expect(ids).toHaveLength(2)
+    })
+  })
+
+  describe('size classes', () => {
+    it('sm and xl apply different padding to the select', () => {
+      const sm = mount(FwbSelect, { props: { size: 'sm' } })
+      const xl = mount(FwbSelect, { props: { size: 'xl' } })
+      const smPadding = sm.find('select').classes().filter(c => /^p[xy]-/.test(c))
+      const xlPadding = xl.find('select').classes().filter(c => /^p[xy]-/.test(c))
+      expect(smPadding).not.toEqual(xlPadding)
+    })
+  })
+
+  describe('validation status classes', () => {
+    it('error state adds rose-colored classes to the select', () => {
+      const wrapper = mount(FwbSelect, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('select').classes().join(' ')).toContain('rose')
+    })
+
+    it('success state adds emerald-colored classes to the select', () => {
+      const wrapper = mount(FwbSelect, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('select').classes().join(' ')).toContain('emerald')
+    })
+
+    it('no validation state adds neither rose nor emerald classes to the select', () => {
+      const wrapper = mount(FwbSelect)
+      const classes = wrapper.find('select').classes().join(' ')
+      expect(classes).not.toContain('rose')
+      expect(classes).not.toContain('emerald')
+    })
+  })
+
+  describe('chevron slot', () => {
+    it('renders the default SVG chevron when no slot is provided', () => {
+      const wrapper = mount(FwbSelect)
+      expect(wrapper.find('svg').exists()).toBe(true)
+    })
+
+    it('replaces the default chevron when the slot is filled', () => {
+      const wrapper = mount(FwbSelect, {
+        slots: { chevron: '<span data-testid="custom-chevron" />' },
+      })
+      expect(wrapper.find('[data-testid="custom-chevron"]').exists()).toBe(true)
+      expect(wrapper.find('path[d="m1 1 4 4 4-4"]').exists()).toBe(false)
+    })
+  })
+})

--- a/src/components/FwbSelect/tests/Select.spec.ts
+++ b/src/components/FwbSelect/tests/Select.spec.ts
@@ -55,10 +55,9 @@ describe('FwbSelect', () => {
   describe('options', () => {
     it('renders all options from the options prop plus the placeholder', () => {
       const wrapper = mount(FwbSelect, { props: { options: countries } })
-      const options = wrapper.findAll('option')
-      expect(options).toHaveLength(3)
-      expect(options[1]!.text()).toBe('United States')
-      expect(options[2]!.text()).toBe('Canada')
+      expect(wrapper.findAll('option')).toHaveLength(3)
+      expect(wrapper.find('option[value="us"]').text()).toBe('United States')
+      expect(wrapper.find('option[value="ca"]').text()).toBe('Canada')
     })
   })
 
@@ -183,6 +182,28 @@ describe('FwbSelect', () => {
       const classes = wrapper.find('select').classes().join(' ')
       expect(classes).not.toContain('rose')
       expect(classes).not.toContain('emerald')
+    })
+  })
+
+  describe('class passthrough props', () => {
+    it('wrapperClass is applied to the root div', () => {
+      const wrapper = mount(FwbSelect, { props: { wrapperClass: 'my-wrapper' } })
+      expect(wrapper.classes()).toContain('my-wrapper')
+    })
+
+    it('labelClass is applied to the label element', () => {
+      const wrapper = mount(FwbSelect, { props: { label: 'Country', labelClass: 'my-label' } })
+      expect(wrapper.find('label').classes()).toContain('my-label')
+    })
+
+    it('class is applied to the select element', () => {
+      const wrapper = mount(FwbSelect, { props: { class: 'my-select' } })
+      expect(wrapper.find('select').classes()).toContain('my-select')
+    })
+
+    it('chevronClass is applied to the chevron container', () => {
+      const wrapper = mount(FwbSelect, { props: { chevronClass: 'my-chevron' } })
+      expect(wrapper.find('.pointer-events-none').classes()).toContain('my-chevron')
     })
   })
 

--- a/src/components/FwbSelect/types.ts
+++ b/src/components/FwbSelect/types.ts
@@ -1,6 +1,26 @@
-export { validationStatusMap, type ValidationStatus } from '@/types/form'
+import type { Autocomplete, FormElementSize, ValidationStatus } from '@/types/form'
+
+export type { ValidationStatus }
+export { validationStatusMap } from '@/types/form'
 
 export type OptionsType = {
   name: string
   value: string
+}
+
+export interface SelectProps {
+  autocomplete?: Autocomplete
+  chevronClass?: string | Record<string, boolean>
+  class?: string | Record<string, boolean>
+  clearable?: boolean
+  disabled?: boolean
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  options?: OptionsType[]
+  placeholder?: string
+  required?: boolean
+  size?: FormElementSize
+  underline?: boolean
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
 }


### PR DESCRIPTION
## Summary

Brings `FwbSelect` to parity with `FwbInput`, `FwbTextarea`, and `FwbFileInput`, adding typed size variants, validation states, accessibility wiring, a custom chevron slot, and proper native attribute passthrough.

## What's new

**New props**
- `chevronClass` — per-element class passthrough for the chevron icon container
- `class` — added to the `<select>` element directly (was not passable before without attr forwarding)
- `clearable` — shows an empty first option that resets the selection; without it the placeholder is `disabled` + `hidden`
- `labelClass`, `wrapperClass` — per-element class passthrough

**New slots**
- `validationMessage` — styled feedback message, linked via `aria-describedby`
- `chevron` — replaces the default SVG chevron icon

**Accessibility**
- `inheritAttrs: false` — extra attrs (e.g. `name`, `form`, `autofocus`) forward to `<select>`, not the root wrapper
- `aria-invalid="true"` set automatically on `validationStatus="error"`
- `aria-describedby` wired to `validationMessage`/`helper` slot IDs, merged with any user-provided value

**Architecture**
- New `useSelectAttributes` composable wrapping `useElementAttributes` — derives a stable `selectId` (respects user-provided `id`) and spreads attrs onto `<select>`
- `SelectProps` interface extracted to `types.ts` (mirrors `FwbInput` pattern)
- `useSelectClasses` rewritten to handle `wrapperClass`, `labelClass`, `chevronClass`, `class`, and all validation states in one place; uses `useMergeClasses` consistently

## Tests

25 new tests covering label/select linkage, user-provided id, attr passthrough, `aria-invalid`, `aria-describedby` (including slot merging and external id merging), v-model, options rendering, clearable behaviour, size classes, validation status classes, and chevron slot replacement.

## Docs

Full rewrite aligned with the `FwbInput` docs structure and [Flowbite select reference](https://flowbite.com/docs/forms/select/):
- Separate **Default** and **Clearable** sections
- **Sizes** with Small / Medium (default) / Large / Extra Large labels
- **Validation** — both states with `validationMessage` slot content
- **Slot - Chevron** — new section showing custom icon replacement
- **Slot - Helper**
- **Styling**
- Full API table including `chevronClass`; accessibility callout; `inheritAttrs` passthrough tip

## Breaking changes

**Custom chevron replaces native browser arrow**
`appearance-none` is now applied to `<select>`, hiding the browser's native dropdown arrow. The Flowbite SVG chevron is rendered in its place via the new `chevron` slot. Apps that relied on the native arrow will now see the Flowbite chevron.

**`inheritAttrs: false` — attr forwarding target changed**
Extra attributes previously fell through to the root `<div>`. They now forward to `<select>`. This is the correct behaviour but may affect apps that relied on attrs landing on the wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the select component guide with new/expanded examples for clearable mode, sizes (including extra large), success/error validation, helper/validation slots, custom chevron, and styling class props; added Props/Slots API tables and accessibility notes.
* **New Features**
  * Added support for a custom `chevron` slot.
  * Improved clearable behavior and added styling hooks for wrapper/label/select/chevron classes.
* **Validation & Accessibility**
  * Enhanced helper/validation rendering and corresponding `aria-describedby` / `aria-invalid` behavior.
* **Tests**
  * Added comprehensive rendering and behavior coverage, including slot/chevron behavior, attribute passthrough, and aria/class updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->