### PR TITLE
refactor: FwbAutocomplete - accessibility, attr passthrough, inputClass, and docs rewrite

### DIFF
--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -455,31 +455,31 @@ const countries = [
 `FwbAutocomplete` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `form`, `autofocus`) directly to the underlying `<input>` element via `FwbInput`.
 :::
 
-| Name | Type | Default | Description |
-| ---------------- | ----------------------------------------- | ------------------- | --------------------------------------------------- |
-| options | `T[]` | — | Array of options to display in the dropdown. Required. |
-| searchFields | `string[]` | `[]` | Fields within each option to search against. |
-| display | `string \| ((option: T) => string)` | `undefined` | Field name or function to render an option label. |
-| valueField | `string` | `undefined` | Field name used as the unique key for each option. |
-| placeholder | `string` | `'Search...'` | Placeholder text for the input. |
-| label | `string` | `undefined` | Label text rendered above the input. |
-| disabled | `boolean` | `false` | Disables the autocomplete. |
-| loading | `boolean` | `false` | Shows a loading indicator when `true`. |
-| loadingText | `string` | `'Loading...'` | Text shown in the dropdown while loading. |
-| noResultsText | `string` | `'No results found'` | Text shown when no options match the query. |
-| minChars | `number` | `0` | Minimum characters typed before filtering begins. |
-| remote | `boolean` | `false` | Disables local filtering; relies on `@search` to populate `options`. |
-| debounce | `number` | `300` | Delay in ms before emitting `search` when `remote` is `true`. |
-| size | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Controls padding and font size of the input. |
-| validationStatus | `'success' \| 'error'` | `undefined` | Applies success or error colour styles. |
-| class | `String \| Object` | `''` | Added to the input wrapper element. |
-| inputClass | `String \| Object` | `''` | Added to the `<input>` element (use for text and placeholder colours). |
-| wrapperClass | `String \| Object` | `''` | Added to the outer root `<div>`. |
-| labelClass | `String \| Object` | `''` | Added to the `<label>` element. |
-| dropdownClass | `String \| Object` | `''` | Added to the dropdown container. |
-| inputComponent | `Component` | `FwbInput` | Vue component used as the input field. |
-| inputProps | `Record<string, any>` | `{}` | Additional props forwarded to the input component. |
-| zIndex | `number` | `100` | Z-index of the dropdown overlay. |
+| Name             | Type                                | Default              | Description                                                            |
+| ---------------- | ----------------------------------- | -------------------- | ---------------------------------------------------------------------- |
+| options          | `T[]`                               | —                    | Array of options to display in the dropdown. Required.                 |
+| searchFields     | `string[]`                          | `[]`                 | Fields within each option to search against.                           |
+| display          | `string \| ((option: T) => string)` | `undefined`          | Field name or function to render an option label.                      |
+| valueField       | `string`                            | `undefined`          | Field name used as the unique key for each option.                     |
+| placeholder      | `string`                            | `'Search...'`        | Placeholder text for the input.                                        |
+| label            | `string`                            | `undefined`          | Label text rendered above the input.                                   |
+| disabled         | `boolean`                           | `false`              | Disables the autocomplete.                                             |
+| loading          | `boolean`                           | `false`              | Shows a loading indicator when `true`.                                 |
+| loadingText      | `string`                            | `'Loading...'`       | Text shown in the dropdown while loading.                              |
+| noResultsText    | `string`                            | `'No results found'` | Text shown when no options match the query.                            |
+| minChars         | `number`                            | `0`                  | Minimum characters typed before filtering begins.                      |
+| remote           | `boolean`                           | `false`              | Disables local filtering; relies on `@search` to populate `options`.   |
+| debounce         | `number`                            | `300`                | Delay in ms before emitting `search` when `remote` is `true`.          |
+| size             | `'sm' \| 'md' \| 'lg' \| 'xl'`      | `'md'`               | Controls padding and font size of the input.                           |
+| validationStatus | `'success' \| 'error'`              | `undefined`          | Applies success or error colour styles.                                |
+| class            | `String \| Object`                  | `''`                 | Added to the input wrapper element.                                    |
+| inputClass       | `String \| Object`                  | `''`                 | Added to the `<input>` element (use for text and placeholder colours). |
+| wrapperClass     | `String \| Object`                  | `''`                 | Added to the outer root `<div>`.                                       |
+| labelClass       | `String \| Object`                  | `''`                 | Added to the `<label>` element.                                        |
+| dropdownClass    | `String \| Object`                  | `''`                 | Added to the dropdown container.                                       |
+| inputComponent   | `Component`                         | `FwbInput`           | Vue component used as the input field.                                 |
+| inputProps       | `Record<string, any>`               | `{}`                 | Additional props forwarded to the input component.                     |
+| zIndex           | `number`                            | `100`                | Z-index of the dropdown overlay.                                       |
 
 :::tip Accessibility
 `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and merged with any `aria-describedby` value you pass as an attribute.
@@ -487,17 +487,17 @@ const countries = [
 
 ### FwbAutocomplete Events
 
-| Event | Parameters | Description |
-| ------------------- | ------------------- | ----------------------------------------------- |
-| update:modelValue | `value: T \| null` | Emitted when the selected value changes. |
-| select | `option: T` | Emitted when an option is clicked or confirmed with Enter. |
-| search | `query: string` | Emitted when the search query changes. |
+| Event             | Parameters         | Description                                                |
+| ----------------- | ------------------ | ---------------------------------------------------------- |
+| update:modelValue | `value: T \| null` | Emitted when the selected value changes.                   |
+| select            | `option: T`        | Emitted when an option is clicked or confirmed with Enter. |
+| search            | `query: string`    | Emitted when the search query changes.                     |
 
 ### FwbAutocomplete Slots
 
-| Name | Props | Description |
-| ----------------- | ----------------------------------------- | --------------------------------------------------------------- |
-| option | `{ option: T, index: number }` | Custom template for rendering each dropdown option. |
-| suffix | `{ loading: boolean, clear: () => void }` | Replaces the default search/clear/loading icons in the input. |
-| validationMessage | — | Validation feedback rendered below the input. |
-| helper | — | Helper text rendered below the input. |
+| Name              | Props                                     | Description                                                   |
+| ----------------- | ----------------------------------------- | ------------------------------------------------------------- |
+| option            | `{ option: T, index: number }`            | Custom template for rendering each dropdown option.           |
+| suffix            | `{ loading: boolean, clear: () => void }` | Replaces the default search/clear/loading icons in the input. |
+| validationMessage | —                                         | Validation feedback rendered below the input.                 |
+| helper            | —                                         | Helper text rendered below the input.                         |

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -1,27 +1,28 @@
 <script setup>
 import FwbAutocompleteExample from './autocomplete/examples/FwbAutocompleteExample.vue'
-import FwbAutocompleteExampleRemote from './autocomplete/examples/FwbAutocompleteExampleRemote.vue'
-import FwbAutocompleteExampleCustom from './autocomplete/examples/FwbAutocompleteExampleCustom.vue'
-import FwbAutocompleteExampleCustomInput from './autocomplete/examples/FwbAutocompleteExampleCustomInput.vue'
-import FwbAutocompleteExampleValidation from './autocomplete/examples/FwbAutocompleteExampleValidation.vue'
 import FwbAutocompleteExampleSize from './autocomplete/examples/FwbAutocompleteExampleSize.vue'
+import FwbAutocompleteExampleDisabled from './autocomplete/examples/FwbAutocompleteExampleDisabled.vue'
+import FwbAutocompleteExampleValidation from './autocomplete/examples/FwbAutocompleteExampleValidation.vue'
+import FwbAutocompleteExampleHelper from './autocomplete/examples/FwbAutocompleteExampleHelper.vue'
+import FwbAutocompleteExampleSuffix from './autocomplete/examples/FwbAutocompleteExampleSuffix.vue'
+import FwbAutocompleteExampleCustom from './autocomplete/examples/FwbAutocompleteExampleCustom.vue'
+import FwbAutocompleteExampleRemote from './autocomplete/examples/FwbAutocompleteExampleRemote.vue'
+import FwbAutocompleteExampleCustomInput from './autocomplete/examples/FwbAutocompleteExampleCustomInput.vue'
+import FwbAutocompleteExampleStyling from './autocomplete/examples/FwbAutocompleteExampleStyling.vue'
 </script>
 
-# Vue Autocomplete - Flowbite
+# Autocomplete - Flowbite Vue
 
-Get started with the autocomplete component to allow users to search and select from a list of options with real-time filtering and keyboard navigation.
+#### Get started with the autocomplete component to allow users to search and select from a list of options with real-time filtering and keyboard navigation
 
 ---
-
-:::tip
-Based on the Flowbite design system: [https://flowbite.com/docs/forms/input-field/](https://flowbite.com/docs/forms/input-field/)
-:::
 
 The autocomplete component supports real-time filtering, keyboard navigation, remote data loading, and custom option rendering. Built with Tailwind CSS utility classes and fully compatible with dark mode.
 
 ## Default
 
 <fwb-autocomplete-example />
+
 ```vue
 <template>
   <fwb-autocomplete
