### PR TITLE
refactor: FwbCheckbox - accessibility, validation, attr passthrough, and docs rewrite

### DIFF
--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -4,11 +4,21 @@ import FwbCheckboxExampleDisabled from './checkbox/examples/FwbCheckboxExampleDi
 import FwbCheckboxExampleGroup from './checkbox/examples/FwbCheckboxExampleGroup.vue'
 import FwbCheckboxExampleHelper from './checkbox/examples/FwbCheckboxExampleHelper.vue'
 import FwbCheckboxExampleLink from './checkbox/examples/FwbCheckboxExampleLink.vue'
+import FwbCheckboxExampleStyling from './checkbox/examples/FwbCheckboxExampleStyling.vue'
+import FwbCheckboxExampleValidation from './checkbox/examples/FwbCheckboxExampleValidation.vue'
 </script>
 
 # Vue Checkbox - Flowbite
 
-## Checkbox example
+#### Use the checkbox component to allow users to select one or more options from a set, with support for validation, helper text, and accessible label linking
+
+---
+
+:::tip
+Original reference: [https://flowbite.com/docs/forms/checkbox/](https://flowbite.com/docs/forms/checkbox/)
+:::
+
+## Default checkbox
 
 <fwb-checkbox-example />
 ```vue
@@ -44,14 +54,14 @@ const check = ref(false)
 
 ## Checkbox with link
 
+Use the default slot instead of the `label` prop when the label contains rich content such as links.
+
 <fwb-checkbox-example-link />
 ```vue
 <template>
   <fwb-checkbox v-model="check">
     I agree with the
-    <fwb-a class="text-blue-600 hover:underline" href="#">
-      terms and conditions.
-    </fwb-a>
+    <fwb-a class="text-blue-600 hover:underline" href="#">terms and conditions.</fwb-a>
   </fwb-checkbox>
 </template>
 
@@ -63,33 +73,11 @@ const check = ref(false)
 </script>
 ```
 
-## Checkbox with helper text
-
-<fwb-checkbox-example-helper />
-```vue
-<template>
-  <fwb-checkbox v-model="check" label="Free shipping via Flowbite">
-    <template #helper>
-      For orders shipped from $25 in books or $29 in other categories.
-    </template>
-  </fwb-checkbox>
-</template>
-
-<script setup>
-import { ref } from 'vue'
-import { FwbCheckbox } from 'flowbite-vue'
-
-const check = ref(false)
-</script>
-```
-
-
 ## Checkbox group
 
-When using the checkbox with `arrays` or `objects`, the selected values will be stored in the array referenced by v-model
+When using `v-model` with an array, pass the `:value` attribute on each checkbox. Selected values are added to or removed from the array automatically.
 
 <fwb-checkbox-example-group />
-
 ```vue
 <template>
   <div class="space-y-2">
@@ -101,20 +89,7 @@ When using the checkbox with `arrays` or `objects`, the selected values will be 
       :value="fruit"
       name="fruits"
     />
-    <p class="mb-4 text-sm text-gray-500">
-      Selected fruits: {{ selectedFruits }}
-    </p>
-    <fwb-checkbox
-      v-for="(name, id) in planets"
-      :key="id"
-      v-model="selectedPlanets"
-      :label="name"
-      :value="id"
-      name="planets"
-    />
-    <p class="text-sm text-gray-500">
-      Selected planets: {{ selectedPlanets }}
-    </p>
+    <p class="text-sm text-gray-500">Selected: {{ selectedFruits }}</p>
   </div>
 </template>
 
@@ -122,34 +97,89 @@ When using the checkbox with `arrays` or `objects`, the selected values will be 
 import { ref } from 'vue'
 import { FwbCheckbox } from 'flowbite-vue'
 
-const selectedFruits = ref(['Banana', 'Strawberry'])
-const fruits = [
-  'Apple',
-  'Banana',
-  'Orange',
-  'Strawberry'
-  ]
-
-const selectedPlanets = ref([3])
-const planets = {
-  1: 'Mercury',
-  2: 'Venus',
-  3: 'Earth',
-  4: 'Mars',
-  5: 'Jupiter',
-  6: 'Saturn',
-  7: 'Uranus',
-  8: 'Neptune',
-}
+const selectedFruits = ref(['Banana'])
+const fruits = ['Apple', 'Banana', 'Orange', 'Strawberry']
 </script>
+```
 
+## Validation
+
+Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the checkbox.
+
+<fwb-checkbox-example-validation />
+```vue
+<template>
+  <fwb-checkbox v-model="check1" label="Terms accepted (success)" validation-status="success">
+    <template #validationMessage>
+      <span class="font-medium">Great!</span> You have accepted the terms.
+    </template>
+  </fwb-checkbox>
+  <fwb-checkbox v-model="check2" label="Terms not accepted (error)" validation-status="error">
+    <template #validationMessage>
+      <span class="font-medium">Required!</span> You must accept the terms to continue.
+    </template>
+  </fwb-checkbox>
+</template>
+```
+
+## Helper text
+
+Use the `helper` slot to show a hint below the checkbox.
+
+<fwb-checkbox-example-helper />
+```vue
+<template>
+  <fwb-checkbox v-model="check" label="Free shipping via Flowbite">
+    <template #helper>
+      For orders shipped from $25 in books or $29 in other categories.
+    </template>
+  </fwb-checkbox>
+</template>
+```
+
+## Styling
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-checkbox-example-styling />
+```vue
+<template>
+  <fwb-checkbox
+    v-model="check"
+    label="Custom styled checkbox"
+    class="text-amber-600 dark:text-green-500 bg-amber-50 dark:bg-green-900 border-amber-400 dark:border-green-600 focus:ring-amber-500 dark:focus:ring-green-400"
+    label-class="font-bold text-amber-900 dark:text-green-200"
+    wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3"
+  />
+</template>
 ```
 
 ## Checkbox component API
 
 ### FwbCheckbox Props
-| Name         | Type             | Default | Description                     |
-| ------------ | ---------------- | ------- | ------------------------------- |
-| wrapperClass | String \| Object | `''`    | Added to main component wrapper |
-| labelClass   | String \| Object | `''`    | Added to `<label>` element.     |
-| class        | String \| Object | `''`    | Added to `<input>` element.     |
+
+:::tip Native attribute passthrough
+`FwbCheckbox` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `value`, `form`, `aria-label`) directly to the `<input type="checkbox">` element. Pass `:value` and `name` as regular attributes when using the checkbox in a group.
+:::
+
+| Name             | Type                           | Default     | Description                                                                      |
+| ---------------- | ------------------------------ | ----------- | -------------------------------------------------------------------------------- |
+| class            | `String \| Object`             | `''`        | Added to the checkbox input element.                                             |
+| disabled         | `Boolean`                      | `false`     | Disables the checkbox.                                                           |
+| label            | `String`                       | `''`        | Label text rendered next to the checkbox. Ignored when the default slot is used. |
+| labelClass       | `String \| Object`             | `''`        | Added to the label text element.                                                 |
+| modelValue       | `Boolean \| Array`             | `false`     | The current value (use with `v-model`). Pass an array for group checkboxes.      |
+| validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error colour styles to the label text.                        |
+| wrapperClass     | `String \| Object`             | `''`        | Added to the outer root `<div>`.                                                 |
+
+:::tip Accessibility
+`aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop or default slot is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
+:::
+
+### FwbCheckbox Slots
+
+| Name              | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| default           | Rich label content rendered next to the checkbox (takes priority over `label` prop). |
+| helper            | Helper text rendered below the checkbox.                                           |
+| validationMessage | Validation feedback rendered below the checkbox (styled by `validationStatus`).    |

--- a/docs/components/checkbox/examples/FwbCheckboxExampleStyling.vue
+++ b/docs/components/checkbox/examples/FwbCheckboxExampleStyling.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="vp-raw">
+    <fwb-checkbox
+      v-model="check"
+      label="Custom styled checkbox"
+      class="text-amber-600 dark:text-green-500 bg-amber-50 dark:bg-green-900 border-amber-400 dark:border-green-600 focus:ring-amber-500 dark:focus:ring-green-400"
+      label-class="font-bold text-amber-900 dark:text-green-200"
+      wrapper-class="border-2 border-amber-700 dark:border-green-400 bg-amber-300 dark:bg-green-800 rounded-lg p-3"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbCheckbox } from '../../../../src/index'
+
+const check = ref(false)
+</script>

