### PR TITLE
refactor: FwbToggle - accessibility, validation, attr passthrough, and docs rewrite

### DIFF
--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -1,10 +1,13 @@
 <script setup>
-  import FwbToggleExample from './toggle/examples/FwbToggleExample.vue'
-  import FwbToggleExampleChecked from './toggle/examples/FwbToggleExampleChecked.vue'
-  import FwbToggleExampleColors from './toggle/examples/FwbToggleExampleColors.vue'
-  import FwbToggleExampleDisabled from './toggle/examples/FwbToggleExampleDisabled.vue'
-  import FwbToggleExampleSize from './toggle/examples/FwbToggleExampleSize.vue'
-  import FwbToggleExampleOrder from './toggle/examples/FwbToggleExampleOrder.vue'
+import FwbToggleExample from './toggle/examples/FwbToggleExample.vue'
+import FwbToggleExampleChecked from './toggle/examples/FwbToggleExampleChecked.vue'
+import FwbToggleExampleColors from './toggle/examples/FwbToggleExampleColors.vue'
+import FwbToggleExampleDisabled from './toggle/examples/FwbToggleExampleDisabled.vue'
+import FwbToggleExampleHelper from './toggle/examples/FwbToggleExampleHelper.vue'
+import FwbToggleExampleOrder from './toggle/examples/FwbToggleExampleOrder.vue'
+import FwbToggleExampleSize from './toggle/examples/FwbToggleExampleSize.vue'
+import FwbToggleExampleStyling from './toggle/examples/FwbToggleExampleStyling.vue'
+import FwbToggleExampleValidation from './toggle/examples/FwbToggleExampleValidation.vue'
 </script>
 
 # Vue Toggle - Flowbite
