### PR TITLE
refactor: FwbRange - accessibility, validation, size variants, and docs rewrite

### DIFF
--- a/docs/components/range.md
+++ b/docs/components/range.md
@@ -24,7 +24,7 @@ Original reference: [https://flowbite.com/docs/forms/range/](https://flowbite.co
 <fwb-range-example />
 ```vue
 <template>
-  <fwb-range v-model="value" />
+  <fwb-range v-model.number="value" />
   <pre>Current value: {{ value }}</pre>
 </template>
 
@@ -43,7 +43,7 @@ const value = ref(50)
 ```vue
 <template>
   <fwb-range
-    v-model="value"
+    v-model.number="value"
     disabled
     label="Disabled range"
   />
@@ -56,7 +56,7 @@ const value = ref(50)
 ```vue
 <template>
   <fwb-range
-    v-model="value"
+    v-model.number="value"
     :min="5"
     :max="15"
     label="Min-Max range"
@@ -70,7 +70,7 @@ const value = ref(50)
 ```vue
 <template>
   <fwb-range
-    v-model="value"
+    v-model.number="value"
     :steps="5"
     label="Steps range"
   />

--- a/docs/components/range.md
+++ b/docs/components/range.md
@@ -1,12 +1,16 @@
 <script setup>
 import FwbRangeExample from './range/examples/FwbRangeExample.vue'
 import FwbRangeExampleDisabled from './range/examples/FwbRangeExampleDisabled.vue'
+import FwbRangeExampleHelper from './range/examples/FwbRangeExampleHelper.vue'
 import FwbRangeExampleMinMax from './range/examples/FwbRangeExampleMinMax.vue'
 import FwbRangeExampleSize from './range/examples/FwbRangeExampleSize.vue'
 import FwbRangeExampleSteps from './range/examples/FwbRangeExampleSteps.vue'
+import FwbRangeExampleStyling from './range/examples/FwbRangeExampleStyling.vue'
+import FwbRangeExampleValidation from './range/examples/FwbRangeExampleValidation.vue'
 </script>
 
-# Vue Toggle Range - Flowbite
+# Vue Range - Flowbite
+
 #### Get started with the range component to receive a number from the user anywhere from 1 to 100 by sliding form control horizontally based on multiple options
 
 ---
@@ -30,6 +34,7 @@ import { FwbRange } from 'flowbite-vue'
 
 const value = ref(50)
 </script>
+
 ```
 
 ## Disabled state
@@ -77,25 +82,99 @@ const value = ref(50)
 <fwb-range-example-size />
 ```vue
 <template>
+  <fwb-range v-model.number="value" label="Small" size="sm" />
+  <fwb-range v-model.number="value" label="Medium" size="md" />
+  <fwb-range v-model.number="value" label="Large" size="lg" />
+  <fwb-range v-model.number="value" label="Extra Large" size="xl" />
+</template>
+```
+
+## Validation
+
+Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the range.
+
+<fwb-range-example-validation />
+```vue
+<template>
+  <fwb-range v-model.number="value" label="Volume (success)" validation-status="success">
+    <template #validationMessage>
+      <span class="font-medium">Looks good!</span> Volume is set correctly.
+    </template>
+  </fwb-range>
+  <fwb-range v-model.number="value" label="Volume (error)" validation-status="error">
+    <template #validationMessage>
+      <span class="font-medium">Too loud!</span> Please lower the volume.
+    </template>
+  </fwb-range>
+</template>
+```
+
+## Helper text
+
+Use the `helper` slot to show a hint below the range input.
+
+<fwb-range-example-helper />
+```vue
+<template>
+  <fwb-range v-model.number="value" label="Brightness">
+    <template #helper>
+      Adjust screen brightness between 0 and 100.
+    </template>
+  </fwb-range>
+</template>
+```
+
+## Styling
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-range-example-styling />
+```vue
+<template>
   <fwb-range
     v-model.number="value"
-    label="Small"
-    size="sm"
-  />
-  <fwb-range
-    v-model.number="value"
-    label="Medium"
-    size="md"
-  />
-  <fwb-range
-    v-model.number="value"
-    label="Large"
-    size="lg"
-  />
-  <fwb-range
-    v-model.number="value"
-    label="Extra Large"
-    size="xl"
+    label="Volume"
+    class="bg-amber-200 dark:bg-green-900"
+    label-class="text-xl font-bold text-amber-900 dark:text-green-200"
+    wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3 [--fwb-range-thumb-color:var(--color-amber-600)] dark:[--fwb-range-thumb-color:var(--color-green-400)]"
   />
 </template>
 ```
+
+## Range component API
+
+### FwbRange Props
+
+:::tip Native attribute passthrough
+`FwbRange` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `form`, `aria-label`) directly to the `<input type="range">` element.
+:::
+
+| Name             | Type                           | Default     | Description                                                                        |
+| ---------------- | ------------------------------ | ----------- | ---------------------------------------------------------------------------------- |
+| class            | `String \| Object`             | `''`        | Added to the `<input>` element.                                                    |
+| disabled         | `Boolean`                      | `false`     | Disables the range input.                                                          |
+| label            | `String`                       | `''`        | Label text rendered above the input. When empty, no `<label>` element is rendered. |
+| labelClass       | `String \| Object`             | `''`        | Added to the `<label>` element.                                                    |
+| max              | `Number`                       | `100`       | Maximum value.                                                                     |
+| min              | `Number`                       | `0`         | Minimum value.                                                                     |
+| modelValue       | `Number`                       | `50`        | The current value (use with `v-model`).                                            |
+| size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`      | Controls track height and thumb size.                                              |
+| steps            | `Number`                       | `1`         | Step increment between values.                                                     |
+| validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error colour styles to the label.                               |
+| wrapperClass     | `String \| Object`             | `''`        | Added to the outer root `<div>`.                                                   |
+
+:::tip Thumb colour
+The thumb colour defaults to blue-500 and can be overridden by setting the `--fwb-range-thumb-color` CSS custom property on any ancestor element. With Tailwind v4, use an arbitrary class on `wrapperClass`:
+`[--fwb-range-thumb-color:var(--color-amber-600)]`
+:::
+
+:::tip Accessibility
+`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
+:::
+
+### FwbRange Slots
+
+| Name              | Description                                                                  |
+| ----------------- | ---------------------------------------------------------------------------- |
+| helper            | Helper text rendered below the range input.                                  |
+| validationMessage | Validation feedback rendered below the input (styled by `validationStatus`). |

--- a/docs/components/range.md
+++ b/docs/components/range.md
@@ -28,7 +28,7 @@ Original reference: [https://flowbite.com/docs/forms/range/](https://flowbite.co
 import { ref } from 'vue'
 import { FwbRange } from 'flowbite-vue'
 
-const value = ref(10)
+const value = ref(50)
 </script>
 ```
 
@@ -37,7 +37,11 @@ const value = ref(10)
 <fwb-range-example-disabled />
 ```vue
 <template>
-  <fwb-range v-model="value" disabled label="Disabled range" />
+  <fwb-range
+    v-model="value"
+    disabled
+    label="Disabled range"
+  />
 </template>
 ```
 
@@ -46,7 +50,12 @@ const value = ref(10)
 <fwb-range-example-min-max />
 ```vue
 <template>
-  <fwb-range v-model="value" :max="15" :min="5" label="Min-max range" />
+  <fwb-range
+    v-model="value"
+    :min="5"
+    :max="15"
+    label="Min-Max range"
+  />
 </template>
 ```
 
@@ -55,7 +64,11 @@ const value = ref(10)
 <fwb-range-example-steps />
 ```vue
 <template>
-  <fwb-range v-model="value" :steps="5" label="Steps range" />
+  <fwb-range
+    v-model="value"
+    :steps="5"
+    label="Steps range"
+  />
 </template>
 ```
 
@@ -64,8 +77,25 @@ const value = ref(10)
 <fwb-range-example-size />
 ```vue
 <template>
-  <fwb-range v-model="value1" label="Small range" size="sm" />
-  <fwb-range v-model="value2" label="Medium range" size="md" />
-  <fwb-range v-model="value3" label="Large range" size="lg" />
+  <fwb-range
+    v-model.number="value"
+    label="Small"
+    size="sm"
+  />
+  <fwb-range
+    v-model.number="value"
+    label="Medium"
+    size="md"
+  />
+  <fwb-range
+    v-model.number="value"
+    label="Large"
+    size="lg"
+  />
+  <fwb-range
+    v-model.number="value"
+    label="Extra Large"
+    size="xl"
+  />
 </template>
 ```

--- a/docs/components/range/examples/FwbRangeExample.vue
+++ b/docs/components/range/examples/FwbRangeExample.vue
@@ -10,5 +10,5 @@ import { ref } from 'vue'
 
 import { FwbRange } from '../../../../src/index'
 
-const value = ref(10)
+const value = ref(50)
 </script>

--- a/docs/components/range/examples/FwbRangeExampleDisabled.vue
+++ b/docs/components/range/examples/FwbRangeExampleDisabled.vue
@@ -13,5 +13,5 @@ import { ref } from 'vue'
 
 import { FwbRange } from '../../../../src/index'
 
-const value = ref(10)
+const value = ref(50)
 </script>

--- a/docs/components/range/examples/FwbRangeExampleHelper.vue
+++ b/docs/components/range/examples/FwbRangeExampleHelper.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="vp-raw">
+    <fwb-range
+      v-model.number="value"
+      label="Brightness"
+    >
+      <template #helper>
+        Adjust screen brightness between 0 and 100.
+      </template>
+    </fwb-range>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRange } from '../../../../src/index'
+
+const value = ref(50)
+</script>