--- a/docs/components/checkbox/examples/FwbCheckboxExampleValidation.vue
+++ b/docs/components/checkbox/examples/FwbCheckboxExampleValidation.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="vp-raw grid gap-4">
+    <fwb-checkbox
+      v-model="check1"
+      label="Terms accepted (success)"
+      validation-status="success"
+    >
+      <template #validationMessage>
+        <span class="font-medium">Great!</span> You have accepted the terms.
+      </template>
+    </fwb-checkbox>
+    <fwb-checkbox
+      v-model="check2"
+      label="Terms not accepted (error)"
+      validation-status="error"
+    >
+      <template #validationMessage>
+        <span class="font-medium">Required!</span> You must accept the terms to continue.
+      </template>
+    </fwb-checkbox>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbCheckbox } from '../../../../src/index'
+
+const check1 = ref(true)
+const check2 = ref(false)
+</script>

--- a/src/components/FwbCheckbox/FwbCheckbox.vue
+++ b/src/components/FwbCheckbox/FwbCheckbox.vue
@@ -2,10 +2,9 @@
   <div :class="wrapperClass">
     <label class="flex items-center">
       <input
-        v-bind="checkboxAttributes"
+        v-bind="inputAttributes"
         v-model="model"
         :aria-describedby="ariaDescribedby"