@@ -17,7 +20,7 @@
 Original reference: [https://flowbite.com/docs/forms/toggle/](https://flowbite.com/docs/forms/toggle/)
 :::
 
-The toggle component can be used to receive a simple “yes” or “no” type of answer from the user by choosing a single option from two options available in multiple sizes, styles, and colors coded with the utility classes from Tailwind CSS and with dark mode support.
+The toggle component can be used to receive a simple "yes" or "no" type of answer from the user by choosing a single option from two options available in multiple sizes, styles, and colors coded with the utility classes from Tailwind CSS and with dark mode support.
 
 ## Default toggle
 
@@ -33,6 +36,7 @@ import { FwbToggle } from 'flowbite-vue'
 
 const toggle = ref(false)
 </script>
+
 ```
 
 ## Checked toggle
@@ -61,10 +65,11 @@ const toggle = ref(true)
 
 <script setup>
 import { ref } from 'vue'
-import { FwbToggle } from 'flowbite'
+import { FwbToggle } from 'flowbite-vue'
 
 const toggle = ref(false)
 </script>
+
 ```
 
 ## Colors
@@ -89,11 +94,8 @@ const toggle = ref(false)
   <fwb-toggle label="Small" size="sm" />
   <fwb-toggle label="Medium" size="md" />
   <fwb-toggle label="Large" size="lg" />
+  <fwb-toggle label="Extra Large" size="xl" />
 </template>
-
-<script setup>
-import { FwbToggle } from 'flowbite-vue'
-</script>
 ```
 
 ## Label position
@@ -104,8 +106,88 @@ import { FwbToggle } from 'flowbite-vue'
   <fwb-toggle label="Toggle me" />
   <fwb-toggle label="Toggle me" reverse />
 </template>
-
-<script setup>
-import { FwbToggle } from 'flowbite-vue'
-</script>
 ```
+
+## Validation
+
+Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the toggle.
+
+<fwb-toggle-example-validation />
+```vue
+<template>
+  <fwb-toggle v-model="toggle1" label="Notifications (success)" validation-status="success">
+    <template #validationMessage>
+      <span class="font-medium">Great!</span> Notifications are enabled.
+    </template>
+  </fwb-toggle>
+  <fwb-toggle v-model="toggle2" label="Location (error)" validation-status="error">
+    <template #validationMessage>
+      <span class="font-medium">Required!</span> Location access must be enabled.
+    </template>
+  </fwb-toggle>
+</template>
+```
+
+## Helper text
+
+Use the `helper` slot to show a hint below the toggle.
+
+<fwb-toggle-example-helper />
+```vue
+<template>
+  <fwb-toggle v-model="toggle" label="Dark mode">
+    <template #helper>
+      Switches the interface between light and dark themes.
+    </template>
+  </fwb-toggle>
+</template>
+```
+
+## Styling
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-toggle-example-styling />
+```vue
+<template>
+  <fwb-toggle
+    v-model="toggle"
+    label="Enable feature"
+    class="bg-amber-200 dark:bg-green-900 peer-checked:bg-amber-600 dark:peer-checked:bg-green-500 peer-focus:ring-amber-300 dark:peer-focus:ring-green-800"
+    label-class="font-bold text-amber-900 dark:text-green-200"
+    wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3"
+  />
+</template>
+```
+
+## Toggle component API
+
+### FwbToggle Props
+
+:::tip Native attribute passthrough
+`FwbToggle` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `form`, `aria-label`) directly to the `<input type="checkbox">` element.
+:::
+
+| Name             | Type                           | Default     | Description                                                                      |
+| ---------------- | ------------------------------ | ----------- | -------------------------------------------------------------------------------- |
+| class            | `String \| Object`             | `''`        | Added to the toggle background element.                                          |
+| color            | `String`                       | `''`        | Accent color when checked: `red`, `green`, `purple`, `yellow`, `teal`, `orange`. |
+| disabled         | `Boolean`                      | `false`     | Disables the toggle.                                                             |
+| label            | `String`                       | `''`        | Label text rendered next to the toggle. When empty, no text is rendered.         |
+| labelClass       | `String \| Object`             | `''`        | Added to the label text element.                                                 |
+| modelValue       | `Boolean`                      | `false`     | The current value (use with `v-model`).                                          |
+| reverse          | `Boolean`                      | `false`     | Places the label text to the left of the toggle.                                 |
+| size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`      | Controls the size of the toggle track and thumb.                                 |
+| validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error colour styles to the label text.                        |
+| wrapperClass     | `String \| Object`             | `''`        | Added to the outer root `<div>`.                                                 |
+
+:::tip Accessibility
+`aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
+:::
+
+### FwbToggle Slots
+
+| Name              | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| helper            | Helper text rendered below the toggle.                                        |
+| validationMessage | Validation feedback rendered below the toggle (styled by `validationStatus`). |

--- a/docs/components/toggle/examples/FwbToggleExampleHelper.vue
+++ b/docs/components/toggle/examples/FwbToggleExampleHelper.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="vp-raw">
+    <fwb-toggle
+      v-model="toggle"
+      label="Dark mode"
+    >
+      <template #helper>
+        Switches the interface between light and dark themes.
+      </template>
+    </fwb-toggle>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbToggle } from '../../../../src/index'
+
+const toggle = ref(false)
+</script>

--- a/docs/components/toggle/examples/FwbToggleExampleSize.vue
+++ b/docs/components/toggle/examples/FwbToggleExampleSize.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vp-raw grid gap-3">
+  <div class="gap-3 grid vp-raw">
     <fwb-toggle
       label="Small"
       size="sm"
@@ -11,6 +11,10 @@
     <fwb-toggle
       label="Large"
       size="lg"
+    />
+    <fwb-toggle
+      label="Extra Large"
+      size="xl"
     />
   </div>
 </template>

--- a/docs/components/toggle/examples/FwbToggleExampleStyling.vue
+++ b/docs/components/toggle/examples/FwbToggleExampleStyling.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="vp-raw">
+    <fwb-toggle
+      v-model="toggle"
+      label="Enable feature"
+      class="bg-amber-200 dark:bg-green-900 peer-checked:bg-amber-600 dark:peer-checked:bg-green-500 peer-focus:ring-amber-300 dark:peer-focus:ring-green-800"
+      label-class="font-bold text-amber-900 dark:text-green-200"
+      wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbToggle } from '../../../../src/index'
+
+const toggle = ref(false)
+</script>