--- a/docs/components/range/examples/FwbRangeExampleMinMax.vue
+++ b/docs/components/range/examples/FwbRangeExampleMinMax.vue
@@ -4,7 +4,7 @@
       v-model.number="value"
       :max="15"
       :min="5"
-      label="Min-max range"
+      label="Min-Max range"
     />
     <pre>Selected value: {{ value }}</pre>
   </div>

--- a/docs/components/range/examples/FwbRangeExampleSize.vue
+++ b/docs/components/range/examples/FwbRangeExampleSize.vue
@@ -1,19 +1,24 @@
 <template>
-  <div class="vp-raw grid gap-3">
+  <div class="gap-3 grid vp-raw">
     <fwb-range
-      v-model.number="value1"
-      label="Small range"
+      v-model.number="value"
+      label="Small"
       size="sm"
     />
     <fwb-range
-      v-model.number="value2"
-      label="Medium range"
+      v-model.number="value"
+      label="Medium"
       size="md"
     />
     <fwb-range
-      v-model.number="value3"
-      label="Large range"
+      v-model.number="value"
+      label="Large"
       size="lg"
+    />
+    <fwb-range
+      v-model.number="value"
+      label="Extra Large"
+      size="xl"
     />
   </div>
 </template>
@@ -23,7 +28,5 @@ import { ref } from 'vue'
 
 import { FwbRange } from '../../../../src/index'
 