-        :aria-invalid="validationStatus === 'error' ? true : undefined"
         :disabled="disabled"
         class="shrink-0"
         :class="checkboxClass"
@@ -36,7 +35,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 
 import { useCheckboxClasses } from './composables/useCheckboxClasses'
 
@@ -60,6 +59,11 @@ const model = defineModel<boolean | (string | number | boolean | object)[]>({ de
 
 const { elementId: checkboxId, elementAttributes: checkboxAttributes } = useElementAttributes()
 const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(checkboxId)
+
+const inputAttributes = computed(() => ({
+  ...checkboxAttributes.value,
+  ...(props.validationStatus === 'error' ? { 'aria-invalid': true } : {}),
+}))
 
 const {
   checkboxClass,

--- a/src/components/FwbCheckbox/FwbCheckbox.vue
+++ b/src/components/FwbCheckbox/FwbCheckbox.vue
@@ -1,26 +1,33 @@
 <template>
   <div :class="wrapperClass">
-    <label class="flex justify-start items-center select-none">
+    <label class="flex items-center">
       <input
+        v-bind="checkboxAttributes"
         v-model="model"
-        :class="checkboxClass"
+        :aria-describedby="ariaDescribedby"
+        :aria-invalid="validationStatus === 'error' ? true : undefined"
         :disabled="disabled"
-        :name="name"
-        :value="value"
+        class="shrink-0"
+        :class="checkboxClass"
         type="checkbox"
       >
       <span
-        v-if="label"
-        :class="labelClass"
+        v-if="label || $slots.default"
+        :class="labelTextClass"
       >
-        {{ label }}
-      </span>
-      <span :class="labelClass">
-        <slot />
+        <slot>{{ label }}</slot>
       </span>
     </label>
     <p
+      v-if="$slots.validationMessage"
+      :id="validationMessageId"
+      :class="validationMessageClass"
+    >
+      <slot name="validationMessage" />
+    </p>
+    <p
       v-if="$slots.helper"
+      :id="helperId"
       :class="helperMessageClass"
     >
       <slot name="helper" />
@@ -33,34 +40,32 @@ import { toRefs } from 'vue'
 
 import { useCheckboxClasses } from './composables/useCheckboxClasses'
 
-interface CheckboxProps {
-  class?: string | Record<string, boolean>
-  disabled?: boolean
-  label?: string
-  labelClass?: string | Record<string, boolean>
-  name?: string
-  value?: string | number | boolean | object
-  wrapperClass?: string | Record<string, boolean>
-}
+import type { CheckboxProps } from './types'
+
+import { useElementAttributes } from '@/composables/useElementAttributes'
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<CheckboxProps>(), {
   class: '',
   disabled: false,
   label: '',
   labelClass: '',
-  name: undefined,
-  value: undefined,
+  validationStatus: undefined,
   wrapperClass: '',
 })
 
-const model = defineModel<boolean | (string | number | boolean | object)[]>({
-  default: false,
-})
+const model = defineModel<boolean | (string | number | boolean | object)[]>({ default: false })
+
+const { elementId: checkboxId, elementAttributes: checkboxAttributes } = useElementAttributes()
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(checkboxId)
 
 const {
   checkboxClass,
   helperMessageClass,
-  labelClass,
+  labelTextClass,
+  validationMessageClass,
   wrapperClass,
 } = useCheckboxClasses(toRefs(props))
 </script>

--- a/src/components/FwbCheckbox/composables/useCheckboxClasses.ts
+++ b/src/components/FwbCheckbox/composables/useCheckboxClasses.ts
@@ -1,49 +1,54 @@
 import { computed, type Ref } from 'vue'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type ValidationStatus, validationStatusMap } from '@/types/form'
 
-const defaultLabelClasses = 'text-sm font-medium text-gray-900 dark:text-gray-300 mr-1'
-const defaultCheckboxClasses = 'mr-2 w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-sm focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-const defaultHelperClasses = 'ml-6 text-xs font-normal text-gray-500 dark:text-gray-300'
+const defaultCheckboxClasses = 'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-sm focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed'
+const defaultLabelTextClasses = 'ms-2 text-sm font-medium select-none'
+const defaultHelperClasses = 'ms-6 mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'
 
-const disabledLabelClasses = 'text-gray-400 dark:text-gray-500'
+const errorTextClasses = 'text-red-700 dark:text-red-500'
+const successTextClasses = 'text-green-700 dark:text-green-500'
+const neutralTextClasses = 'text-gray-900 dark:text-gray-300'
 
 export type UseCheckboxClassesProps = {
   class: Ref<string | Record<string, boolean>>
   disabled: Ref<boolean>
   labelClass: Ref<string | Record<string, boolean>>
+  validationStatus: Ref<ValidationStatus | undefined>
   wrapperClass: Ref<string | Record<string, boolean>>
 }
 
-export function useCheckboxClasses (props: UseCheckboxClassesProps): {
-  checkboxClass: Ref<string>
-  labelClass: Ref<string>
-  helperMessageClass: Ref<string>
-  wrapperClass: Ref<string>
-} {
-  const labelClass = computed(() => useMergeClasses([
-    defaultLabelClasses,
-    props.disabled.value ? disabledLabelClasses : '',
-    props.labelClass.value,
-  ]))
+export function useCheckboxClasses (props: UseCheckboxClassesProps) {
+  const wrapperClass = computed(() => useMergeClasses(['flex flex-col items-start', props.wrapperClass.value]))
 
-  const checkboxClass = computed(() => useMergeClasses([
-    defaultCheckboxClasses,
-    props.class.value,
-  ]))
+  const checkboxClass = computed(() => useMergeClasses([defaultCheckboxClasses, props.class.value]))
 
-  const helperMessageClass = computed(() => useMergeClasses([
-    defaultHelperClasses,
-  ]))
+  const labelTextClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultLabelTextClasses,
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error
+          ? errorTextClasses
+          : neutralTextClasses,
+      props.disabled.value ? 'opacity-50 cursor-not-allowed' : '',
+      props.labelClass.value,
+    ])
+  })
 