--- a/docs/components/toggle/examples/FwbToggleExampleValidation.vue
+++ b/docs/components/toggle/examples/FwbToggleExampleValidation.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="vp-raw grid gap-4">
+    <fwb-toggle
+      v-model="toggle1"
+      label="Notifications (success)"
+      validation-status="success"
+    >
+      <template #validationMessage>
+        <span class="font-medium">Great!</span> Notifications are enabled.
+      </template>
+    </fwb-toggle>
+    <fwb-toggle
+      v-model="toggle2"
+      label="Location (error)"
+      validation-status="error"
+    >
+      <template #validationMessage>
+        <span class="font-medium">Required!</span> Location access must be enabled.
+      </template>
+    </fwb-toggle>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbToggle } from '../../../../src/index'
+
+const toggle1 = ref(true)
+const toggle2 = ref(false)
+</script>

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -13,4 +13,12 @@ export default defineConfig({
       '@': resolve(__dirname, '../src'), // to resolve @ inside docs
     },
   },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
+  build: {
+    target: 'esnext',
+  },
 })

--- a/src/components/FwbToggle/FwbToggle.vue
+++ b/src/components/FwbToggle/FwbToggle.vue
@@ -3,7 +3,7 @@
     <input
       v-model="model"
       :disabled="disabled"
-      class="peer sr-only"
+      class="sr-only peer"
       type="checkbox"
     >
     <span :class="[toggleClasses, toggleSize, toggleColor]" />

--- a/src/components/FwbToggle/FwbToggle.vue
+++ b/src/components/FwbToggle/FwbToggle.vue
@@ -1,61 +1,73 @@
 <template>
-  <label :class="[labelClasses, labelOrder]">
-    <input
-      v-model="model"
-      :disabled="disabled"
-      class="sr-only peer"
-      type="checkbox"
+  <div :class="wrapperClass">
+    <label :class="toggleContainerClass">
+      <input
+        v-bind="toggleAttributes"
+        v-model="model"
+        :aria-describedby="ariaDescribedby"
+        :aria-invalid="validationStatus === 'error' ? true : undefined"
+        :disabled="disabled"
+        class="sr-only peer"
+        type="checkbox"
+      >
+      <span :class="toggleBackgroundClass" />
+      <span
+        v-if="label"
+        :class="labelTextClass"
+      >{{ label }}</span>
+    </label>
+    <p
+      v-if="$slots.validationMessage"
+      :id="validationMessageId"
+      :class="validationMessageClass"
     >
-    <span :class="[toggleClasses, toggleSize, toggleColor]" />
-    <span
-      v-if="label"
-      :class="[toggleBallClasses, toggleBallOrder]"
-    >{{ label }}</span>
-  </label>
+      <slot name="validationMessage" />
+    </p>
+    <p
+      v-if="$slots.helper"
+      :id="helperId"
+      :class="helperMessageClass"
+    >
+      <slot name="helper" />
+    </p>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, toRefs } from 'vue'
+import { toRefs } from 'vue'
 
 import { useToggleClasses } from './composables/useToggleClasses'
 
-import type { FormElementSize } from '@/types/form'
+import type { ToggleProps } from './types'
 
-interface ToggleProps {
-  color?: string
-  disabled?: boolean
-  label?: string
-  modelValue?: boolean
-  size?: FormElementSize
-  reverse?: boolean
-}
+import { useElementAttributes } from '@/composables/useElementAttributes'
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<ToggleProps>(), {
+  class: '',
   color: '',
   disabled: false,
   label: '',
-  modelValue: false,
-  size: 'md',
+  labelClass: '',
   reverse: false,
+  size: 'md',
+  validationStatus: undefined,
+  wrapperClass: '',
 })
 