@@ -47,11 +48,291 @@ const countries = [
   { id: 5, name: 'United Kingdom', code: 'UK' },
 ]
 </script>
+
 ```
 
-## Remote Data with Debounce
+## Sizes
+
+<fwb-autocomplete-example-size />
+
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selected1"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Small"
+    size="sm"
+    placeholder="Small autocomplete..."
+  />
+  <fwb-autocomplete
+    v-model="selected2"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Medium (default)"
+    size="md"
+    placeholder="Medium autocomplete..."
+  />
+  <fwb-autocomplete
+    v-model="selected3"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Large"
+    size="lg"
+    placeholder="Large autocomplete..."
+  />
+  <fwb-autocomplete
+    v-model="selected4"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Extra Large"
+    size="xl"
+    placeholder="Extra Large autocomplete..."
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selected1 = ref(null)
+const selected2 = ref(null)
+const selected3 = ref(null)
+const selected4 = ref(null)
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+</script>
+
+```
+
+## Disabled
+
+<fwb-autocomplete-example-disabled />
+
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selected"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    disabled
+    label="Select a country"
+    placeholder="Search disabled..."
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selected = ref(null)
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+</script>
+
+```
+
+## Validation
+
+- Set validation status via `validationStatus` prop, which accepts `'success'` or `'error'`.
+- Add validation message via `validationMessage` slot.
+
+<fwb-autocomplete-example-validation />
+
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selected1"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Select a country"
+    validation-status="success"
+  >
+    <template #validationMessage>
+      <span class="font-medium">Well done!</span> Your selection looks good.
+    </template>
+  </fwb-autocomplete>
+  <hr class="mt-4 border-0">
+  <fwb-autocomplete
+    v-model="selected2"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Select a country"
+    validation-status="error"
+  >
+    <template #validationMessage>
+      <span class="font-medium">Oh, snap!</span> Please select a country.
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selected1 = ref(null)
+const selected2 = ref(null)
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+</script>
+
+```
+
+## Slot - Helper
+
+<fwb-autocomplete-example-helper />
+
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selected"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Select a country"
+    placeholder="Search countries..."
+  >
+    <template #helper>
+      We'll never share your selection. Read our
+      <a href="#" class="font-medium text-blue-600 hover:underline dark:text-blue-500">
+        Privacy Policy
+      </a>.
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selected = ref(null)
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+</script>
+
+```
+
+## Slot - Suffix
+
+Replace the default search/clear/loading icons by providing content in the `suffix` slot.
+
+<fwb-autocomplete-example-suffix />
+
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selected"
+    :options="countries"
+    :search-fields="['name']"
+    display="name"
+    label="Select a country"
+    placeholder="Search countries..."
+  >
+    <template #suffix>
+      <svg
+        aria-hidden="true"
+        class="size-5 opacity-40"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+      </svg>
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selected = ref(null)
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+</script>
+
+```
+
+## Slot - Option
+
+Customise how each dropdown option is rendered using the `option` slot.
+
+<fwb-autocomplete-example-custom />
+
+```vue
+<template>
+  <fwb-autocomplete
+    v-model="selectedUser"
+    :options="users"
+    :search-fields="['name', 'email']"
+    display="name"
+    label="Select user"
+    placeholder="Search users..."
+  >
+    <template #option="{ option }">
+      <div class="flex items-center">
+        <img
+          :src="option.avatar"
+          :alt="option.name"
+          class="w-8 h-8 rounded-full mr-3"
+        >
+        <div>
+          <div class="font-medium">{{ option.name }}</div>
+          <div class="text-sm text-gray-500">{{ option.email }}</div>
+        </div>
+      </div>
+    </template>
+  </fwb-autocomplete>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbAutocomplete } from 'flowbite-vue'
+
+const selectedUser = ref(null)
+const users = [
+  { id: 1, name: 'John Doe', email: 'john@example.com', avatar: 'https://i.pravatar.cc/150?img=1' },
+  { id: 2, name: 'Jane Smith', email: 'jane@example.com', avatar: 'https://i.pravatar.cc/150?img=2' },
+]
+</script>
+
+```
+
+## Remote Data
+
+Use `remote` with `@search` and `debounce` to fetch options from an API as the user types. Local filtering is disabled in remote mode.
 
 <fwb-autocomplete-example-remote />
+
 ```vue
 <template>
   <fwb-autocomplete
@@ -92,34 +373,29 @@ const searchCountries = async (query) => {
   try {
     const response = await fetch(`https://restcountries.com/v3.1/name/${query}`)
     const data = await response.json()
-    
     countries.value = data.slice(0, 10).map(country => ({
       name: country.name.common,
-      capital: country.capital?.[0] || 'N/A',
       region: country.region,
-      population: country.population,
       flag: country.flag,
     }))
-  } catch (err) {
+  } catch {
     countries.value = []
   } finally {
     loading.value = false
   }
 }
 </script>
+
 ```
 
-## Custom Input Components
+## Custom Input
+
+Replace the default `FwbInput` with any Vue input component via the `inputComponent` prop. Extra props for the input component are forwarded via `inputProps`.
 
 <fwb-autocomplete-example-custom-input />
 
-The autocomplete component provides maximum flexibility by allowing you to use any Vue input component through the `inputComponent` and `inputProps` props.
-
-### Using Custom Input Components
-
 ```vue
 <template>
-  <!-- Use any Vue input component -->
   <fwb-autocomplete
     v-model="selected"
     :options="options"
@@ -130,273 +406,98 @@ The autocomplete component provides maximum flexibility by allowing you to use a
       class: 'custom-styling'
     }"
   />
+</template>
 
-  <!-- Customize FwbInput with props -->
+```
+
+## Styling
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-autocomplete-example-styling />
+
+```vue
+<template>
   <fwb-autocomplete
     v-model="selected"