-  const wrapperClass = computed(() => useMergeClasses([
-    props.wrapperClass.value,
-  ]))
+  const validationMessageClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultHelperClasses,
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error ? errorTextClasses : '',
+    ])
+  })
 
-  return {
-    checkboxClass,
-    helperMessageClass,
-    labelClass,
-    wrapperClass,
-  }
+  const helperMessageClass = computed(() => useMergeClasses([defaultHelperClasses]))
+
+  return { checkboxClass, helperMessageClass, labelTextClass, validationMessageClass, wrapperClass }
 }

--- a/src/components/FwbCheckbox/tests/FwbCheckbox.spec.ts
+++ b/src/components/FwbCheckbox/tests/FwbCheckbox.spec.ts
@@ -79,6 +79,11 @@ describe('FwbCheckbox', () => {
       const wrapper = mount(FwbCheckbox)
       expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBeUndefined()
     })
+
+    it('preserves a user-provided aria-invalid when validationStatus is not "error"', () => {
+      const wrapper = mount(FwbCheckbox, { attrs: { 'aria-invalid': 'grammar' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBe('grammar')
+    })
   })
 
   describe('aria-describedby', () => {

--- a/src/components/FwbCheckbox/tests/FwbCheckbox.spec.ts
+++ b/src/components/FwbCheckbox/tests/FwbCheckbox.spec.ts
@@ -1,0 +1,160 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbCheckbox from '../FwbCheckbox.vue'
+
+describe('FwbCheckbox', () => {
+  describe('label/checkbox structure', () => {
+    it('checkbox is inside the label element', () => {
+      const wrapper = mount(FwbCheckbox)
+      expect(wrapper.find('label').find('input[type="checkbox"]').exists()).toBe(true)
+    })
+
+    it('checkbox has a stable generated id', () => {
+      const wrapper = mount(FwbCheckbox)
+      expect(wrapper.find('input[type="checkbox"]').attributes('id')).toBeDefined()
+    })
+
+    it('uses a user-provided id on the checkbox', () => {
+      const wrapper = mount(FwbCheckbox, { attrs: { id: 'my-checkbox' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('id')).toBe('my-checkbox')
+    })
+
+    it('renders label text when label prop is provided', () => {
+      const wrapper = mount(FwbCheckbox, { props: { label: 'Accept terms' } })
+      expect(wrapper.find('label span').text()).toBe('Accept terms')
+    })
+
+    it('renders no label span when neither label prop nor default slot is provided', () => {
+      const wrapper = mount(FwbCheckbox)
+      expect(wrapper.find('label span').exists()).toBe(false)
+    })
+
+    it('renders slot content when default slot is provided', () => {
+      const wrapper = mount(FwbCheckbox, { slots: { default: 'I agree' } })
+      expect(wrapper.find('label span').text()).toBe('I agree')
+    })
+
+    it('slot content takes priority over label prop', () => {
+      const wrapper = mount(FwbCheckbox, {
+        props: { label: 'prop label' },
+        slots: { default: 'slot label' },
+      })
+      expect(wrapper.find('label span').text()).toBe('slot label')
+    })
+  })
+
+  describe('native attribute passthrough', () => {
+    it('passes extra attrs to the checkbox, not the root wrapper', () => {
+      const wrapper = mount(FwbCheckbox, { attrs: { name: 'agreement', form: 'signup' } })
+      const checkbox = wrapper.find('input[type="checkbox"]')
+      expect(checkbox.attributes('name')).toBe('agreement')
+      expect(checkbox.attributes('form')).toBe('signup')
+      expect(wrapper.element.getAttribute('name')).toBeNull()
+    })
+
+    it('forwards value attr to the checkbox for group binding', () => {
+      const wrapper = mount(FwbCheckbox, { attrs: { value: 'banana' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('value')).toBe('banana')
+    })
+
+    it('disabled prop reaches the checkbox', () => {
+      const wrapper = mount(FwbCheckbox, { props: { disabled: true } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('aria-invalid', () => {
+    it('is "true" when validationStatus is "error"', () => {
+      const wrapper = mount(FwbCheckbox, { props: { validationStatus: 'error' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('is absent when validationStatus is "success"', () => {
+      const wrapper = mount(FwbCheckbox, { props: { validationStatus: 'success' } })
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('is absent when validationStatus is not set', () => {
+      const wrapper = mount(FwbCheckbox)
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no slots are provided', () => {
+      const wrapper = mount(FwbCheckbox)
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBeUndefined()
+    })
+
+    it('points to the helper paragraph id when the helper slot is provided', () => {
+      const wrapper = mount(FwbCheckbox, { slots: { helper: 'Some hint' } })
+      const helperP = wrapper.find('p')
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbCheckbox, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs space-joined when both slots are rendered', () => {
+      const wrapper = mount(FwbCheckbox, {
+        props: { validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Check this box to continue' },
+      })
+      const describedby = wrapper.find('input[type="checkbox"]').attributes('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+
+    it('merges a user-passed aria-describedby with slot IDs', () => {
+      const wrapper = mount(FwbCheckbox, {
+        attrs: { 'aria-describedby': 'external-hint' },
+        slots: { helper: 'Some hint' },
+      })
+      const ids = (wrapper.find('input[type="checkbox"]').attributes('aria-describedby') ?? '').split(' ')
+      expect(ids).toContain('external-hint')
+      expect(ids).toHaveLength(2)
+    })
+  })
+
+  describe('validation label text colors', () => {
+    it('applies error color to label text when validationStatus is "error"', () => {
+      const wrapper = mount(FwbCheckbox, { props: { label: 'Accept', validationStatus: 'error' } })
+      expect(wrapper.find('label span').classes()).toContain('text-red-700')
+    })
+
+    it('applies success color to label text when validationStatus is "success"', () => {
+      const wrapper = mount(FwbCheckbox, { props: { label: 'Accept', validationStatus: 'success' } })
+      expect(wrapper.find('label span').classes()).toContain('text-green-700')
+    })
+
+    it('applies neutral color to label text when validationStatus is not set', () => {
+      const wrapper = mount(FwbCheckbox, { props: { label: 'Accept' } })
+      expect(wrapper.find('label span').classes()).toContain('text-gray-900')
+    })
+  })
+
+  describe('styling props', () => {
+    it('applies class prop to the checkbox input', () => {
+      const wrapper = mount(FwbCheckbox, { props: { class: 'border-2' } })
+      expect(wrapper.find('input[type="checkbox"]').classes()).toContain('border-2')
+    })
+
+    it('applies wrapperClass prop to the root wrapper element', () => {
+      const wrapper = mount(FwbCheckbox, { props: { wrapperClass: 'p-4' } })
+      expect(wrapper.element.classList).toContain('p-4')
+    })
+
+    it('applies labelClass prop to the label text span', () => {
+      const wrapper = mount(FwbCheckbox, { props: { label: 'Accept', labelClass: 'font-bold' } })
+      expect(wrapper.find('label span').classes()).toContain('font-bold')
+    })
+  })
+})

--- a/src/components/FwbCheckbox/types.ts
+++ b/src/components/FwbCheckbox/types.ts
@@ -1,0 +1,10 @@
+import type { ValidationStatus } from '@/types/form'
+
+export interface CheckboxProps {
+  class?: string | Record<string, boolean>
+  disabled?: boolean
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
+}


### PR DESCRIPTION
## Summary

Brings `FwbCheckbox` to parity with the other refactored form components, adding `inheritAttrs: false` attr forwarding, `aria-describedby` wiring, validation state support, per-element class props, and a full docs rewrite.

## What's new

**New props**
- `class` — added to the `<input type="checkbox">` element directly
- `labelClass`, `wrapperClass` — per-element class passthrough (`String | Object`)
- `validationStatus` — drives label colour and `aria-invalid` on the input

**New slots**
- `validationMessage` — styled feedback message (coloured by `validationStatus`), linked via `aria-describedby`
- `helper` — hint text rendered below the checkbox, linked via `aria-describedby`

**Fixed: dual-span bug**
The previous implementation rendered two `<span>` elements inside the label (one for `label` prop, one unconditional for the default slot), giving each the same `labelClass`. This meant both spans were always rendered with styles applied even when empty. Replaced with a single `<span v-if="label || $slots.default"><slot>{{ label }}</slot></span>` — slot takes priority over the prop, and the span only renders when there is content.

**Accessibility**
- `inheritAttrs: false` — extra attrs (`name`, `value`, `form`, `aria-label`, etc.) now forward to `<input type="checkbox">`, not the root wrapper
- `aria-invalid="true"` set automatically on `validationStatus="error"`
- `aria-describedby` wired to `validationMessage`/`helper` slot IDs via `useFormFieldIds`, merged with any user-provided value
- `disabled` now also applies `opacity-50 cursor-not-allowed` to the label text

**Architecture**
- `CheckboxProps` extracted to `types.ts`; `ValidationStatus` imported from `@/types/form`
- `name` and `value` removed as explicit props — they now flow via attr passthrough, which is correct for group checkbox binding (`:value="fruit"` works as a regular attribute)
- `useCheckboxClasses` fully rewritten with validation colour logic (`validationStatusMap`) for label text and the validation message paragraph

## Tests

24 new tests covering: wrapper/label/input structure, default slot vs label prop priority, attr passthrough (including `name`, `value`, `form`; attrs land on `<input>`, not root wrapper), `disabled` passthrough, `aria-invalid` (present on error, absent otherwise), `aria-describedby` (absent with no slots, helper slot ID, validationMessage slot ID, both IDs space-joined, external `aria-describedby` merged), validation label colours, and styling props (`class`, `labelClass`, `wrapperClass`).

## Docs

Full rewrite aligned with other refactored form component docs:
- **Default**, **Disabled**, **Checkbox with link** (slot for rich label content), **Checkbox group** (`:value` attr passthrough for array binding), **Validation** (new), **Helper text**, **Styling** (new, amber/green theme demonstrating `wrapperClass`, `labelClass`, `class`)
- Full API table with `### FwbCheckbox Props/Slots` subsections; `:::tip` callouts for native attr passthrough and accessibility behaviour

## Breaking changes

**`name` and `value` are no longer explicit props**
They are now forwarded as attributes to the `<input>` element via `inheritAttrs: false`. The usage is identical — pass them as regular attributes — but they no longer appear in the props definition. This is the correct behaviour for group checkboxes (Vue's `v-model` array mode uses the native `value` attribute).

**`inheritAttrs: false` — attr forwarding target changed**
Extra attributes previously fell through to the root `<div>` wrapper. They now forward to `<input type="checkbox">`. This is the correct behaviour but may affect apps that relied on attrs landing on the wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added checkbox validation states with dedicated error/success messaging support.
  * Included new checkbox examples for styling and validation.

* **Documentation**
  * Updated checkbox docs with revised examples, improved checkbox-group guidance, and a clearer API reference (including slots and accessibility notes).

* **Accessibility**
  * Improved ARIA behavior for validation: adds `aria-invalid` for error states and more accurate `aria-describedby` linking for helper/validation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->