-const emit = defineEmits(['update:modelValue'])
-const model = computed({
-  get () {
-    return props.modelValue
-  },
-  set (val) {
-    emit('update:modelValue', val)
-  },
-})
+const model = defineModel<boolean>({ default: false })
+
+const { elementId: toggleId, elementAttributes: toggleAttributes } = useElementAttributes()
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(toggleId)
 
 const {
-  labelClasses,
-  toggleSize,
-  toggleClasses,
-  toggleColor,
-  toggleBallClasses,
-  toggleBallOrder,
-  labelOrder,
+  helperMessageClass,
+  labelTextClass,
+  toggleBackgroundClass,
+  toggleContainerClass,
+  validationMessageClass,
+  wrapperClass,
 } = useToggleClasses(toRefs(props))
 </script>

--- a/src/components/FwbToggle/composables/useToggleClasses.ts
+++ b/src/components/FwbToggle/composables/useToggleClasses.ts
@@ -1,18 +1,23 @@
 import { computed, type Ref } from 'vue'
 
-import type { FormElementSize } from '@/types/form'
+import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type FormElementSize, type ValidationStatus, validationStatusMap } from '@/types/form'
 
-// Toggle Background
-const defaultLabelClasses = 'w-fit relative inline-flex items-center cursor-pointer'
-const defaultToggleBackgroundClasses = 'relative bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:bg-white after:border-gray-300 after:border after:rounded-full after:transition-all dark:border-gray-600 peer-checked:bg-blue-600'
-const defaultToggleBallClasses = 'text-sm font-medium text-gray-900 dark:text-gray-300'
+const defaultToggleContainerClasses = 'w-fit relative inline-flex items-center cursor-pointer has-[:disabled]:cursor-not-allowed'
+const defaultToggleBackgroundClasses = 'relative bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[""] after:absolute after:bg-white after:border-gray-300 after:border after:rounded-full after:transition-all dark:border-gray-600 peer-checked:bg-blue-600 peer-disabled:opacity-50 peer-disabled:cursor-not-allowed'
+const defaultLabelTextClasses = 'select-none text-sm font-medium'
+const defaultHelperClasses = 'mt-2 text-sm text-gray-500 dark:text-gray-400'
 
-const labelOrderClasses: Record<string, string> = {
+const errorTextClasses = 'text-red-700 dark:text-red-500'
+const successTextClasses = 'text-green-700 dark:text-green-500'
+const neutralTextClasses = 'text-gray-900 dark:text-gray-300'
+
+const toggleContainerOrderClasses: Record<'direct' | 'reverse', string> = {
   direct: '',
   reverse: 'flex-row-reverse',
 }
 
-const toggleBallOrderClasses: Record<string, string> = {
+const labelTextOrderClasses: Record<'direct' | 'reverse', string> = {
   direct: 'ms-3',
   reverse: 'me-3',
 }
@@ -34,27 +39,55 @@ const toggleColorClasses: Record<string, string> = {
 }
 
 export type UseToggleClassesProps = {
+  class: Ref<string | Record<string, boolean>>
   color: Ref<string>
+  labelClass: Ref<string | Record<string, boolean>>
   reverse: Ref<boolean>
   size: Ref<FormElementSize>
+  validationStatus: Ref<ValidationStatus | undefined>
+  wrapperClass: Ref<string | Record<string, boolean>>
 }
 
 export function useToggleClasses (props: UseToggleClassesProps) {
-  const labelClasses = computed(() => defaultLabelClasses)
-  const labelOrder = computed(() => labelOrderClasses[props.reverse.value ? 'reverse' : 'direct'])
-  const toggleBallClasses = computed(() => defaultToggleBallClasses)
-  const toggleBallOrder = computed(() => toggleBallOrderClasses[props.reverse.value ? 'reverse' : 'direct'])
-  const toggleClasses = computed(() => defaultToggleBackgroundClasses)
-  const toggleColor = computed(() => toggleColorClasses[props.color.value])
-  const toggleSize = computed(() => toggleSizeClasses[props.size.value])
+  const wrapperClass = computed(() => useMergeClasses(['flex flex-col items-start', props.wrapperClass.value]))
 
-  return {
-    labelClasses,
-    labelOrder,
-    toggleBallClasses,
-    toggleBallOrder,
-    toggleClasses,
-    toggleColor,
-    toggleSize,
-  }
+  const toggleContainerClass = computed(() => useMergeClasses([
+    defaultToggleContainerClasses,
+    toggleContainerOrderClasses[props.reverse.value ? 'reverse' : 'direct'],
+  ]))
+
+  const toggleBackgroundClass = computed(() => useMergeClasses([
+    defaultToggleBackgroundClasses,
+    toggleSizeClasses[props.size.value],
+    props.color.value ? (toggleColorClasses[props.color.value] ?? '') : '',
+    props.class.value,
+  ]))
+
+  const labelTextClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultLabelTextClasses,
+      labelTextOrderClasses[props.reverse.value ? 'reverse' : 'direct'],
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error
+          ? errorTextClasses
+          : neutralTextClasses,
+      props.labelClass.value,
+    ])
+  })
+
+  const validationMessageClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultHelperClasses,
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error ? errorTextClasses : '',
+    ])
+  })
+
+  const helperMessageClass = computed(() => useMergeClasses([defaultHelperClasses]))
+
+  return { helperMessageClass, labelTextClass, toggleBackgroundClass, toggleContainerClass, validationMessageClass, wrapperClass }
 }