-    :options="options"
-    :input-props="{
-      size: 'lg',
-      class: 'border-purple-300 focus:border-purple-500'
-    }"
-  />
-</template>
-```
-
-### Input Component Props
-
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `inputComponent` | `Component` | `FwbInput` | The Vue input component to use |
-| `inputProps` | `Record<string, any>` | `{}` | Additional props to pass to the input component |
-
-The component automatically passes through standard props like `placeholder`, `disabled`, `size`, `label`, etc., and you can provide additional props via `inputProps`.
-
-## Custom Option Template
-
-<fwb-autocomplete-example-custom />
-```vue
-<template>
-  <fwb-autocomplete
-    v-model="selectedUser"
-    :options="users"
-    :search-fields="['name', 'email']"
-    display="name"
-    label="Select user"
-    placeholder="Search users..."
-  >
-    <template #option="{ option }">
-      <div class="flex items-center">
-        <img
-          :src="option.avatar"
-          :alt="option.name"
-          class="w-8 h-8 rounded-full mr-3"
-        >
-        <div>
-          <div class="font-medium">{{ option.name }}</div>
-          <div class="text-sm text-gray-500">{{ option.email }}</div>
-        </div>
-      </div>
-    </template>
-  </fwb-autocomplete>
-</template>
-
-<script setup>
-import { ref } from 'vue'
-import { FwbAutocomplete } from 'flowbite-vue'
-
-const selectedUser = ref(null)
-const users = [
-  {
-    id: 1,
-    name: 'John Doe',
-    email: 'john@example.com',
-    avatar: 'https://i.pravatar.cc/150?img=1'
-  },
-  {
-    id: 2,
-    name: 'Jane Smith',
-    email: 'jane@example.com',
-    avatar: 'https://i.pravatar.cc/150?img=2'
-  },
-]
-</script>
-```
-
-## Validation
-
-<fwb-autocomplete-example-validation />
-```vue
-<template>
-  <fwb-autocomplete
-    v-model="selectedCountry"
     :options="countries"
     :search-fields="['name']"
+    class="bg-amber-100 dark:bg-green-900 border-2 border-amber-500 has-[input:focus]:border-amber-900 dark:border-green-600 dark:has-[input:focus]:border-green-400 has-[input:focus]:ring-amber-300 dark:has-[input:focus]:ring-green-800"
     display="name"
-    label="Country *"
-    placeholder="Select a country..."
-    :validation-status="validationStatus"
-  >
-    <template #validationMessage>
-      Please select a country
-    </template>
-    <template #helper>
-      Choose the country where you reside
-    </template>
-  </fwb-autocomplete>
-</template>
-
-<script setup>
-import { ref, computed } from 'vue'
-import { FwbAutocomplete } from 'flowbite-vue'
-
-const selectedCountry = ref(null)
-const countries = [
-  { id: 1, name: 'United States', code: 'US' },
-  { id: 2, name: 'Canada', code: 'CA' },
-  { id: 3, name: 'France', code: 'FR' },
-]
-
-const validationStatus = computed(() => {
-  return selectedCountry.value ? 'success' : 'error'
-})
-</script>
-```
-
-## Sizes
-
-<fwb-autocomplete-example-size />
-```vue
-<template>
-  <div class="space-y-4">
-    <fwb-autocomplete
-      v-model="selected1"
-      :options="countries"
-      :search-fields="['name']"
-      display="name"
-      label="Small"
-      size="sm"
-      placeholder="Small autocomplete..."
-    />
-    
-    <fwb-autocomplete
-      v-model="selected2"
-      :options="countries"
-      :search-fields="['name']"
-      display="name"
-      label="Medium (default)"
-      size="md"
-      placeholder="Medium autocomplete..."
-    />
-    
-    <fwb-autocomplete
-      v-model="selected3"
-      :options="countries"
-      :search-fields="['name']"
-      display="name"
-      label="Large"
-      size="lg"
-      placeholder="Large autocomplete..."
-    />
-  </div>
+    dropdown-class="border-amber-300 dark:border-green-700"
+    input-class="text-amber-900 dark:text-green-100 placeholder:text-amber-500 dark:placeholder:text-green-500"
+    label="Select a country"
+    label-class="text-xl font-bold text-amber-900 dark:text-green-200"
+    placeholder="Search countries..."
+    wrapper-class="bg-amber-300 dark:bg-green-800 border-2 border-amber-700 dark:border-green-400 rounded-lg p-3"
+  />
 </template>
 
 <script setup>
 import { ref } from 'vue'
 import { FwbAutocomplete } from 'flowbite-vue'
 
-const selected1 = ref(null)
-const selected2 = ref(null)
-const selected3 = ref(null)
-
+const selected = ref(null)
 const countries = [
   { id: 1, name: 'United States', code: 'US' },
   { id: 2, name: 'Canada', code: 'CA' },
   { id: 3, name: 'France', code: 'FR' },
 ]
 </script>
+
 ```
 
-## API
+## Autocomplete component API
 
-### Props
+### FwbAutocomplete Props
+
+:::tip Native attribute passthrough
+`FwbAutocomplete` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `form`, `autofocus`) directly to the underlying `<input>` element via `FwbInput`.
+:::
 
 | Name | Type | Default | Description |
-|------|------|---------|-------------|
-| `modelValue` | `T \| null` | `null` | The currently selected option |
-| `options` | `T[]` | `[]` | Array of options to display in dropdown |
-| `loading` | `boolean` | `false` | Shows loading indicator when true |
-| `placeholder` | `string` | `'Search...'` | Placeholder text for input field |
-| `disabled` | `boolean` | `false` | Disables the autocomplete component |
-| `valueField` | `string` | `undefined` | Field name to use as unique identifier for options |
-| `searchFields` | `string[]` | `[]` | Array of field names to search within each option |
-| `loadingText` | `string` | `'Loading...'` | Text to display when loading |
-| `noResultsText` | `string` | `'No results found'` | Text to display when no results match |
-| `minChars` | `number` | `0` | Minimum characters required before filtering |
-| `remote` | `boolean` | `false` | Whether to fetch data remotely (disables local filtering) |
-| `debounce` | `number` | `300` | Debounce delay in milliseconds for search events |
-| `display` | `string \| ((option: T) => string)` | `undefined` | Field name or function to generate display text for options |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of the input component |
-| `validationStatus` | `'success' \| 'error'` | `undefined` | Validation status for styling |
-| `class` | `string \| Record<string, boolean>` | `''` | Additional CSS classes for the component |
-| `wrapperClass` | `string \| Record<string, boolean>` | `''` | CSS classes for the wrapper element |
-| `labelClass` | `string \| Record<string, boolean>` | `''` | CSS classes for the label element |
-| `dropdownClass` | `string \| Record<string, boolean>` | `''` | CSS classes for the dropdown container |
-| `label` | `string` | `undefined` | Label text for the input field |
-| `inputComponent` | `Component` | `FwbInput` | Vue component to use as the input field |
-| `inputProps` | `Record<string, any>` | `{}` | Additional props to pass to the input component |
-| `zIndex` | `number` | `100` | Z-index value for the dropdown overlay |
+| ---------------- | ----------------------------------------- | ------------------- | --------------------------------------------------- |
+| options | `T[]` | — | Array of options to display in the dropdown. Required. |
+| searchFields | `string[]` | `[]` | Fields within each option to search against. |
+| display | `string \| ((option: T) => string)` | `undefined` | Field name or function to render an option label. |
+| valueField | `string` | `undefined` | Field name used as the unique key for each option. |
+| placeholder | `string` | `'Search...'` | Placeholder text for the input. |
+| label | `string` | `undefined` | Label text rendered above the input. |
+| disabled | `boolean` | `false` | Disables the autocomplete. |
+| loading | `boolean` | `false` | Shows a loading indicator when `true`. |
+| loadingText | `string` | `'Loading...'` | Text shown in the dropdown while loading. |
+| noResultsText | `string` | `'No results found'` | Text shown when no options match the query. |
+| minChars | `number` | `0` | Minimum characters typed before filtering begins. |
+| remote | `boolean` | `false` | Disables local filtering; relies on `@search` to populate `options`. |
+| debounce | `number` | `300` | Delay in ms before emitting `search` when `remote` is `true`. |
+| size | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Controls padding and font size of the input. |
+| validationStatus | `'success' \| 'error'` | `undefined` | Applies success or error colour styles. |
+| class | `String \| Object` | `''` | Added to the input wrapper element. |
+| inputClass | `String \| Object` | `''` | Added to the `<input>` element (use for text and placeholder colours). |
+| wrapperClass | `String \| Object` | `''` | Added to the outer root `<div>`. |
+| labelClass | `String \| Object` | `''` | Added to the `<label>` element. |
+| dropdownClass | `String \| Object` | `''` | Added to the dropdown container. |
+| inputComponent | `Component` | `FwbInput` | Vue component used as the input field. |
+| inputProps | `Record<string, any>` | `{}` | Additional props forwarded to the input component. |
+| zIndex | `number` | `100` | Z-index of the dropdown overlay. |
 
-### Input Component Props
+:::tip Accessibility
+`aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and merged with any `aria-describedby` value you pass as an attribute.
+:::
 