-const value1 = ref(10)
-const value2 = ref(10)
-const value3 = ref(10)
+const value = ref(50)
 </script>

--- a/docs/components/range/examples/FwbRangeExampleSteps.vue
+++ b/docs/components/range/examples/FwbRangeExampleSteps.vue
@@ -14,5 +14,5 @@ import { ref } from 'vue'
 
 import { FwbRange } from '../../../../src/index'
 
-const value = ref(10)
+const value = ref(50)
 </script>

--- a/docs/components/range/examples/FwbRangeExampleStyling.vue
+++ b/docs/components/range/examples/FwbRangeExampleStyling.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="vp-raw">
+    <fwb-range
+      v-model.number="value"
+      label="Volume"
+      class="bg-amber-200 dark:bg-green-900"
+      label-class="text-xl font-bold text-amber-900 dark:text-green-200"
+      wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3 [--fwb-range-thumb-color:var(--color-amber-600)] dark:[--fwb-range-thumb-color:var(--color-green-400)]"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRange } from '../../../../src/index'
+
+const value = ref(50)
+</script>

--- a/docs/components/range/examples/FwbRangeExampleValidation.vue
+++ b/docs/components/range/examples/FwbRangeExampleValidation.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="flex flex-col gap-4 vp-raw">
+    <fwb-range
+      v-model.number="value"
+      label="Volume (success)"
+      validation-status="success"
+    >
+      <template #validationMessage>
+        <span class="font-medium">Looks good!</span> Volume is set correctly.
+      </template>
+    </fwb-range>
+    <fwb-range
+      v-model.number="value"
+      label="Volume (error)"
+      validation-status="error"
+    >
+      <template #validationMessage>
+        <span class="font-medium">Too loud!</span> Please lower the volume.
+      </template>
+    </fwb-range>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRange } from '../../../../src/index'
+
+const value = ref(50)
+</script>