--- a/src/components/FwbToggle/composables/useToggleClasses.ts
+++ b/src/components/FwbToggle/composables/useToggleClasses.ts
@@ -21,40 +21,40 @@ const toggleSizeClasses: Record<FormElementSize, string> = {
   sm: 'w-9 h-5 after:top-[2px] after:start-[2px] after:h-4 after:w-4',
   md: 'w-11 h-6 after:top-[2px] after:start-[2px] after:h-5 after:w-5',
   lg: 'w-14 h-7 after:top-0.5 after:start-[4px] after:h-6 after:w-6',
-  xl: 'w-14 h-7 after:top-0.5 after:start-[4px] after:h-6 after:w-6', // intentionally reuses lg until xl is designed
+  xl: 'w-16 h-8 after:top-0.5 after:start-[4px] after:h-7 after:w-7',
 }
 
 const toggleColorClasses: Record<string, string> = {
-  red: 'peer-focus:ring-red-300 dark:peer-focus:ring-red-800 peer-checked:bg-red-600',
   green: 'peer-focus:ring-green-300 dark:peer-focus:ring-green-800 peer-checked:bg-green-600',
-  purple: 'peer-focus:ring-purple-300 dark:peer-focus:ring-purple-800 peer-checked:bg-purple-600',
-  yellow: 'peer-focus:ring-yellow-300 dark:peer-focus:ring-yellow-800 peer-checked:bg-yellow-400',
-  teal: 'peer-focus:ring-teal-300 dark:peer-focus:ring-teal-800 peer-checked:bg-teal-600',
   orange: 'peer-focus:ring-orange-300 dark:peer-focus:ring-orange-800 peer-checked:bg-orange-500',
+  purple: 'peer-focus:ring-purple-300 dark:peer-focus:ring-purple-800 peer-checked:bg-purple-600',
+  red: 'peer-focus:ring-red-300 dark:peer-focus:ring-red-800 peer-checked:bg-red-600',
+  teal: 'peer-focus:ring-teal-300 dark:peer-focus:ring-teal-800 peer-checked:bg-teal-600',
+  yellow: 'peer-focus:ring-yellow-300 dark:peer-focus:ring-yellow-800 peer-checked:bg-yellow-400',
 }
 
 export type UseToggleClassesProps = {
-  size: Ref<FormElementSize>
   color: Ref<string>
   reverse: Ref<boolean>
+  size: Ref<FormElementSize>
 }
 
 export function useToggleClasses (props: UseToggleClassesProps) {
   const labelClasses = computed(() => defaultLabelClasses)
-  const toggleClasses = computed(() => defaultToggleBackgroundClasses)
-  const toggleSize = computed(() => toggleSizeClasses[props.size.value])
-  const toggleColor = computed(() => toggleColorClasses[props.color.value])
+  const labelOrder = computed(() => labelOrderClasses[props.reverse.value ? 'reverse' : 'direct'])
   const toggleBallClasses = computed(() => defaultToggleBallClasses)
   const toggleBallOrder = computed(() => toggleBallOrderClasses[props.reverse.value ? 'reverse' : 'direct'])
-  const labelOrder = computed(() => labelOrderClasses[props.reverse.value ? 'reverse' : 'direct'])
+  const toggleClasses = computed(() => defaultToggleBackgroundClasses)
+  const toggleColor = computed(() => toggleColorClasses[props.color.value])
+  const toggleSize = computed(() => toggleSizeClasses[props.size.value])
 
   return {
     labelClasses,
-    toggleSize,
-    toggleClasses,
-    toggleColor,
+    labelOrder,
     toggleBallClasses,
     toggleBallOrder,
-    labelOrder,
+    toggleClasses,
+    toggleColor,
+    toggleSize,
   }
 }