-The autocomplete component uses `FwbInput` by default and passes through all standard input props. For a complete list of available input props, see the [Input component documentation](./input.md#input-component-api).
-
-Common input props that can be passed through:
-- `placeholder` - Input placeholder text
-- `disabled` - Disable the input
-- `size` - Input size (`'sm'` | `'md'` | `'lg'`)
-- `label` - Input label text
-- `class` - CSS classes for styling
-- `inputClass` - CSS classes for the input element
-- `wrapperClass` - CSS classes for the input wrapper
-- `labelClass` - CSS classes for the label
-
-You can also pass additional props via the `inputProps` prop or use a completely different input component via the `inputComponent` prop.
-
-### Events
+### FwbAutocomplete Events
 
 | Event | Parameters | Description |
-|-------|------------|-------------|
-| `update:modelValue` | `value: T \| null` | Emitted when the selected value changes |
-| `select` | `option: T` | Emitted when an option is selected |
-| `search` | `query: string` | Emitted when the search query changes |
+| ------------------- | ------------------- | ----------------------------------------------- |
+| update:modelValue | `value: T \| null` | Emitted when the selected value changes. |
+| select | `option: T` | Emitted when an option is clicked or confirmed with Enter. |
+| search | `query: string` | Emitted when the search query changes. |
 
-### Slots
+### FwbAutocomplete Slots
 
-| Slot | Props | Description |
-|------|-------|-------------|
-| `option` | `{ option: T, index: number }` | Custom template for rendering dropdown options |
-| `suffix` | `{ loading: boolean, clear: () => void }` | Custom suffix content (overrides default loading/clear icons) |
-| `validationMessage` | - | Custom validation message content |
-| `helper` | - | Helper text content below the input |
-
-### Examples
-
-#### Basic Usage
-```vue
-<fwb-autocomplete
-  v-model="selected"
-  :options="countries"
-  :search-fields="['name']"
-  display="name"
-  placeholder="Search countries..."
-/>
-```
-
-#### Remote Data with Custom Input Props
-```vue
-<fwb-autocomplete
-  v-model="selected"
-  :options="users"
-  :loading="loading"
-  :search-fields="['name', 'email']"
-  display="name"
-  remote
-  :debounce="500"
-  :input-props="{
-    size: 'lg',
-    class: 'border-blue-300 focus:border-blue-500'
-  }"
-  @search="fetchUsers"
-/>
-```
-
-#### Custom Input Component
-```vue
-<fwb-autocomplete
-  v-model="selected"
-  :options="options"
-  :input-component="MyCustomInput"
-  :input-props="{ theme: 'rounded', prefixIcon: 'search' }"
-/>
-```
+| Name | Props | Description |
+| ----------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| option | `{ option: T, index: number }` | Custom template for rendering each dropdown option. |
+| suffix | `{ loading: boolean, clear: () => void }` | Replaces the default search/clear/loading icons in the input. |
+| validationMessage | — | Validation feedback rendered below the input. |
+| helper | — | Helper text rendered below the input. |

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleDisabled.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleDisabled.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selected"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      disabled
+      label="Select a country"
+      placeholder="Search disabled..."
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+
+const selected = ref<typeof countries[0] | null>(null)
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleHelper.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleHelper.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selected"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Select a country"
+      placeholder="Search countries..."
+    >
+      <template #helper>
+        We'll never share your selection. Read our
+        <a
+          href="#"
+          class="font-medium text-blue-600 hover:underline dark:text-blue-500"
+        >Privacy Policy</a>.
+      </template>
+    </fwb-autocomplete>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+
+const selected = ref<typeof countries[0] | null>(null)
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleSize.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleSize.vue
@@ -1,36 +1,41 @@
 <template>
-  <div class="vp-raw">
-    <div class="space-y-4">
-      <fwb-autocomplete
-        v-model="selected1"
-        :options="countries"
-        :search-fields="['name']"
-        display="name"
-        label="Small"
-        size="sm"
-        placeholder="Small autocomplete..."
-      />
-
-      <fwb-autocomplete
-        v-model="selected2"
-        :options="countries"
-        :search-fields="['name']"
-        display="name"
-        label="Medium (default)"
-        size="md"
-        placeholder="Medium autocomplete..."
-      />
-
-      <fwb-autocomplete
-        v-model="selected3"
-        :options="countries"
-        :search-fields="['name']"
-        display="name"
-        label="Large"
-        size="lg"
-        placeholder="Large autocomplete..."
-      />
-    </div>
+  <div class="gap-2 grid vp-raw">
+    <fwb-autocomplete
+      v-model="selected1"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Small"
+      placeholder="Small autocomplete..."
+      size="sm"
+    />
+    <fwb-autocomplete
+      v-model="selected2"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Medium (default)"
+      placeholder="Medium autocomplete..."
+      size="md"
+    />
+    <fwb-autocomplete
+      v-model="selected3"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Large"
+      placeholder="Large autocomplete..."
+      size="lg"
+    />
+    <fwb-autocomplete
+      v-model="selected4"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Extra Large"
+      placeholder="Extra Large autocomplete..."
+      size="xl"
+    />
   </div>
 </template>
 
@@ -50,4 +55,5 @@ const countries = [
 const selected1 = ref<typeof countries[0] | null>(null)
 const selected2 = ref<typeof countries[0] | null>(null)
 const selected3 = ref<typeof countries[0] | null>(null)
+const selected4 = ref<typeof countries[0] | null>(null)
 </script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleStyling.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleStyling.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selected"
+      :options="countries"
+      :search-fields="['name']"
+      class="bg-amber-100 dark:bg-green-900 border-2 border-amber-500 has-[input:focus]:border-amber-900 dark:border-green-600 dark:has-[input:focus]:border-green-400 has-[input:focus]:ring-amber-300 dark:has-[input:focus]:ring-green-800"
+      display="name"
+      dropdown-class="border-amber-300 dark:border-green-700"
+      input-class="text-amber-900 dark:text-green-100 placeholder:text-amber-500 dark:placeholder:text-green-500"
+      label="Select a country"
+      label-class="text-xl font-bold text-amber-900 dark:text-green-200"
+      placeholder="Search countries..."
+      wrapper-class="bg-amber-300 dark:bg-green-800 border-2 border-amber-700 dark:border-green-400 rounded-lg p-3"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+
+const selected = ref<typeof countries[0] | null>(null)
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleSuffix.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleSuffix.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="vp-raw">
+    <fwb-autocomplete
+      v-model="selected"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Select a country"
+      placeholder="Search countries..."
+    >
+      <template #suffix>
+        <svg
+          aria-hidden="true"
+          class="size-5 opacity-40"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </template>
+    </fwb-autocomplete>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbAutocomplete } from '../../../../src/index'
+
+const countries = [
+  { id: 1, name: 'United States', code: 'US' },
+  { id: 2, name: 'Canada', code: 'CA' },
+  { id: 3, name: 'France', code: 'FR' },
+]
+
+const selected = ref<typeof countries[0] | null>(null)
+</script>

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleValidation.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleValidation.vue
@@ -1,44 +1,37 @@
 <template>
   <div class="vp-raw">
     <fwb-autocomplete
-      v-model="selectedCountry"
+      v-model="selected1"
       :options="countries"
       :search-fields="['name']"
       display="name"
-      label="Country *"
-      placeholder="Select a country..."
-      :validation-status="validationStatus"
+      label="Select a country"
+      placeholder="Search countries..."
+      validation-status="success"
     >
       <template #validationMessage>
-        <span v-if="!selectedCountry">Please select a country</span>
-        <span v-else-if="showValidation">This field is required for shipping</span>
-      </template>
-      <template #helper>
-        Choose the country where you reside
+        <span class="font-medium">Well done!</span> Your selection looks good.
       </template>
     </fwb-autocomplete>
-
-    <div
-      v-if="selectedCountry"
-      class="mt-4 p-3 bg-green-50 border border-green-200 rounded-lg"
+    <hr class="mt-4 border-0">
+    <fwb-autocomplete
+      v-model="selected2"
+      :options="countries"
+      :search-fields="['name']"
+      display="name"
+      label="Select a country"
+      placeholder="Search countries..."
+      validation-status="error"
     >
-      <p class="text-sm text-green-700">
-        ✓ Selected: {{ selectedCountry.name }} ({{ selectedCountry.code }})
-      </p>
-    </div>
-
-    <button
-      v-if="selectedCountry"
-      class="mt-2 px-3 py-1 text-xs bg-blue-500 text-white rounded hover:bg-blue-600"
-      @click="toggleValidationMessage"
-    >
-      {{ showValidation ? 'Hide' : 'Show' }} persistent validation
-    </button>
+      <template #validationMessage>
+        <span class="font-medium">Oh, snap!</span> Please select a country.
+      </template>
+    </fwb-autocomplete>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 
 import { FwbAutocomplete } from '../../../../src/index'
 
@@ -46,18 +39,8 @@ const countries = [
   { id: 1, name: 'United States', code: 'US' },
   { id: 2, name: 'Canada', code: 'CA' },
   { id: 3, name: 'France', code: 'FR' },
-  { id: 4, name: 'Germany', code: 'DE' },
-  { id: 5, name: 'United Kingdom', code: 'UK' },
 ]
 
-const selectedCountry = ref<typeof countries[0] | null>(null)
-const showValidation = ref(false)
-
-const validationStatus = computed(() => {
-  return selectedCountry.value ? 'success' : 'error'
-})
-
-const toggleValidationMessage = () => {
-  showValidation.value = !showValidation.value
-}
+const selected1 = ref<typeof countries[0] | null>(null)
+const selected2 = ref<typeof countries[0] | null>(null)
 </script>

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -11,8 +11,7 @@
         v-bind="{
           placeholder,
           disabled,
-          size,
-          label,
+          ...(inputComponent === FwbInput ? { size, label } : {}),
           ...inputProps,
           ...$attrs,
         }"