--- a/src/components/FwbRange/FwbRange.vue
+++ b/src/components/FwbRange/FwbRange.vue
@@ -1,72 +1,92 @@
 <template>
-  <label class="flex flex-col">
-    <span :class="labelClasses">{{ label }}</span>
+  <div :class="wrapperClass">
+    <label
+      v-if="label"
+      :for="rangeId"
+      :class="labelClass"
+    >{{ label }}</label>
     <input
+      v-bind="rangeAttributes"
       v-model="model"
-      :step="steps"
-      :min="min"
-      :max="max"
+      :aria-describedby="ariaDescribedby"
+      :aria-invalid="validationStatus === 'error' ? true : undefined"
+      :class="rangeClass"
       :disabled="disabled"
+      :max="max"
+      :min="min"
+      :step="steps"
       type="range"
-      :class="rangeClasses"
     >
-  </label>
+    <p
+      v-if="$slots.validationMessage"
+      :id="validationMessageId"
+      :class="validationMessageClass"
+    >
+      <slot name="validationMessage" />
+    </p>
+    <p
+      v-if="$slots.helper"
+      :id="helperId"
+      :class="helperMessageClass"
+    >
+      <slot name="helper" />
+    </p>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, toRefs } from 'vue'
+import { toRefs } from 'vue'
 
 import { useRangeClasses } from './composables/useRangeClasses'
+import type { RangeProps } from './types'
 
-import type { FormElementSize } from '@/types/form'
+import { useElementAttributes } from '@/composables/useElementAttributes'
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
 
-interface RangeProps {
-  disabled?: boolean
-  label?: string
-  max?: number
-  min?: number
-  modelValue?: number
-  size?: FormElementSize
-  steps?: number
-}
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<RangeProps>(), {
+  class: '',
   disabled: false,
-  label: 'Range slider',
+  label: '',
+  labelClass: '',
   max: 100,
   min: 0,
-  modelValue: 50,
   size: 'md',
   steps: 1,
+  validationStatus: undefined,
+  wrapperClass: '',
 })
 
-const emit = defineEmits(['update:modelValue'])
+const model = defineModel<number>({ default: 50 })
 
-const model = computed({
-  get () {
-    return props.modelValue
-  },
-  set (val) {
-    emit('update:modelValue', val)
-  },
-})
+const { elementId: rangeId, elementAttributes: rangeAttributes } = useElementAttributes()
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(rangeId)
 
-const { rangeClasses, labelClasses } = useRangeClasses(toRefs(props))
+const {
+  helperMessageClass,
+  labelClass,
+  rangeClass,
+  validationMessageClass,
+  wrapperClass,
+} = useRangeClasses(toRefs(props))
 </script>
 
 <style lang="css">
-@reference '@/style.css';
-
 .fwb-range-input::-moz-range-thumb {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  @apply bg-blue-500 border-none rounded-full;
+  background-color: var(--fwb-range-thumb-color, var(--color-blue-500));
+  border: none;
+  border-radius: 9999px;
 }
 .fwb-range-input::-webkit-slider-thumb {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  @apply bg-blue-500 border-none rounded-full;
+  background-color: var(--fwb-range-thumb-color, var(--color-blue-500));
+  border: none;
+  border-radius: 9999px;
 }
 </style>

--- a/src/components/FwbRange/FwbRange.vue
+++ b/src/components/FwbRange/FwbRange.vue
@@ -1,8 +1,6 @@
 <template>
   <label class="flex flex-col">
-    <span
-      :class="labelClasses"
-    >{{ label }}</span>
+    <span :class="labelClasses">{{ label }}</span>
     <input
       v-model="model"
       :step="steps"