--- a/src/components/FwbToggle/tests/FwbToggle.spec.ts
+++ b/src/components/FwbToggle/tests/FwbToggle.spec.ts
@@ -1,0 +1,163 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbToggle from '../FwbToggle.vue'
+
+describe('FwbToggle', () => {
+  describe('label/checkbox structure', () => {
+    it('checkbox is inside the label element', () => {
+      const wrapper = mount(FwbToggle)
+      expect(wrapper.find('label').find('input[type="checkbox"]').exists()).toBe(true)
+    })
+
+    it('checkbox has a stable generated id', () => {
+      const wrapper = mount(FwbToggle)
+      expect(wrapper.find('input[type="checkbox"]').attributes('id')).toBeDefined()
+    })
+
+    it('uses a user-provided id on the checkbox', () => {
+      const wrapper = mount(FwbToggle, { attrs: { id: 'my-toggle' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('id')).toBe('my-toggle')
+    })
+
+    it('renders label text when label prop is provided', () => {
+      const wrapper = mount(FwbToggle, { props: { label: 'Enable' } })
+      expect(wrapper.find('label').text()).toBe('Enable')
+    })
+
+    it('renders no label text span when label prop is empty', () => {
+      const wrapper = mount(FwbToggle)
+      expect(wrapper.find('label').text()).toBe('')
+    })
+  })
+
+  describe('native attribute passthrough', () => {
+    it('passes extra attrs to the checkbox, not the root wrapper', () => {
+      const wrapper = mount(FwbToggle, { attrs: { name: 'notifications', form: 'settings' } })
+      const checkbox = wrapper.find('input[type="checkbox"]')
+      expect(checkbox.attributes('name')).toBe('notifications')
+      expect(checkbox.attributes('form')).toBe('settings')
+      expect(wrapper.element.getAttribute('name')).toBeNull()
+    })
+
+    it('disabled prop reaches the checkbox', () => {
+      const wrapper = mount(FwbToggle, { props: { disabled: true } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('size classes', () => {
+    it('sm applies a smaller track than xl', () => {
+      const sm = mount(FwbToggle, { props: { size: 'sm' } })
+      const xl = mount(FwbToggle, { props: { size: 'xl' } })
+      expect(sm.find('label span').classes()).toContain('w-9')
+      expect(xl.find('label span').classes()).toContain('w-16')
+    })
+  })
+
+  describe('color classes', () => {
+    it('applies color-specific checked background', () => {
+      const wrapper = mount(FwbToggle, { props: { color: 'red' } })
+      expect(wrapper.find('label span').classes().join(' ')).toContain('peer-checked:bg-red-600')
+    })
+
+    it('applies no color override when color is not set', () => {
+      const wrapper = mount(FwbToggle)
+      expect(wrapper.find('label span').classes().join(' ')).not.toContain('peer-checked:bg-red-600')
+    })
+  })
+
+  describe('aria-invalid', () => {
+    it('is "true" when validationStatus is "error"', () => {
+      const wrapper = mount(FwbToggle, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('is absent when validationStatus is "success"', () => {
+      const wrapper = mount(FwbToggle, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('is absent when validationStatus is not set', () => {
+      const wrapper = mount(FwbToggle)
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no slots are provided', () => {
+      const wrapper = mount(FwbToggle)
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('points to the helper paragraph id when the helper slot is provided', () => {
+      const wrapper = mount(FwbToggle, { slots: { helper: 'Toggle this on or off' } })
+      const helperP = wrapper.find('p')
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbToggle, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs space-joined when both slots are rendered', () => {
+      const wrapper = mount(FwbToggle, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Toggle to accept terms' },
+      })
+      const describedby = wrapper.find('input[type="checkbox"]').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+
+    it('merges a user-passed aria-describedby with slot IDs', () => {
+      const wrapper = mount(FwbToggle, {
+        attrs: { 'aria-describedby': 'external-hint' },
+        slots: { helper: 'Toggle to accept terms' },
+      })
+      const ids = (wrapper.find('input[type="checkbox"]').attributes('aria-describedby') ?? '').split(' ')
+      expect(ids).toContain('external-hint')
+      expect(ids).toHaveLength(2)
+    })
+  })
+
+  describe('validation label text colors', () => {
+    it('applies error color to label text when validationStatus is "error"', () => {
+      const wrapper = mount(FwbToggle, { props: { label: 'Notifications', validationStatus: 'error' } })
+      expect(wrapper.find('label > span + span').classes()).toContain('text-red-700')
+    })
+
+    it('applies success color to label text when validationStatus is "success"', () => {
+      const wrapper = mount(FwbToggle, { props: { label: 'Notifications', validationStatus: 'success' } })
+      expect(wrapper.find('label > span + span').classes()).toContain('text-green-700')
+    })
+
+    it('applies neutral color to label text when validationStatus is not set', () => {
+      const wrapper = mount(FwbToggle, { props: { label: 'Notifications' } })
+      expect(wrapper.find('label > span + span').classes()).toContain('text-gray-900')
+    })
+  })
+
+  describe('styling props', () => {
+    it('applies class prop to the toggle background span', () => {
+      const wrapper = mount(FwbToggle, { props: { class: 'border-2' } })
+      expect(wrapper.find('label span').classes()).toContain('border-2')
+    })
+
+    it('applies wrapperClass prop to the root wrapper element', () => {
+      const wrapper = mount(FwbToggle, { props: { wrapperClass: 'p-4' } })
+      expect(wrapper.element.classList).toContain('p-4')
+    })
+
+    it('applies labelClass prop to the label text span', () => {
+      const wrapper = mount(FwbToggle, { props: { label: 'Enable', labelClass: 'font-bold' } })
+      expect(wrapper.find('label > span + span').classes()).toContain('font-bold')
+    })
+  })
+})

--- a/src/components/FwbToggle/types.ts
+++ b/src/components/FwbToggle/types.ts
@@ -1,0 +1,15 @@
+import type { FormElementSize, ValidationStatus } from '@/types/form'
+
+export type ToggleColor = 'red' | 'green' | 'purple' | 'yellow' | 'teal' | 'orange'
+
+export interface ToggleProps {
+  class?: string | Record<string, boolean>
+  color?: ToggleColor | string
+  disabled?: boolean
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  reverse?: boolean
+  size?: FormElementSize
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export { default as FwbInput } from '@/components/FwbInput/FwbInput.vue'
 export { default as FwbRadio } from '@/components/FwbRadio/FwbRadio.vue'
 export { default as FwbRange } from '@/components/FwbRange/FwbRange.vue'
 export { default as FwbSelect } from '@/components/FwbSelect/FwbSelect.vue'
+export type { OptionsType } from '@/components/FwbSelect/types'
 export { default as FwbTextarea } from '@/components/FwbTextarea/FwbTextarea.vue'
 export { default as FwbToggle } from '@/components/FwbToggle/FwbToggle.vue'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ export { default as FwbInput } from '@/components/FwbInput/FwbInput.vue'
 export { default as FwbRadio } from '@/components/FwbRadio/FwbRadio.vue'
 export { default as FwbRange } from '@/components/FwbRange/FwbRange.vue'
 export { default as FwbSelect } from '@/components/FwbSelect/FwbSelect.vue'
-export type { OptionsType } from '@/components/FwbSelect/types'
 export { default as FwbTextarea } from '@/components/FwbTextarea/FwbTextarea.vue'
 export { default as FwbToggle } from '@/components/FwbToggle/FwbToggle.vue'
 


### PR DESCRIPTION
## Summary

Brings `FwbToggle` to parity with the other refactored form components, adding proper `inheritAttrs: false` attr forwarding, `aria-describedby` wiring, validation state support, per-element class props, and a full docs rewrite.

## What's new

**New props**
- `class` — added to the toggle background `<span>` element directly
- `labelClass`, `wrapperClass` — per-element class passthrough (`String | Object`)
- `validationStatus` — drives label colour and `aria-invalid` on the checkbox input

**New slots**
- `validationMessage` — styled feedback message, linked via `aria-describedby`
- `helper` — hint text rendered below the toggle, linked via `aria-describedby`

**Accessibility**
- `inheritAttrs: false` — extra attrs (e.g. `name`, `form`, `aria-label`) now forward to `<input type="checkbox">`, not the root wrapper
- Stable generated `id` on the checkbox via `useElementAttributes`
- `aria-invalid="true"` set automatically on `validationStatus="error"`
- `aria-describedby` wired to `validationMessage`/`helper` slot IDs via `useFormFieldIds`, merged with any user-provided value
- `has-[:disabled]:cursor-not-allowed` on the label container; `peer-disabled:opacity-50 peer-disabled:cursor-not-allowed` on the track

**Styling**
- Outer wrapper gets `flex flex-col items-start` by default, making vertical stacking of label row + helper/validation paragraphs explicit and predictable in any container context

**Architecture**
- `defineModel` replaces the old computed + emit pattern
- `ToggleProps` extracted to `types.ts`; `FormElementSize` and `ValidationStatus` imported from `@/types/form`
- `useToggleClasses` fully rewritten; order-class maps typed as `Record<'direct' | 'reverse', string>` to satisfy `noUncheckedIndexedAccess`

## Tests

24 new tests covering: checkbox-inside-label structure, stable generated id, user-provided id, label text rendering, attr passthrough (attrs land on `<input>`, not root wrapper), `disabled` passthrough, size classes, color classes, `aria-invalid` (present on error, absent otherwise), `aria-describedby` (absent with no slots, helper slot ID, validationMessage slot ID, both IDs space-joined, external `aria-describedby` merged), validation label colours, and styling props (`class`, `wrapperClass`, `labelClass`).

## Docs

Full rewrite aligned with the other refactored form component docs:
- **Default**, **Checked**, **Disabled**, **Colors**, **Size** (now includes Extra Large / `xl`), **Label position**, **Validation** (new), **Helper text** (new), **Styling** (new)
- Full API table with `### FwbToggle Props/Slots` subsections; `:::tip` callouts for native attr passthrough and accessibility behaviour
- Fixed stale `import { FwbToggle } from 'flowbite'` in Disabled example
- Removed `<script setup>` blocks from static-template examples (no imports needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toggle component now supports validation messaging with success and error states
  * Added helper text slot for additional context
  * Introduced custom styling via dedicated props for wrapper, label, and toggle elements
  * Added "Extra Large" size option to toggle component
  * Enhanced accessibility with improved ARIA attributes

* **Documentation**
  * Expanded toggle component documentation with new sections covering validation, helper text, and styling options
  * Added complete component API reference

* **Tests**
  * Added comprehensive test suite for toggle component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->