@@ -33,7 +32,7 @@
             <div class="flex items-center">
               <div
                 v-if="loading"
-                class="border-2 border-t-transparent border-blue-600 rounded-full w-4 h-4 animate-spin"
+                class="border-2 border-blue-600 border-t-transparent rounded-full w-4 h-4 animate-spin"
                 data-testid="fwb-autocomplete-loading-spinner"
               />
               <svg
@@ -87,7 +86,7 @@
         >
           <div class="flex justify-center items-center gap-2">
             <div
-              class="border-2 border-t-transparent border-blue-600 rounded-full w-4 h-4 animate-spin"
+              class="border-2 border-blue-600 border-t-transparent rounded-full w-4 h-4 animate-spin"
             />
             {{ loadingText }}
           </div>
@@ -105,7 +104,7 @@
           v-for="(option, index) in filteredOptions"
           v-else
           :key="getOptionKey(option)"
-          :class="getDropdownItemClasses(highlightedIndex === index)"
+          :class="getDropdownItemClasses(highlightedIndex === index, props.size)"
           :data-testid="`fwb-autocomplete-option-${index}`"
           class="fwb-autocomplete-option"
           @mousedown="isSelectingOption = true"
@@ -166,7 +165,7 @@ const props = withDefaults(
   defineProps<
     AutocompleteProps<T> & {
       inputComponent?: Component
-      inputProps?: Record<string, any>
+      inputProps?: Record<string, unknown>
     }
   >(),
   {

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -15,7 +15,7 @@
           ...(inputComponent === FwbInput ? { size, label } : {}),
           ...inputProps,
           ...$attrs,
-          inputClass,
+          ...(inputClass ? { inputClass } : {}),
           'aria-describedby': ariaDescribedby,
         }"
         :label-class="labelClass"
@@ -38,22 +38,29 @@
                 class="border-2 border-current border-t-transparent rounded-full w-4 h-4 animate-spin opacity-60"
                 data-testid="fwb-autocomplete-loading-spinner"
               />
-              <svg
+              <button
                 v-else-if="inputValue"
-                class="w-5 h-5 opacity-40 hover:opacity-70 cursor-pointer"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+                type="button"
+                aria-label="Clear selection"
+                class="opacity-40 hover:opacity-70 cursor-pointer"
                 data-testid="fwb-autocomplete-clear-button"
                 @click="clear"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  class="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
               <svg
                 v-else
                 class="w-5 h-5 opacity-40"
@@ -80,6 +87,7 @@
             (filteredOptions.length > 0 || loading || noResultsFound)
         "
         :class="dropdownClasses"
+        :style="{ zIndex: props.zIndex }"
         data-testid="fwb-autocomplete-dropdown"
       >
         <div

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -11,6 +11,7 @@
         v-bind="{
           placeholder,
           disabled,
+          class: props.class,
           ...(inputComponent === FwbInput ? { size, label } : {}),
           ...inputProps,
           ...$attrs,
@@ -32,12 +33,12 @@
             <div class="flex items-center">
               <div
                 v-if="loading"
-                class="border-2 border-blue-600 border-t-transparent rounded-full w-4 h-4 animate-spin"
+                class="border-2 border-current border-t-transparent rounded-full w-4 h-4 animate-spin opacity-60"
                 data-testid="fwb-autocomplete-loading-spinner"
               />
               <svg
                 v-else-if="inputValue"
-                class="w-5 h-5 text-gray-400 hover:text-gray-600 cursor-pointer"
+                class="w-5 h-5 opacity-40 hover:opacity-70 cursor-pointer"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -53,7 +54,7 @@
               </svg>
               <svg
                 v-else
-                class="w-5 h-5 text-gray-400"
+                class="w-5 h-5 opacity-40"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -86,7 +87,7 @@
         >
           <div class="flex justify-center items-center gap-2">
             <div
-              class="border-2 border-blue-600 border-t-transparent rounded-full w-4 h-4 animate-spin"
+              class="border-2 border-current border-t-transparent rounded-full w-4 h-4 animate-spin opacity-60"
             />
             {{ loadingText }}
           </div>
@@ -126,14 +127,14 @@
 
     <p
       v-if="$slots.validationMessage"
-      class="mt-2 text-red-600 dark:text-red-500 text-sm"
+      :class="validationMessageClass"
       data-testid="fwb-autocomplete-validation-message"
     >
       <slot name="validationMessage" />
     </p>
     <p
       v-if="$slots.helper"
-      class="mt-2 text-gray-500 dark:text-gray-400 text-sm"
+      :class="helperMessageClass"
       data-testid="fwb-autocomplete-helper-text"
     >
       <slot name="helper" />
@@ -182,6 +183,7 @@ const props = withDefaults(
     wrapperClass: '',
     labelClass: '',
     dropdownClass: '',
+    validationStatus: undefined,
     inputComponent: FwbInput,
     inputProps: () => ({}),
     zIndex: 100,
@@ -201,7 +203,9 @@ const {
   wrapperClasses,
   dropdownClasses,
   getDropdownItemClasses,
+  helperMessageClass,
   messageClasses,
+  validationMessageClass,
 } = useAutocompleteClasses(toRefs(props))
 
 const filteredOptions = computed(() => {

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -15,6 +15,8 @@
           ...(inputComponent === FwbInput ? { size, label } : {}),
           ...inputProps,
           ...$attrs,
+          inputClass,
+          'aria-describedby': ariaDescribedby,
         }"
         :label-class="labelClass"
         :validation-status="validationStatus"
@@ -127,6 +129,7 @@
 
     <p
       v-if="$slots.validationMessage"
+      :id="validationMessageId"
       :class="validationMessageClass"
       data-testid="fwb-autocomplete-validation-message"
     >
@@ -134,6 +137,7 @@
     </p>
     <p
       v-if="$slots.helper"
+      :id="helperId"
       :class="helperMessageClass"
       data-testid="fwb-autocomplete-helper-text"
     >
@@ -144,13 +148,13 @@
 
 <script setup lang="ts" generic="T extends Record<string, any>">
 import {
-  type Component,
   computed,
   nextTick,
   onMounted,
   onUnmounted,
   ref,
   toRefs,
+  useId,
   watch,
 } from 'vue'
 
@@ -160,15 +164,12 @@ import { useAutocompleteClasses } from './composables/useAutocompleteClasses'
 
 import type { AutocompleteEmits, AutocompleteProps } from './types'
 
-defineOptions({ inheritAttrs: true })
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(
-  defineProps<
-    AutocompleteProps<T> & {
-      inputComponent?: Component
-      inputProps?: Record<string, unknown>
-    }
-  >(),
+  defineProps<AutocompleteProps<T>>(),
   {
     placeholder: 'Search...',
     disabled: false,
@@ -180,9 +181,11 @@ const props = withDefaults(
     debounce: 300,
     size: 'md',
     class: '',
+    inputClass: '',
     wrapperClass: '',
     labelClass: '',
     dropdownClass: '',
+    loading: false,
     validationStatus: undefined,
     inputComponent: FwbInput,
     inputProps: () => ({}),
@@ -207,6 +210,10 @@ const {
   messageClasses,
   validationMessageClass,
 } = useAutocompleteClasses(toRefs(props))
+
+const _id = useId()
+const autocompleteId = computed(() => _id)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(autocompleteId)
 
 const filteredOptions = computed(() => {
   if (props.remote || inputValue.value.length < props.minChars) {

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -1,53 +1,62 @@
 import { computed, type Ref } from 'vue'
 
+import type { InputSize } from '@/components/FwbInput/types'
+
 import { useMergeClasses } from '@/composables/useMergeClasses'
 
 const baseWrapperClasses = 'relative w-full'
-const baseDropdownItemClasses = 'px-4 py-3 cursor-pointer transition-colors duration-150 border-b border-gray-200 dark:border-gray-600 last:border-b-0'
+
+const baseDropdownClasses = 'z-100 absolute bg-white dark:bg-gray-800 shadow-lg mt-1 border border-gray-300 dark:border-gray-600 rounded-lg w-full max-h-60 overflow-y-auto'
+const baseDropdownItemClasses = 'px-4 py-3 border-gray-200 dark:border-gray-600 border-b last:border-b-0 text-gray-900 dark:text-white transition-colors duration-150 cursor-pointer'
 const highlightedDropdownItemClasses = 'bg-blue-50 dark:bg-blue-900/20'
 const hoverDropdownItemClasses = 'hover:bg-gray-50 dark:hover:bg-gray-700'
-const baseMessageClasses = 'px-4 py-3 text-center text-gray-500 dark:text-gray-400'
 
-export interface UseAutocompleteClassesProps {
-  class?: Ref<string | Record<string, boolean> | undefined>
-  wrapperClass?: Ref<string | Record<string, boolean> | undefined>
-  labelClass?: Ref<string | Record<string, boolean> | undefined>
-  dropdownClass?: Ref<string | Record<string, boolean> | undefined>
-  zIndex?: Ref<number | undefined>
+const baseMessageClasses = 'px-4 py-3 text-gray-500 dark:text-gray-400 text-center'
+
+const dropdownItemSizeClasses: Record<string, string> = {
+  sm: 'px-2.5 py-2 text-sm',
+  md: 'px-3 py-2.5 text-sm',
+  lg: 'px-3.5 py-3 text-base',
+  xl: 'px-4 py-3.5 text-base',
 }
 
-export function useAutocompleteClasses (props: UseAutocompleteClassesProps) {
-  const wrapperClasses = computed(() => {
-    return useMergeClasses([
-      baseWrapperClasses,
-      typeof props.wrapperClass?.value === 'string' ? props.wrapperClass.value : '',
-    ])
-  })
+export interface UseAutocompleteClassesProps {
+  class: Ref<string | Record<string, boolean>>
+  dropdownClass: Ref<string | Record<string, boolean>>
+  labelClass: Ref<string | Record<string, boolean>>
+  wrapperClass: Ref<string | Record<string, boolean>>
+  zIndex: Ref<number>
+}
 
-  const baseDropdownClasses = computed(() =>
-    `absolute z-[${props.zIndex?.value}] w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto`,
-  )
+export function useAutocompleteClasses (props: UseAutocompleteClassesProps): {
+  dropdownClasses: Ref<string>
+  getDropdownItemClasses: (isHighlighted: boolean, size: InputSize) => string
+  messageClasses: Ref<string>
+  wrapperClasses: Ref<string>
+} {
+  const wrapperClasses = computed(() => useMergeClasses([
+    baseWrapperClasses,
+    props.wrapperClass.value,
+  ]))
 
-  const dropdownClasses = computed(() => {
-    return useMergeClasses([
-      baseDropdownClasses.value,
-      typeof props.dropdownClass?.value === 'string' ? props.dropdownClass.value : '',
-    ])
-  })
+  const dropdownClasses = computed(() => useMergeClasses([
+    baseDropdownClasses,
+    `z-[${props.zIndex.value}]`,
+    props.dropdownClass.value,
+  ]))
 
-  const getDropdownItemClasses = (isHighlighted: boolean) => {
-    return useMergeClasses([
-      baseDropdownItemClasses,
-      isHighlighted ? highlightedDropdownItemClasses : hoverDropdownItemClasses,
-    ])
-  }
+  const getDropdownItemClasses = (isHighlighted: boolean, size: InputSize) => useMergeClasses([
+    baseDropdownItemClasses,
+    isHighlighted ? highlightedDropdownItemClasses : hoverDropdownItemClasses,
+    dropdownItemSizeClasses[size] ?? '',
+  ])
 
   const messageClasses = computed(() => baseMessageClasses)
 
   return {
-    wrapperClasses,
     dropdownClasses,
     getDropdownItemClasses,
     messageClasses,
+    wrapperClasses,
   }
 }

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -1,8 +1,7 @@
 import { computed, type Ref } from 'vue'
 
-import type { InputSize } from '@/components/FwbInput/types'
-
 import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type FormElementSize, type ValidationStatus, validationStatusMap } from '@/types/form'
 
 const baseWrapperClasses = 'relative w-full'
 
@@ -12,6 +11,10 @@ const highlightedDropdownItemClasses = 'bg-blue-50 dark:bg-blue-900/20'
 const hoverDropdownItemClasses = 'hover:bg-gray-50 dark:hover:bg-gray-700'
 
 const baseMessageClasses = 'px-4 py-3 text-gray-500 dark:text-gray-400 text-center'
+const defaultHelperClasses = 'mt-2 text-gray-500 dark:text-gray-400 text-sm'
+const defaultValidationMessageClasses = 'mt-2 text-sm'
+const errorTextClasses = 'text-rose-600 dark:text-rose-500'
+const successTextClasses = 'text-emerald-600 dark:text-emerald-500'
 
 const dropdownItemSizeClasses: Record<string, string> = {
   sm: 'px-2.5 py-2 text-sm',
@@ -21,17 +24,19 @@ const dropdownItemSizeClasses: Record<string, string> = {
 }
 
 export interface UseAutocompleteClassesProps {
-  class: Ref<string | Record<string, boolean>>
   dropdownClass: Ref<string | Record<string, boolean>>
   labelClass: Ref<string | Record<string, boolean>>
+  validationStatus: Ref<ValidationStatus | undefined>
   wrapperClass: Ref<string | Record<string, boolean>>
   zIndex: Ref<number>
 }
 
 export function useAutocompleteClasses (props: UseAutocompleteClassesProps): {
   dropdownClasses: Ref<string>
-  getDropdownItemClasses: (isHighlighted: boolean, size: InputSize) => string
+  getDropdownItemClasses: (isHighlighted: boolean, size: FormElementSize) => string
+  helperMessageClass: Ref<string>
   messageClasses: Ref<string>
+  validationMessageClass: Ref<string>
   wrapperClasses: Ref<string>
 } {
   const wrapperClasses = computed(() => useMergeClasses([
@@ -45,7 +50,7 @@ export function useAutocompleteClasses (props: UseAutocompleteClassesProps): {
     props.dropdownClass.value,
   ]))
 
-  const getDropdownItemClasses = (isHighlighted: boolean, size: InputSize) => useMergeClasses([
+  const getDropdownItemClasses = (isHighlighted: boolean, size: FormElementSize) => useMergeClasses([
     baseDropdownItemClasses,
     isHighlighted ? highlightedDropdownItemClasses : hoverDropdownItemClasses,
     dropdownItemSizeClasses[size] ?? '',
@@ -53,10 +58,25 @@ export function useAutocompleteClasses (props: UseAutocompleteClassesProps): {
 
   const messageClasses = computed(() => baseMessageClasses)
 
+  const validationMessageClass = computed(() => useMergeClasses([
+    defaultValidationMessageClasses,
+    props.validationStatus.value === validationStatusMap.Success
+      ? successTextClasses
+      : props.validationStatus.value === validationStatusMap.Error
+        ? errorTextClasses
+        : '',
+  ]))
+
+  const helperMessageClass = computed(() => useMergeClasses([
+    defaultHelperClasses,
+  ]))
+
   return {
     dropdownClasses,
     getDropdownItemClasses,
+    helperMessageClass,
     messageClasses,
+    validationMessageClass,
     wrapperClasses,
   }
 }

--- a/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
+++ b/src/components/FwbAutocomplete/composables/useAutocompleteClasses.ts
@@ -5,7 +5,7 @@ import { type FormElementSize, type ValidationStatus, validationStatusMap } from
 
 const baseWrapperClasses = 'relative w-full'
 
-const baseDropdownClasses = 'z-100 absolute bg-white dark:bg-gray-800 shadow-lg mt-1 border border-gray-300 dark:border-gray-600 rounded-lg w-full max-h-60 overflow-y-auto'
+const baseDropdownClasses = 'absolute bg-white dark:bg-gray-800 shadow-lg mt-1 border border-gray-300 dark:border-gray-600 rounded-lg w-full max-h-60 overflow-y-auto'
 const baseDropdownItemClasses = 'px-4 py-3 border-gray-200 dark:border-gray-600 border-b last:border-b-0 text-gray-900 dark:text-white transition-colors duration-150 cursor-pointer'
 const highlightedDropdownItemClasses = 'bg-blue-50 dark:bg-blue-900/20'
 const hoverDropdownItemClasses = 'hover:bg-gray-50 dark:hover:bg-gray-700'
@@ -28,7 +28,6 @@ export interface UseAutocompleteClassesProps {
   labelClass: Ref<string | Record<string, boolean>>
   validationStatus: Ref<ValidationStatus | undefined>
   wrapperClass: Ref<string | Record<string, boolean>>
-  zIndex: Ref<number>
 }
 
 export function useAutocompleteClasses (props: UseAutocompleteClassesProps): {
@@ -46,7 +45,6 @@ export function useAutocompleteClasses (props: UseAutocompleteClassesProps): {
 
   const dropdownClasses = computed(() => useMergeClasses([
     baseDropdownClasses,
-    `z-[${props.zIndex.value}]`,
     props.dropdownClass.value,
   ]))
 

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -123,12 +123,11 @@ describe('FwbAutocomplete', () => {
     })
 
     const clearButton = wrapper.find('[data-testid="fwb-autocomplete-clear-button"]')
-    if (clearButton.exists()) {
-      await clearButton.trigger('click')
-      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-      const emittedEvents = wrapper.emitted('update:modelValue') as Array<[unknown]>
-      expect(emittedEvents[emittedEvents.length - 1]?.[0]).toBe(null)
-    }
+    expect(clearButton.exists()).toBe(true)
+    await clearButton.trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    const emittedEvents = wrapper.emitted('update:modelValue') as Array<[unknown]>
+    expect(emittedEvents[emittedEvents.length - 1]?.[0]).toBe(null)
   })
 
   it('shows loading state', async () => {
@@ -500,7 +499,7 @@ describe('FwbAutocomplete', () => {
 
     const dropdown = wrapper.find('[data-testid="fwb-autocomplete-dropdown"]')
     expect(dropdown.exists()).toBe(true)
-    expect(dropdown.classes()).toContain('z-[200]')
+    expect((dropdown.element as HTMLElement).style.zIndex).toBe('200')
   })
 
   it('uses default z-index when not specified', async () => {
@@ -518,7 +517,7 @@ describe('FwbAutocomplete', () => {
 
     const dropdown = wrapper.find('[data-testid="fwb-autocomplete-dropdown"]')
     expect(dropdown.exists()).toBe(true)
-    expect(dropdown.classes()).toContain('z-[100]')
+    expect((dropdown.element as HTMLElement).style.zIndex).toBe('100')
   })
 
   describe('native attribute passthrough', () => {
@@ -568,6 +567,19 @@ describe('FwbAutocomplete', () => {
       const ids = describedby.split(' ')
       expect(ids).toHaveLength(2)
       ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+
+    it('preserves external aria-describedby merged with slot IDs', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        attrs: { 'aria-describedby': 'external-id' },
+        props: { options: mockOptions, searchFields: ['name'], validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Help text' },
+      })
+      const describedby = wrapper.find('input').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(3)
+      expect(ids).toContain('external-id')
+      ids.filter(id => id !== 'external-id').forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
     })
   })
 })

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -520,4 +520,54 @@ describe('FwbAutocomplete', () => {
     expect(dropdown.exists()).toBe(true)
     expect(dropdown.classes()).toContain('z-[100]')
   })
+
+  describe('native attribute passthrough', () => {
+    it('extra attrs land on the input, not on the root wrapper', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        attrs: { name: 'country', form: 'my-form' },
+        props: { options: mockOptions, searchFields: ['name'] },
+      })
+      expect(wrapper.find('input').attributes('name')).toBe('country')
+      expect(wrapper.find('input').attributes('form')).toBe('my-form')
+      expect(wrapper.element.getAttribute('name')).toBeNull()
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no helper or validationMessage slot is provided', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'] },
+      })
+      expect(wrapper.find('input').attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('points to the helper paragraph id when the helper slot is provided', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'] },
+        slots: { helper: 'Some help text' },
+      })
+      const helperP = wrapper.find('[data-testid="fwb-autocomplete-helper-text"]')
+      expect(wrapper.find('input').attributes('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'], validationStatus: 'error' },
+        slots: { validationMessage: 'Please select a country' },
+      })
+      const msgP = wrapper.find('[data-testid="fwb-autocomplete-validation-message"]')
+      expect(wrapper.find('input').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs space-joined when both slots are rendered', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'], validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Help text' },
+      })
+      const describedby = wrapper.find('input').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+  })
 })

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -126,8 +126,8 @@ describe('FwbAutocomplete', () => {
     if (clearButton.exists()) {
       await clearButton.trigger('click')
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
-      const emittedEvents = wrapper.emitted('update:modelValue') as Array<any>
-      expect(emittedEvents[emittedEvents.length - 1][0]).toBe(null)
+      const emittedEvents = wrapper.emitted('update:modelValue') as Array<[unknown]>
+      expect(emittedEvents[emittedEvents.length - 1]?.[0]).toBe(null)
     }
   })
 
@@ -288,9 +288,9 @@ describe('FwbAutocomplete', () => {
   })
 
   it('handles custom display function', async () => {
-    const displayFn = vi.fn((option: any) => `${option.name} (${option.code})`)
+    const displayFn = vi.fn((option: Record<string, unknown>) => `${String(option['name'])} (${String(option['code'])})`)
 
-    const wrapper = mount(FwbAutocomplete, {
+    mount(FwbAutocomplete, {
       props: {
         options: mockOptions,
         searchFields: ['name'],

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -5,33 +5,33 @@ export type AutocompleteSize = FormElementSize
 export type { ValidationStatus }
 
 export interface AutocompleteProps<T = Record<string, any>> {
-  modelValue?: T | null
-  options: T[]
-  loading?: boolean
-  placeholder?: string
-  disabled?: boolean
-  valueField?: string
-  searchFields?: string[]
-  loadingText?: string
-  noResultsText?: string
-  minChars?: number
-  remote?: boolean
-  debounce?: number
-  display?: string | ((option: T) => string)
-  size?: AutocompleteSize
-  validationStatus?: ValidationStatus
   class?: string | Record<string, boolean>
-  wrapperClass?: string | Record<string, boolean>
-  label?: string
-  labelClass?: string | Record<string, boolean>
+  debounce?: number
+  disabled?: boolean
+  display?: string | ((option: T) => string)
   dropdownClass?: string | Record<string, boolean>
   inputComponent?: Component
   inputProps?: Record<string, any>
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  loading?: boolean
+  loadingText?: string
+  minChars?: number
+  modelValue?: T | null
+  noResultsText?: string
+  options: T[]
+  placeholder?: string
+  remote?: boolean
+  searchFields?: string[]
+  size?: AutocompleteSize
+  validationStatus?: ValidationStatus
+  valueField?: string
+  wrapperClass?: string | Record<string, boolean>
   zIndex?: number
 }
 
 export interface AutocompleteEmits<T = Record<string, any>> {
-  (e: 'update:modelValue', value: T | null): void
-  (e: 'select', option: T): void
   (e: 'search', query: string): void
+  (e: 'select', option: T): void
+  (e: 'update:modelValue', value: T | null): void
 }

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -7,6 +7,7 @@ export type { ValidationStatus }
 export interface AutocompleteProps<T = Record<string, any>> {
   class?: string | Record<string, boolean>
   debounce?: number
+  inputClass?: string | Record<string, boolean>
   disabled?: boolean
   display?: string | ((option: T) => string)
   dropdownClass?: string | Record<string, boolean>


### PR DESCRIPTION
## Summary

Brings `FwbAutocomplete` to parity with the other refactored form components, adding proper `inheritAttrs: false` attr forwarding, `aria-describedby` wiring, an `inputClass` prop for direct `<input>` styling, and a full docs rewrite.

## What's new

**New props**
- `inputClass` — added to the inner `<input>` element via FwbInput; previously there was no way to set placeholder or text colours without reaching into `inputProps`

**Accessibility**
- `inheritAttrs: false` — extra attrs (e.g. `name`, `form`, `autofocus`) now forward to `<input>` via FwbInput, not the root wrapper
- `aria-describedby` wired to `validationMessage`/`helper` slot IDs via `useFormFieldIds`, merged with any user-provided value

**Architecture**
- Redundant `defineProps` intersection removed — `inputComponent` and `inputProps` were declared in both `AutocompleteProps` and the `defineProps<T & { ... }>()` call
- Explicit `loading: false` default added to `withDefaults`

## Tests

31 tests (up from 26), covering the existing behaviour plus: `inheritAttrs: false` attr passthrough (attrs land on `<input>`, not the root wrapper), and `aria-describedby` wiring (absent with no slots, helper slot ID, validationMessage slot ID, and both IDs space-joined when both slots are present).

## Docs

Full rewrite aligned with the other refactored form component docs:
- **Default**, **Sizes** (now includes Extra Large / `xl`), **Disabled** (new), **Validation** (simplified to static success/error states), **Slot - Helper** (new, split out from Validation), **Slot - Suffix** (new), **Slot - Option** (renamed from "Custom Option Template"), **Remote Data**, **Custom Input**, **Styling** (new, amber/green theme demonstrating `wrapperClass`, `labelClass`, `class`, `inputClass`, `dropdownClass`)
- Full API table restructured into `### FwbAutocomplete Props/Events/Slots` subsections; `:::tip` callouts for native attr passthrough and `aria-describedby` behaviour

## Breaking changes

**`inheritAttrs: false` — attr forwarding target changed**
Extra attributes previously fell through to the root `<div>`. They now forward to `<input>` via FwbInput. This is the correct behaviour but may affect apps that relied on attrs landing on the wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `validationMessage` slot for custom validation feedback.
  * Introduced `helper` and `suffix` slots, plus new `inputClass` styling support.
  * Added an “Extra Large” (XL) size option.

* **Documentation**
  * Reorganized the Autocomplete guide with clearer API sections and expanded examples (disabled, validation, remote data, custom input, styling, and option/slot customization).

* **Improvements**
  * Enhanced accessibility for helper/validation messaging and improved dropdown/loading visual styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->