@@ -56,13 +54,19 @@ const model = computed({
 const { rangeClasses, labelClasses } = useRangeClasses(toRefs(props))
 </script>
 
-<style scoped>
-input[type="range"].range-lg::-moz-range-thumb {
-  height: 1.5rem;
-  width: 1.5rem;
+<style lang="css">
+@reference '@/style.css';
+
+.fwb-range-input::-moz-range-thumb {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  @apply bg-blue-500 border-none rounded-full;
 }
-input[type="range"].range-sm::-moz-range-thumb {
-  height: 1rem;
-  width: 1rem;
+.fwb-range-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  @apply bg-blue-500 border-none rounded-full;
 }
 </style>

--- a/src/components/FwbRange/FwbRange.vue
+++ b/src/components/FwbRange/FwbRange.vue
@@ -38,6 +38,7 @@
 import { toRefs } from 'vue'
 
 import { useRangeClasses } from './composables/useRangeClasses'
+
 import type { RangeProps } from './types'
 
 import { useElementAttributes } from '@/composables/useElementAttributes'

--- a/src/components/FwbRange/composables/useRangeClasses.ts
+++ b/src/components/FwbRange/composables/useRangeClasses.ts
@@ -1,11 +1,16 @@
 import { computed, type Ref } from 'vue'
 
-import type { FormElementSize } from '@/types/form'
-
 import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type FormElementSize, type ValidationStatus, validationStatusMap } from '@/types/form'
 
-const rangeDefaultClasses = 'fwb-range-input w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700'
-const rangeLabelClasses = 'block mb-2 text-sm font-medium text-gray-900 dark:text-white'
+const defaultRangeClasses = 'fwb-range-input w-full bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700'
+const disabledRangeClasses = 'cursor-not-allowed opacity-50'
+const defaultLabelClasses = 'block mb-2 text-sm font-medium'
+const defaultHelperClasses = 'mt-2 text-sm text-gray-500 dark:text-gray-400'
+
+const errorTextClasses = 'text-red-700 dark:text-red-500'
+const successTextClasses = 'text-green-700 dark:text-green-500'
+const neutralTextClasses = 'text-gray-900 dark:text-white'
 
 const rangeSizeClasses: Record<FormElementSize, string> = {
   sm: 'h-1 [&::-webkit-slider-thumb]:size-3 [&::-moz-range-thumb]:size-3',
@@ -15,20 +20,48 @@ const rangeSizeClasses: Record<FormElementSize, string> = {
 }
 
 export type UseRangeClassesProps = {
-  size: Ref<FormElementSize>
+  class: Ref<string | Record<string, boolean>>
   disabled: Ref<boolean>
+  labelClass: Ref<string | Record<string, boolean>>
+  size: Ref<FormElementSize>
+  validationStatus: Ref<ValidationStatus | undefined>
+  wrapperClass: Ref<string | Record<string, boolean>>
 }
 
-export function useRangeClasses (props: UseRangeClassesProps) {
-  const rangeClasses = computed(() => useMergeClasses([
-    rangeDefaultClasses,
+export function useRangeClasses(props: UseRangeClassesProps) {
+  const wrapperClass = computed(() => useMergeClasses([props.wrapperClass.value]))
+
+  const labelClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultLabelClasses,
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error
+          ? errorTextClasses
+          : neutralTextClasses,
+      props.labelClass.value,
+    ])
+  })
+
+  const rangeClass = computed(() => useMergeClasses([
+    defaultRangeClasses,
     rangeSizeClasses[props.size.value],
+    props.disabled.value ? disabledRangeClasses : '',
+    props.class.value,
   ]))
 
-  const labelClasses = computed(() => rangeLabelClasses)
+  const validationMessageClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultHelperClasses,
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error ? errorTextClasses : '',
+    ])
+  })
 
-  return {
-    rangeClasses,
-    labelClasses,
-  }
+  const helperMessageClass = computed(() => useMergeClasses([defaultHelperClasses]))
+
+  return { helperMessageClass, labelClass, rangeClass, validationMessageClass, wrapperClass }
 }

--- a/src/components/FwbRange/composables/useRangeClasses.ts
+++ b/src/components/FwbRange/composables/useRangeClasses.ts
@@ -28,7 +28,7 @@ export type UseRangeClassesProps = {
   wrapperClass: Ref<string | Record<string, boolean>>
 }
 
-export function useRangeClasses(props: UseRangeClassesProps) {
+export function useRangeClasses (props: UseRangeClassesProps) {
   const wrapperClass = computed(() => useMergeClasses([props.wrapperClass.value]))
 
   const labelClass = computed(() => {

--- a/src/components/FwbRange/composables/useRangeClasses.ts
+++ b/src/components/FwbRange/composables/useRangeClasses.ts
@@ -4,14 +4,14 @@ import type { FormElementSize } from '@/types/form'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
 
-const rangeDefaultClasses = 'w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700'
+const rangeDefaultClasses = 'fwb-range-input w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700'
 const rangeLabelClasses = 'block mb-2 text-sm font-medium text-gray-900 dark:text-white'
 
 const rangeSizeClasses: Record<FormElementSize, string> = {
-  sm: 'h-1 range-sm',
-  md: 'h-2 range-md',
-  lg: 'h-3 range-lg',
-  xl: 'h-3 range-lg', // intentionally reuses lg until xl is designed
+  sm: 'h-1 [&::-webkit-slider-thumb]:size-3 [&::-moz-range-thumb]:size-3',
+  md: 'h-2 [&::-webkit-slider-thumb]:size-4 [&::-moz-range-thumb]:size-4',
+  lg: 'h-3 [&::-webkit-slider-thumb]:size-5 [&::-moz-range-thumb]:size-5',
+  xl: 'h-4 [&::-webkit-slider-thumb]:size-6 [&::-moz-range-thumb]:size-6',
 }
 
 export type UseRangeClassesProps = {

--- a/src/components/FwbRange/tests/FwbRange.spec.ts
+++ b/src/components/FwbRange/tests/FwbRange.spec.ts
@@ -1,0 +1,135 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbRange from '../FwbRange.vue'
+
+describe('FwbRange', () => {
+  describe('label/input linkage', () => {
+    it('links label for to input id', () => {
+      const wrapper = mount(FwbRange, { props: { label: 'Volume' } })
+      const labelFor = wrapper.find('label').attributes('for')
+      const inputId = wrapper.find('input[type="range"]').attributes('id')
+      expect(labelFor).toBeDefined()
+      expect(labelFor).toBe(inputId)
+    })
+
+    it('uses a user-provided id for both the input and the label', () => {
+      const wrapper = mount(FwbRange, { props: { label: 'Volume' }, attrs: { id: 'my-range' } })
+      expect(wrapper.find('input[type="range"]').attributes('id')).toBe('my-range')
+      expect(wrapper.find('label').attributes('for')).toBe('my-range')
+    })
+
+    it('renders no label element when label prop is empty', () => {
+      const wrapper = mount(FwbRange)
+      expect(wrapper.find('label').exists()).toBe(false)
+    })
+  })
+
+  describe('native attribute passthrough', () => {
+    it('passes extra attrs to the input, not the root wrapper', () => {
+      const wrapper = mount(FwbRange, { attrs: { name: 'brightness', form: 'settings' } })
+      const input = wrapper.find('input[type="range"]')
+      expect(input.attributes('name')).toBe('brightness')
+      expect(input.attributes('form')).toBe('settings')
+      expect(wrapper.element.getAttribute('name')).toBeNull()
+    })
+
+    it('disabled prop reaches the input', () => {
+      const wrapper = mount(FwbRange, { props: { disabled: true } })
+      expect(wrapper.find('input[type="range"]').attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('size classes', () => {
+    it('sm applies a shorter track height than xl', () => {
+      const sm = mount(FwbRange, { props: { size: 'sm' } })
+      const xl = mount(FwbRange, { props: { size: 'xl' } })
+      expect(sm.find('input').classes()).toContain('h-1')
+      expect(xl.find('input').classes()).toContain('h-4')
+    })
+
+    it('sm applies smaller thumb size than xl', () => {
+      const sm = mount(FwbRange, { props: { size: 'sm' } })
+      const xl = mount(FwbRange, { props: { size: 'xl' } })
+      expect(sm.find('input').classes().join(' ')).toContain('[&::-webkit-slider-thumb]:size-3')
+      expect(xl.find('input').classes().join(' ')).toContain('[&::-webkit-slider-thumb]:size-6')
+    })
+  })
+
+  describe('aria-invalid', () => {
+    it('is "true" when validationStatus is "error"', () => {
+      const wrapper = mount(FwbRange, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('input[type="range"]').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('is absent when validationStatus is "success"', () => {
+      const wrapper = mount(FwbRange, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('input[type="range"]').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('is absent when validationStatus is not set', () => {
+      const wrapper = mount(FwbRange)
+      expect(wrapper.find('input[type="range"]').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no slots are provided', () => {
+      const wrapper = mount(FwbRange)
+      expect(wrapper.find('input[type="range"]').attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('points to the helper paragraph id when the helper slot is provided', () => {
+      const wrapper = mount(FwbRange, { slots: { helper: 'Adjust the value' } })
+      const helperP = wrapper.find('p')
+      expect(wrapper.find('input[type="range"]').attributes('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbRange, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Value is out of range' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="range"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs space-joined when both slots are rendered', () => {
+      const wrapper = mount(FwbRange, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Too high', helper: 'Between 0 and 100' },
+      })
+      const describedby = wrapper.find('input[type="range"]').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+
+    it('merges a user-passed aria-describedby with slot IDs', () => {
+      const wrapper = mount(FwbRange, {
+        attrs: { 'aria-describedby': 'external-hint' },
+        slots: { helper: 'Between 0 and 100' },
+      })
+      const ids = (wrapper.find('input[type="range"]').attributes('aria-describedby') ?? '').split(' ')
+      expect(ids).toContain('external-hint')
+      expect(ids).toHaveLength(2)
+    })
+  })
+
+  describe('validation label colors', () => {
+    it('applies error color to label when validationStatus is "error"', () => {
+      const wrapper = mount(FwbRange, { props: { label: 'Volume', validationStatus: 'error' } })
+      expect(wrapper.find('label').classes()).toContain('text-red-700')
+    })
+
+    it('applies success color to label when validationStatus is "success"', () => {
+      const wrapper = mount(FwbRange, { props: { label: 'Volume', validationStatus: 'success' } })
+      expect(wrapper.find('label').classes()).toContain('text-green-700')
+    })
+
+    it('applies neutral color to label when validationStatus is not set', () => {
+      const wrapper = mount(FwbRange, { props: { label: 'Volume' } })
+      expect(wrapper.find('label').classes()).toContain('text-gray-900')
+    })
+  })
+})

--- a/src/components/FwbRange/tests/FwbRange.spec.ts
+++ b/src/components/FwbRange/tests/FwbRange.spec.ts
@@ -116,6 +116,23 @@ describe('FwbRange', () => {
     })
   })
 
+  describe('styling props', () => {
+    it('applies class prop classes to the input element', () => {
+      const wrapper = mount(FwbRange, { props: { class: 'bg-amber-200' } })
+      expect(wrapper.find('input[type="range"]').classes()).toContain('bg-amber-200')
+    })
+
+    it('applies wrapperClass prop classes to the root wrapper element', () => {
+      const wrapper = mount(FwbRange, { props: { wrapperClass: 'border-2' } })
+      expect(wrapper.element.classList).toContain('border-2')
+    })
+
+    it('applies labelClass prop classes to the label element', () => {
+      const wrapper = mount(FwbRange, { props: { label: 'Volume', labelClass: 'text-xl' } })
+      expect(wrapper.find('label').classes()).toContain('text-xl')
+    })
+  })
+
   describe('validation label colors', () => {
     it('applies error color to label when validationStatus is "error"', () => {
       const wrapper = mount(FwbRange, { props: { label: 'Volume', validationStatus: 'error' } })

--- a/src/components/FwbRange/types.ts
+++ b/src/components/FwbRange/types.ts
@@ -1,0 +1,14 @@
+import type { FormElementSize, ValidationStatus } from '@/types/form'
+
+export interface RangeProps {
+  class?: string | Record<string, boolean>
+  disabled?: boolean
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  max?: number
+  min?: number
+  size?: FormElementSize
+  steps?: number
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
+}


### PR DESCRIPTION
## Summary

Brings \`FwbRange\` to parity with the other refactored form components, adding proper \`inheritAttrs: false\` attr forwarding, \`aria-describedby\` wiring, validation state support, per-element class props, and a full docs rewrite.

## What's new

**New props**
- \`class\` — added to the \`<input type="range">\` element directly
- \`labelClass\`, \`wrapperClass\` — per-element class passthrough (\`String | Object\`)
- \`validationStatus\` — drives label colour and \`aria-invalid\` on the input

**New slots**
- \`validationMessage\` — styled feedback message, linked via \`aria-describedby\`
- \`helper\` — hint text rendered below the input, linked via \`aria-describedby\`

**Accessibility**
- \`inheritAttrs: false\` — extra attrs (e.g. \`name\`, \`form\`, \`aria-label\`) now forward to \`<input>\`, not the root wrapper
- Explicit \`<label :for="rangeId">\` replaces the old implicit wrapping label, wired via \`useElementAttributes\`
- \`aria-invalid="true"\` set automatically on \`validationStatus="error"\`
- \`aria-describedby\` wired to \`validationMessage\`/\`helper\` slot IDs via \`useFormFieldIds\`, merged with any user-provided value

**Styling**
- Thumb colour exposed via \`--fwb-range-thumb-color\` CSS custom property (defaults to blue-500); override from any ancestor with a Tailwind arbitrary class, e.g. \`[--fwb-range-thumb-color:var(--color-amber-600)]\`

**Architecture**
- Scoped CSS thumb sizing (\`.range-sm\`/\`.range-lg\`) replaced with Tailwind arbitrary variants (\`[&::-webkit-slider-thumb]:size-*\`); \`xl\` now has its own proper size (was aliasing \`lg\`)
- \`defineModel\` replaces the old computed + emit pattern
- \`RangeProps\` extracted to \`types.ts\`; \`FormElementSize\` and \`ValidationStatus\` imported from \`@/types/form\`

## Tests

18 new tests covering: label/input \`for\`/\`id\` linkage, user-provided \`id\`, attr passthrough (attrs land on \`<input>\`, not root wrapper), \`disabled\` passthrough, size classes (track height and thumb size), \`aria-invalid\` (present on error, absent otherwise), \`aria-describedby\` (absent with no slots, helper slot ID, validationMessage slot ID, both IDs space-joined, and external \`aria-describedby\` merged), and validation label colours.

## Docs

Full rewrite aligned with the other refactored form component docs:
- **Default**, **Disabled**, **Min and Max**, **Steps**, **Sizes** (now includes Extra Large / \`xl\`), **Validation** (new), **Helper text** (new), **Styling** (new, amber/green theme demonstrating \`wrapperClass\`, \`labelClass\`, \`class\`, and \`--fwb-range-thumb-color\`)
- Full API table with \`### FwbRange Props/Slots\` subsections; \`:::tip\` callouts for native attr passthrough, thumb colour override, and accessibility behaviour
- Title corrected from "Vue Toggle Range" to "Vue Range"

## Breaking changes

**\`label\` default changed**
The \`label\` prop default changed from \`'Range slider'\` to \`''\`, consistent with all other refactored form components. Callers that relied on the implicit label will now render no label; pass \`label="Range slider"\` explicitly to restore the previous behaviour.

**\`inheritAttrs: false\` — attr forwarding target changed**
Extra attributes previously fell through to the root \`<label>\` wrapper. They now forward to \`<input type="range">\`. This is the correct behaviour but may affect apps that relied on attrs landing on the wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Enhanced the Range component with validation messaging and helper text slots
* Added improved styling controls, including `wrapperClass`/`labelClass`, and thumb color via CSS variable
* Improved accessibility handling, including `aria-invalid` and conditional `aria-describedby`
* Added “Extra Large” size
* Range now uses `v-model` (numeric) for a simpler binding experience

## Documentation
* Updated Range docs with refreshed examples and a more complete API reference (including validation/helper behavior)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->