### PR TITLE
refactor: FwbRadio - accessibility, group support, validation, attr passthrough, and docs rewrite

### DIFF
--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -220,7 +220,7 @@ const picked = ref('vue')
 
 ## Bordered radio
 
-Wrap each `FwbRadio` in a bordered container to create a card-style selection option.
+Apply border styling directly to `FwbRadio` via `wrapper-class` to create a card-style selection option — no external wrapper element is needed.
 
 <fwb-radio-example-bordered />
 ```vue

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -2,23 +2,31 @@
 import FwbRadioExample from './radio/examples/FwbRadioExample.vue'
 import FwbRadioExampleBordered from './radio/examples/FwbRadioExampleBordered.vue'
 import FwbRadioExampleDisabled from './radio/examples/FwbRadioExampleDisabled.vue'
+import FwbRadioExampleGroup from './radio/examples/FwbRadioExampleGroup.vue'
+import FwbRadioExampleHelper from './radio/examples/FwbRadioExampleHelper.vue'
 import FwbRadioExampleInline from './radio/examples/FwbRadioExampleInline.vue'
 import FwbRadioExampleLink from './radio/examples/FwbRadioExampleLink.vue'
 import FwbRadioExampleList from './radio/examples/FwbRadioExampleList.vue'
 import FwbRadioExampleListHorizontal from './radio/examples/FwbRadioExampleListHorizontal.vue'
+import FwbRadioExampleStyling from './radio/examples/FwbRadioExampleStyling.vue'
+import FwbRadioExampleValidation from './radio/examples/FwbRadioExampleValidation.vue'
 </script>
 
-# Vue Toggle Radio - Flowbite
+# Vue Radio - Flowbite
 
 #### Get started with the radio component to let the user choose a single option from multiple options in the form of a circle based on multiple styles and colors
+
+The radio component can be used to allow the user to choose a single option from one or more available options coded with the utility classes from Tailwind CSS and available in multiple styles, variants, and colors and support dark mode.
 
 ---
 
 :::tip
-Original reference: [https://flowbite.com/docs/forms/range/](https://flowbite.com/docs/forms/radio/)
+Original reference: [https://flowbite.com/docs/forms/radio/](https://flowbite.com/docs/forms/radio/)
 :::
 
-## Radio examples
+## Default radio
+
+Use `FwbRadio` with `v-model` and a `value` prop to let the user select a single option. Pass `name` directly on each radio when used standalone, or use `FwbRadioGroup` to share it automatically across child radios.
 
 <fwb-radio-example />
 ```vue
@@ -33,27 +41,18 @@ import { FwbRadio } from 'flowbite-vue'
 
 const picked = ref()
 </script>
+
 ```
 
-## Disabled Radio
+## Disabled state
+
+Set the `disabled` prop to prevent the user from selecting the radio. Disabled styling is applied automatically to both the input and the label text.
 
 <fwb-radio-example-disabled />
 ```vue
 <template>
-  <fwb-radio
-    v-model="picked"
-    disabled
-    label="Disabled radio"
-    name="radio-disabled"
-    value="one"
-  />
-  <fwb-radio
-    v-model="picked"
-    disabled
-    label="Disabled checked"
-    name="radio-disabled"
-    value="two"
-  />
+  <fwb-radio v-model="picked" disabled label="Disabled radio" name="radio-disabled" value="one" />
+  <fwb-radio v-model="picked" disabled label="Disabled checked" name="radio-disabled" value="two" />
 </template>
 
 <script setup>
@@ -64,121 +63,51 @@ const picked = ref('two')
 </script>
 ```
 
-## Radio list group
+## Radio group
 
-<fwb-radio-example-list />
+Use `FwbRadioGroup` to wrap related radio buttons. The `name` prop on the group is shared across all child radios automatically, so you don't need to repeat it on each one.
+
+<fwb-radio-example-group />
+
 ```vue
 <template>
-  <fwb-p class="mb-2">
-    Technology {{ picked }}
-  </fwb-p>
-
-  <fwb-list-group>
-    <fwb-list-group-item>
-      <fwb-radio
-        v-model="picked"
-        label="Svelte"
-        name="list-radio"
-        value="Svelte"
-      />
-    </fwb-list-group-item>
-    <fwb-list-group-item>
-      <fwb-radio
-        v-model="picked"
-        label="Vue JS"
-        name="list-radio"
-        value="Vue JS"
-      />
-    </fwb-list-group-item>
-    <fwb-list-group-item>
-      <fwb-radio
-        v-model="picked"
-        label="React"
-        name="list-radio"
-        value="React"
-      />
-    </fwb-list-group-item>
-    <fwb-list-group-item>
-      <fwb-radio
-        v-model="picked"
-        label="Angular"
-        name="list-radio"
-        value="Angular"
-      />
-    </fwb-list-group-item>
-  </fwb-list-group>
+  <fwb-radio-group name="fruit" label="Pick a fruit">
+    <fwb-radio
+      v-for="fruit in fruits"
+      :key="fruit.value"
+      v-model="picked"
+      :label="fruit.label"
+      :value="fruit.value"
+    />
+  </fwb-radio-group>
 </template>
 
 <script setup>
 import { ref } from 'vue'
-import { FwbListGroup, FwbListGroupItem, FwbP, FwbRadio } from 'flowbite-vue'
+import { FwbRadio, FwbRadioGroup } from 'flowbite-vue'
 
-const picked = ref('Vue JS')
+const fruits = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Orange', value: 'orange' },
+]
+
+const picked = ref('banana')
 </script>
 ```
 
-## Horizontal list group
+## Inline radio
 
-<fwb-radio-example-list-horizontal />
-```vue
-<template>
-  <fwb-p class="mb-2">
-    Technology {{ picked }}
-  </fwb-p>
-  <ul class="items-center w-full text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg sm:flex dark:bg-gray-700 dark:border-gray-600 dark:text-white">
-    <li class="w-full m-0! pl-3 flex border-gray-200 rounded-t-lg dark:border-gray-600">
-      <fwb-radio
-        v-model="picked"
-        label="Svelte"
-        name="radio-horizontal"
-        value="Svelte"
-      />
-    </li>
-    <li class="w-full m-0! pl-3 flex border-gray-200 rounded-t-lg dark:border-gray-600">
-      <fwb-radio
-        v-model="picked"
-        label="Vue JS"
-        name="radio-horizontal"
-        value="Vue JS"
-      />
-    </li>
-    <li class="w-full m-0! pl-3 flex border-gray-200 rounded-t-lg dark:border-gray-600">
-      <fwb-radio
-        v-model="picked"
-        label="React"
-        name="radio-horizontal"
-        value="React"
-      />
-    </li>
-    <li class="w-full m-0! pl-3 flex border-gray-200 rounded-t-lg dark:border-gray-600">
-      <fwb-radio
-        v-model="picked"
-        label="Angular"
-        name="radio-horizontal"
-        value="Angular"
-      />
-    </li>
-  </ul>
-</template>
-
-<script setup>
-import { ref } from 'vue'
-import { FwbP, FwbRadio } from 'flowbite-vue'
-
-const picked = ref('svelte')
-</script>
-```
-
-## Inline Radio
+Place multiple `FwbRadio` components inside a flex wrapper to lay them out horizontally side by side.
 
 <fwb-radio-example-inline />
 ```vue
 <template>
-  <div class="flex w-96">
-    <fwb-radio v-model="picked" label="Inline 1" value="first" />
-    <fwb-radio v-model="picked" label="Inline 2" value="second" />
-    <fwb-radio v-model="picked" label="Inline 3" value="third" />
-    <fwb-radio v-model="picked" label="Inline 4" value="fourth" />
+  <div class="flex gap-2">
+    <fwb-radio v-model="picked" label="Inline 1" name="inline-radio" value="first" />
+    <fwb-radio v-model="picked" label="Inline 2" name="inline-radio" value="second" />
+    <fwb-radio v-model="picked" label="Inline 3" name="inline-radio" value="third" />
+    <fwb-radio v-model="picked" label="Inline 4" name="inline-radio" value="fourth" />
   </div>
 </template>
 
@@ -188,18 +117,19 @@ import { FwbRadio } from 'flowbite-vue'
 
 const picked = ref('first')
 </script>
+
 ```
 
 ## Radio with a link
+
+Use the default slot instead of the `label` prop when the label contains rich content such as links.
 
 <fwb-radio-example-link />
 ```vue
 <template>
   <fwb-radio v-model="picked" name="with-link" value="first">
     I agree with the
-    <fwb-a class="ml-1" href="#">
-      terms and conditions
-    </fwb-a>.
+    <fwb-a class="ml-1" href="#">terms and conditions</fwb-a>.
   </fwb-radio>
 </template>
 
@@ -209,20 +139,107 @@ import { FwbA, FwbRadio } from 'flowbite-vue'
 
 const picked = ref()
 </script>
+
 ```
 
-## Bordered Radio
+## Radio list group
+
+Use `FwbListGroup` and `FwbListGroupItem` to display radio buttons inside a vertical grouped list.
+
+<fwb-radio-example-list />
+```vue
+<template>
+  <fwb-list-group>
+    <fwb-list-group-item v-for="option in options" :key="option.value">
+      <fwb-radio
+        v-model="picked"
+        :label="option.label"
+        name="list-radio"
+        :value="option.value"
+        wrapper-class="-mx-4 -my-2 w-full px-4 py-2"
+      />
+    </fwb-list-group-item>
+  </fwb-list-group>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbListGroup, FwbListGroupItem, FwbRadio } from 'flowbite-vue'
+
+const options = [
+  { label: 'Angular', value: 'Angular' },
+  { label: 'React', value: 'React' },
+  { label: 'Svelte', value: 'Svelte' },
+  { label: 'Vue JS', value: 'Vue JS' },
+]
+
+const picked = ref('Vue JS')
+</script>
+
+```
+
+## Horizontal list group
+
+Nest `FwbRadio` components inside a horizontal `<ul>` to create a full-width inline list selection.
+
+<fwb-radio-example-list-horizontal />
+```vue
+<template>
+  <ul class="w-full items-center rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:flex">
+    <li
+      v-for="option in options"
+      :key="option.value"
+      class="flex w-full border-b border-gray-200 last:border-b-0 dark:border-gray-600 sm:border-b-0 sm:border-r sm:last:border-r-0"
+    >
+      <fwb-radio
+        v-model="picked"
+        :label="option.label"
+        name="radio-horizontal"
+        :value="option.value"
+        wrapper-class="w-full py-2 pl-3"
+      />
+    </li>
+  </ul>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbRadio } from 'flowbite-vue'
+
+const options = [
+  { label: 'Angular', value: 'angular' },
+  { label: 'React', value: 'react' },
+  { label: 'Svelte', value: 'svelte' },
+  { label: 'Vue JS', value: 'vue' },
+]
+
+const picked = ref('vue')
+</script>
+
+```
+
+## Bordered radio
+
+Wrap each `FwbRadio` in a bordered container to create a card-style selection option.
 
 <fwb-radio-example-bordered />
 ```vue
 <template>
   <div class="grid grid-cols-2 gap-6">
-    <div class="flex items-center p-2 border border-gray-200 rounded dark:border-gray-700">
-      <fwb-radio v-model="picked" label="Radio 1" name="radio-bordered" value="one" />
-    </div>
-    <div class="flex items-center p-2 border border-gray-200 rounded dark:border-gray-700">
-      <fwb-radio v-model="picked" label="Radio 2" name="radio-bordered" value="two" />
-    </div>
+    <fwb-radio
+      v-model="picked"
+      label="Radio 1"
+      name="radio-bordered"
+      value="one"
+      wrapper-class="rounded border border-gray-200 p-2 dark:border-gray-700"
+    />
+    <fwb-radio
+      v-model="picked"
+      label="Radio 2"
+      name="radio-bordered"
+      value="two"
+      wrapper-class="rounded border border-gray-200 p-2 dark:border-gray-700"
+    />
   </div>
 </template>
 
@@ -232,4 +249,159 @@ import { FwbRadio } from 'flowbite-vue'
 
 const picked = ref('one')
 </script>
+
 ```
+
+## Validation
+
+Use `validationStatus` on `FwbRadioGroup` together with the `validationMessage` slot to show success or error feedback below the group.
+
+<fwb-radio-example-validation />
+```vue
+<template>
+  <div class="space-y-6">
+    <fwb-radio-group name="fruit-success" label="Pick a fruit (success)" validation-status="success">
+      <fwb-radio v-model="picked1" label="Apple" value="apple" />
+      <fwb-radio v-model="picked1" label="Banana" value="banana" />
+      <template #validationMessage>
+        <span class="font-medium">Great!</span> You selected a fruit.
+      </template>
+    </fwb-radio-group>
+
+    <fwb-radio-group name="fruit-error" label="Pick a fruit (error)" validation-status="error">
+      <fwb-radio v-model="picked2" label="Apple" value="apple" />
+      <fwb-radio v-model="picked2" label="Banana" value="banana" />
+      <template #validationMessage>
+        <span class="font-medium">Required!</span> Please select a fruit to continue.
+      </template>
+    </fwb-radio-group>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbRadio, FwbRadioGroup } from 'flowbite-vue'
+
+const picked1 = ref('banana')
+const picked2 = ref('')
+</script>
+
+```
+
+## Helper text
+
+Use the `helper` slot on `FwbRadioGroup` to show a hint below the group.
+
+<fwb-radio-example-helper />
+```vue
+<template>
+  <fwb-radio-group name="shipping" label="Shipping method">
+    <fwb-radio v-model="picked" label="Standard (3–5 days)" value="standard" />
+    <fwb-radio v-model="picked" label="Express (1–2 days)" value="express" />
+    <template #helper>
+      Delivery times are estimates and may vary during peak seasons.
+    </template>
+  </fwb-radio-group>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbRadio, FwbRadioGroup } from 'flowbite-vue'
+
+const picked = ref('standard')
+</script>
+
+```
+
+## Styling
+
+Use dedicated props to pass classes to individual elements.
+
+<fwb-radio-example-styling />
+```vue
+<template>
+  <fwb-radio-group
+    name="styled"
+    label="Custom styled group"
+    wrapper-class="bg-amber-300 dark:bg-green-800 p-3 pt-2 border-2 border-amber-700 dark:border-green-400 rounded-lg"
+    legend-class="mb-0 px-2 font-bold text-amber-900 dark:text-green-200"
+  >
+    <fwb-radio
+      v-model="picked"
+      label="Option A"
+      value="a"
+      class="text-amber-600 dark:text-green-500 focus:ring-amber-500 dark:focus:ring-green-400"
+      label-class="text-amber-900 dark:text-green-200"
+    />
+    <fwb-radio
+      v-model="picked"
+      label="Option B"
+      value="b"
+      class="text-amber-600 dark:text-green-500 focus:ring-amber-500 dark:focus:ring-green-400"
+      label-class="text-amber-900 dark:text-green-200"
+    />
+  </fwb-radio-group>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbRadio, FwbRadioGroup } from 'flowbite-vue'
+
+const picked = ref('a')
+</script>
+
+```
+
+## FwbRadio component API
+
+### FwbRadio Props
+
+:::tip Native attribute passthrough
+`FwbRadio` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `form`, `aria-label`) directly to the `<input type="radio">` element. When using radios outside a `FwbRadioGroup`, pass `name` as either a prop or an attribute.
+:::
+
+| Name         | Type               | Default | Description                                                                   |
+| ------------ | ------------------ | ------- | ----------------------------------------------------------------------------- |
+| class        | `String \| Object` | `''`    | Added to the radio input element.                                             |
+| disabled     | `Boolean`          | `false` | Disables the radio.                                                           |
+| label        | `String`           | `''`    | Label text rendered next to the radio. Ignored when the default slot is used. |
+| labelClass   | `String \| Object` | `''`    | Added to the label text element.                                              |
+| modelValue   | `Any`              | —       | The current value (use with `v-model`).                                       |
+| name         | `String`           | `''`    | Groups radio buttons together. Inherited from `FwbRadioGroup` when omitted.   |
+| value        | `String`           | `''`    | The value this radio represents.                                              |
+| wrapperClass | `String \| Object` | `''`    | Added to the outer `<label>` element.                                         |
+
+:::tip Accessibility
+When a `FwbRadio` is inside a `FwbRadioGroup` with `validationStatus="error"`, `aria-invalid="true"` is set automatically on the input — you do not need to set it manually on individual radios. `aria-describedby` is managed at the fieldset level by `FwbRadioGroup`. For radios without a visible label, pass `aria-label` as an attribute — it is forwarded directly to the `<input type="radio">`.
+:::
+
+### FwbRadio Slots
+
+| Name    | Description                                                                       |
+| ------- | --------------------------------------------------------------------------------- |
+| default | Rich label content rendered next to the radio (takes priority over `label` prop). |
+
+## FwbRadioGroup component API
+
+### FwbRadioGroup Props
+
+:::tip Accessibility
+`FwbRadioGroup` renders as a `<fieldset>` with a `<legend>`. `aria-invalid="true"` is set on every child `FwbRadio` when `validationStatus="error"`. `aria-describedby` on the fieldset is wired to the IDs of any rendered `validationMessage` and `helper` slots.
+:::
+
+| Name             | Type                   | Default     | Description                                                                     |
+| ---------------- | ---------------------- | ----------- | ------------------------------------------------------------------------------- |
+| label            | `String`               | `''`        | Legend text for the group. Ignored when the `legend` slot is used.              |
+| legendClass      | `String \| Object`     | `''`        | Added to the `<legend>` element.                                                |
+| name             | `String`               | —           | **Required.** Shared `name` attribute provided to all child `FwbRadio` inputs.  |
+| validationStatus | `'success' \| 'error'` | `undefined` | Applies success or error colour styles and sets `aria-invalid` on child radios. |
+| wrapperClass     | `String \| Object`     | `''`        | Added to the outer `<fieldset>` element.                                        |
+
+### FwbRadioGroup Slots
+
+| Name              | Description                                                                  |
+| ----------------- | ---------------------------------------------------------------------------- |
+| default           | Container for `FwbRadio` instances.                                          |
+| legend            | Rich legend content (takes priority over `label` prop).                      |
+| helper            | Helper text rendered below the group.                                        |
+| validationMessage | Validation feedback rendered below the group (styled by `validationStatus`). |

--- a/docs/components/radio/examples/FwbRadioExampleBordered.vue
+++ b/docs/components/radio/examples/FwbRadioExampleBordered.vue
@@ -1,21 +1,19 @@
 <template>
   <div class="vp-raw grid grid-cols-2 gap-6">
-    <div class="flex items-center rounded border border-gray-200 p-2 dark:border-gray-700">
-      <fwb-radio
-        v-model="picked"
-        label="Radio 1"
-        name="radio-bordered"
-        value="one"
-      />
-    </div>
-    <div class="flex items-center rounded border border-gray-200 p-2 dark:border-gray-700">
-      <fwb-radio
-        v-model="picked"
-        label="Radio 2"
-        name="radio-bordered"
-        value="two"
-      />
-    </div>
+    <fwb-radio
+      v-model="picked"
+      label="Radio 1"
+      name="radio-bordered"
+      value="one"
+      wrapper-class="rounded border border-gray-200 p-2 dark:border-gray-700"
+    />
+    <fwb-radio
+      v-model="picked"
+      label="Radio 2"
+      name="radio-bordered"
+      value="two"
+      wrapper-class="rounded border border-gray-200 p-2 dark:border-gray-700"
+    />
   </div>
 </template>
 

--- a/docs/components/radio/examples/FwbRadioExampleGroup.vue
+++ b/docs/components/radio/examples/FwbRadioExampleGroup.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="vp-raw">
-    <fwb-radio-group name="fruit" label="Pick a fruit">
+    <fwb-radio-group
+      name="fruit"
+      label="Pick a fruit"
+    >
       <fwb-radio
         v-for="fruit in fruits"
         :key="fruit.value"

--- a/docs/components/radio/examples/FwbRadioExampleGroup.vue
+++ b/docs/components/radio/examples/FwbRadioExampleGroup.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="vp-raw">
+    <fwb-radio-group name="fruit" label="Pick a fruit">
+      <fwb-radio
+        v-for="fruit in fruits"
+        :key="fruit.value"
+        v-model="picked"
+        :label="fruit.label"
+        :value="fruit.value"
+      />
+    </fwb-radio-group>
+    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+      Selected: {{ picked }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRadio, FwbRadioGroup } from '../../../../src/index'
+
+const fruits = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Orange', value: 'orange' },
+]
+
+const picked = ref('banana')
+</script>

--- a/docs/components/radio/examples/FwbRadioExampleHelper.vue
+++ b/docs/components/radio/examples/FwbRadioExampleHelper.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="vp-raw">
+    <fwb-radio-group name="shipping" label="Shipping method">
+      <fwb-radio v-model="picked" label="Standard (3–5 days)" value="standard" />
+      <fwb-radio v-model="picked" label="Express (1–2 days)" value="express" />
+      <template #helper>
+        Delivery times are estimates and may vary during peak seasons.
+      </template>
+    </fwb-radio-group>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRadio, FwbRadioGroup } from '../../../../src/index'
+
+const picked = ref('standard')
+</script>

--- a/docs/components/radio/examples/FwbRadioExampleInline.vue
+++ b/docs/components/radio/examples/FwbRadioExampleInline.vue
@@ -1,23 +1,27 @@
 <template>
-  <div class="vp-raw flex w-96">
+  <div class="flex gap-2 vp-raw">
     <fwb-radio
       v-model="picked"
       label="Inline 1"
+      name="inline-radio"
       value="first"
     />
     <fwb-radio
       v-model="picked"
       label="Inline 2"
+      name="inline-radio"
       value="second"
     />
     <fwb-radio
       v-model="picked"
       label="Inline 3"
+      name="inline-radio"
       value="third"
     />
     <fwb-radio
       v-model="picked"
       label="Inline 4"
+      name="inline-radio"
       value="fourth"
     />
   </div>

--- a/docs/components/radio/examples/FwbRadioExampleList.vue
+++ b/docs/components/radio/examples/FwbRadioExampleList.vue
@@ -1,40 +1,20 @@
 <template>
   <div class="vp-raw">
     <fwb-p class="mb-2">
-      Technology {{ picked }}
+      Selected: <em>{{ picked }}</em>
     </fwb-p>
 
     <fwb-list-group>
-      <fwb-list-group-item>
+      <fwb-list-group-item
+        v-for="option in options"
+        :key="option.value"
+      >
         <fwb-radio
           v-model="picked"
-          label="Svelte"
+          :label="option.label"
           name="list-radio"
-          value="Svelte"
-        />
-      </fwb-list-group-item>
-      <fwb-list-group-item>
-        <fwb-radio
-          v-model="picked"
-          label="Vue JS"
-          name="list-radio"
-          value="Vue JS"
-        />
-      </fwb-list-group-item>
-      <fwb-list-group-item>
-        <fwb-radio
-          v-model="picked"
-          label="React"
-          name="list-radio"
-          value="React"
-        />
-      </fwb-list-group-item>
-      <fwb-list-group-item>
-        <fwb-radio
-          v-model="picked"
-          label="Angular"
-          name="list-radio"
-          value="Angular"
+          :value="option.value"
+          wrapper-class="-mx-4 -my-2 w-full px-4 py-2"
         />
       </fwb-list-group-item>
     </fwb-list-group>
@@ -45,6 +25,13 @@
 import { ref } from 'vue'
 
 import { FwbListGroup, FwbListGroupItem, FwbP, FwbRadio } from '../../../../src/index'
+
+const options = [
+  { label: 'Angular', value: 'Angular' },
+  { label: 'React', value: 'React' },
+  { label: 'Svelte', value: 'Svelte' },
+  { label: 'Vue JS', value: 'Vue JS' },
+]
 
 const picked = ref('Vue JS')
 </script>

--- a/docs/components/radio/examples/FwbRadioExampleListHorizontal.vue
+++ b/docs/components/radio/examples/FwbRadioExampleListHorizontal.vue
@@ -1,49 +1,37 @@
 <template>
   <div class="vp-raw">
-    <fwb-p class="mb-2">
-      Technology {{ picked }}
-    </fwb-p>
     <ul class="w-full items-center rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:flex">
-      <li class="m-0! flex w-full rounded-t-lg border-gray-200 pl-3 dark:border-gray-600">
+      <li
+        v-for="option in options"
+        :key="option.value"
+        class="m-0 flex w-full border-b border-gray-200 last:border-b-0 dark:border-gray-600 sm:border-b-0 sm:border-r sm:last:border-r-0"
+      >
         <fwb-radio
           v-model="picked"
-          label="Svelte"
+          :label="option.label"
           name="radio-horizontal"
-          value="Svelte"
-        />
-      </li>
-      <li class="m-0! flex w-full rounded-t-lg border-gray-200 pl-3 dark:border-gray-600">
-        <fwb-radio
-          v-model="picked"
-          label="Vue JS"
-          name="radio-horizontal"
-          value="Vue JS"
-        />
-      </li>
-      <li class="m-0! flex w-full rounded-t-lg border-gray-200 pl-3 dark:border-gray-600">
-        <fwb-radio
-          v-model="picked"
-          label="React"
-          name="radio-horizontal"
-          value="React"
-        />
-      </li>
-      <li class="m-0! flex w-full rounded-t-lg border-gray-200 pl-3 dark:border-gray-600">
-        <fwb-radio
-          v-model="picked"
-          label="Angular"
-          name="radio-horizontal"
-          value="Angular"
+          :value="option.value"
+          wrapper-class="w-full py-2 pl-3"
         />
       </li>
     </ul>
+    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+      Selected: {{ picked }}
+    </p>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue'
 
-import { FwbP, FwbRadio } from '../../../../src/index'
+import { FwbRadio } from '../../../../src/index'
 
-const picked = ref('svelte')
+const options = [
+  { label: 'Angular', value: 'angular' },
+  { label: 'React', value: 'react' },
+  { label: 'Svelte', value: 'svelte' },
+  { label: 'Vue JS', value: 'vue' },
+]
+
+const picked = ref('vue')
 </script>

--- a/docs/components/radio/examples/FwbRadioExampleStyling.vue
+++ b/docs/components/radio/examples/FwbRadioExampleStyling.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="vp-raw">
+    <fwb-radio-group
+      name="styled"
+      label="Custom styled group"
+      wrapper-class="bg-amber-300 dark:bg-green-800 p-3 pt-2 border-2 border-amber-700 dark:border-green-400 rounded-lg"
+      legend-class="mb-0 px-2 font-bold text-amber-900 dark:text-green-200"
+    >
+      <fwb-radio
+        v-model="picked"
+        label="Option A"
+        value="a"
+        class="focus:ring-amber-500 dark:focus:ring-green-400 text-amber-600 dark:text-green-500"
+        label-class="text-amber-900 dark:text-green-200"
+      />
+      <fwb-radio
+        v-model="picked"
+        label="Option B"
+        value="b"
+        class="focus:ring-amber-500 dark:focus:ring-green-400 text-amber-600 dark:text-green-500"
+        label-class="text-amber-900 dark:text-green-200"
+      />
+    </fwb-radio-group>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRadio, FwbRadioGroup } from '../../../../src/index'
+
+const picked = ref('a')
+</script>

--- a/docs/components/radio/examples/FwbRadioExampleValidation.vue
+++ b/docs/components/radio/examples/FwbRadioExampleValidation.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="vp-raw space-y-6">
+    <fwb-radio-group name="fruit-success" label="Pick a fruit (success)" validation-status="success">
+      <fwb-radio v-model="picked1" label="Apple" value="apple" />
+      <fwb-radio v-model="picked1" label="Banana" value="banana" />
+      <template #validationMessage>
+        <span class="font-medium">Great!</span> You selected a fruit.
+      </template>
+    </fwb-radio-group>
+
+    <fwb-radio-group name="fruit-error" label="Pick a fruit (error)" validation-status="error">
+      <fwb-radio v-model="picked2" label="Apple" value="apple" />
+      <fwb-radio v-model="picked2" label="Banana" value="banana" />
+      <template #validationMessage>
+        <span class="font-medium">Required!</span> Please select a fruit to continue.
+      </template>
+    </fwb-radio-group>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbRadio, FwbRadioGroup } from '../../../../src/index'
+
+const picked1 = ref('banana')
+const picked2 = ref('')
+</script>

--- a/src/components/FwbRadio/FwbRadio.vue
+++ b/src/components/FwbRadio/FwbRadio.vue
@@ -1,54 +1,62 @@
 <template>
-  <label class="flex w-full items-center">
+  <label :class="wrapperClass">
     <input
+      v-bind="inputAttributes"
       v-model="model"
-      type="radio"
       :disabled="disabled"
-      :name="name"
+      :name="effectiveName || undefined"
       :value="value"
-      :class="radioClasses"
+      class="shrink-0"
+      :class="radioClass"
+      type="radio"
     >
-    <span :class="labelClasses">{{ label }}</span>
-    <slot />
+    <span
+      v-if="label || $slots.default"
+      :class="labelClass"
+    >
+      <slot>{{ label }}</slot>
+    </span>
   </label>
 </template>
 
-<script setup lang="ts">
-import { twMerge } from 'tailwind-merge'
-import { computed } from 'vue'
+<script lang="ts" setup>
+import { computed, inject, ref, toRefs } from 'vue'
 
-interface RadioProps {
-  modelValue?: string
-  name?: string
-  value?: string
-  label?: string
-  disabled?: boolean
-}
-const radioDefaultClasses = 'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-const radioLabelClasses = 'm-2 mr-0 text-sm font-medium text-gray-900 dark:text-gray-300'
+import { useRadioClasses } from './composables/useRadioClasses'
+import { radioGroupNameKey, radioGroupValidationStatusKey } from './types'
+
+import type { RadioProps } from './types'
+
+import { useElementAttributes } from '@/composables/useElementAttributes'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<RadioProps>(), {
-  modelValue: '',
+  class: '',
+  disabled: false,
+  label: '',
+  labelClass: '',
   name: '',
   value: '',
-  label: '',
-  disabled: false,
+  wrapperClass: '',
 })
 
-const emit = defineEmits(['update:modelValue'])
-const model = computed({
-  get () {
-    return props.modelValue
-  },
-  set (val) {
-    emit('update:modelValue', val)
-  },
-})
-const radioClasses = computed(() => {
-  return radioDefaultClasses
-})
+const model = defineModel<string | number | boolean | null | undefined | (string | number | boolean | object)[]>()
 
-const labelClasses = computed(() => {
-  return twMerge(radioLabelClasses, props.disabled && 'text-gray-400 dark:text-gray-500')
+const { elementAttributes: radioAttributes } = useElementAttributes()
+
+const groupName = inject(radioGroupNameKey, undefined)
+const groupValidationStatus = inject(radioGroupValidationStatusKey, ref(undefined))
+
+const effectiveName = computed(() => props.name || groupName?.value || '')
+
+const inputAttributes = computed(() => ({
+  ...radioAttributes.value,
+  ...(groupValidationStatus.value === 'error' ? { 'aria-invalid': true } : {}),
+}))
+
+const { labelClass, radioClass, wrapperClass } = useRadioClasses({
+  ...toRefs(props),
+  validationStatus: groupValidationStatus,
 })
 </script>

--- a/src/components/FwbRadio/FwbRadio.vue
+++ b/src/components/FwbRadio/FwbRadio.vue
@@ -23,9 +23,7 @@
 import { computed, inject, ref, toRefs } from 'vue'
 
 import { useRadioClasses } from './composables/useRadioClasses'
-import { radioGroupNameKey, radioGroupValidationStatusKey } from './types'
-
-import type { RadioProps } from './types'
+import { radioGroupNameKey, radioGroupValidationStatusKey, type RadioProps } from './types'
 
 import { useElementAttributes } from '@/composables/useElementAttributes'
 

--- a/src/components/FwbRadio/FwbRadioGroup.vue
+++ b/src/components/FwbRadio/FwbRadioGroup.vue
@@ -8,7 +8,9 @@
       v-if="label || $slots.legend"
       :class="legendClass"
     >
-      <slot name="legend">{{ label }}</slot>
+      <slot name="legend">
+        {{ label }}
+      </slot>
     </legend>
     <slot />
     <p
@@ -32,9 +34,7 @@
 import { provide, toRef, toRefs } from 'vue'
 
 import { useRadioGroupClasses } from './composables/useRadioGroupClasses'
-import { radioGroupNameKey, radioGroupValidationStatusKey } from './types'
-
-import type { RadioGroupProps } from './types'
+import { radioGroupNameKey, type RadioGroupProps, radioGroupValidationStatusKey } from './types'
 
 import { useElementAttributes } from '@/composables/useElementAttributes'
 import { useFormFieldIds } from '@/composables/useFormFieldIds'

--- a/src/components/FwbRadio/FwbRadioGroup.vue
+++ b/src/components/FwbRadio/FwbRadioGroup.vue
@@ -1,0 +1,58 @@
+<template>
+  <fieldset
+    v-bind="fieldsetAttributes"
+    :aria-describedby="ariaDescribedby"
+    :class="wrapperClass"
+  >
+    <legend
+      v-if="label || $slots.legend"
+      :class="legendClass"
+    >
+      <slot name="legend">{{ label }}</slot>
+    </legend>
+    <slot />
+    <p
+      v-if="$slots.validationMessage"
+      :id="validationMessageId"
+      :class="validationMessageClass"
+    >
+      <slot name="validationMessage" />
+    </p>
+    <p
+      v-if="$slots.helper"
+      :id="helperId"
+      :class="helperMessageClass"
+    >
+      <slot name="helper" />
+    </p>
+  </fieldset>
+</template>
+
+<script lang="ts" setup>
+import { provide, toRef, toRefs } from 'vue'
+
+import { useRadioGroupClasses } from './composables/useRadioGroupClasses'
+import { radioGroupNameKey, radioGroupValidationStatusKey } from './types'
+
+import type { RadioGroupProps } from './types'
+
+import { useElementAttributes } from '@/composables/useElementAttributes'
+import { useFormFieldIds } from '@/composables/useFormFieldIds'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<RadioGroupProps>(), {
+  label: '',
+  legendClass: '',
+  validationStatus: undefined,
+  wrapperClass: '',
+})
+
+const { elementId: fieldsetId, elementAttributes: fieldsetAttributes } = useElementAttributes()
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(fieldsetId)
+
+provide(radioGroupNameKey, toRef(props, 'name'))
+provide(radioGroupValidationStatusKey, toRef(props, 'validationStatus'))
+
+const { helperMessageClass, legendClass, validationMessageClass, wrapperClass } = useRadioGroupClasses(toRefs(props))
+</script>

--- a/src/components/FwbRadio/composables/useRadioClasses.ts
+++ b/src/components/FwbRadio/composables/useRadioClasses.ts
@@ -1,0 +1,43 @@
+import { computed, type Ref } from 'vue'
+
+import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type ValidationStatus, validationStatusMap } from '@/types/form'
+
+const defaultRadioClasses = 'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed'
+const defaultLabelClasses = 'ms-2 text-sm font-medium'
+
+const defaultWrapperClasses = 'flex items-center'
+
+const errorTextClasses = 'text-red-700 dark:text-red-500'
+const successTextClasses = 'text-green-700 dark:text-green-500'
+const neutralTextClasses = 'text-gray-900 dark:text-gray-300'
+
+export type UseRadioClassesProps = {
+  class: Ref<string | Record<string, boolean>>
+  disabled: Ref<boolean>
+  labelClass: Ref<string | Record<string, boolean>>
+  validationStatus: Ref<ValidationStatus | undefined>
+  wrapperClass: Ref<string | Record<string, boolean>>
+}
+
+export function useRadioClasses (props: UseRadioClassesProps) {
+  const wrapperClass = computed(() => useMergeClasses([defaultWrapperClasses, props.wrapperClass.value]))
+
+  const radioClass = computed(() => useMergeClasses([defaultRadioClasses, props.class.value]))
+
+  const labelClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultLabelClasses,
+      vs === validationStatusMap.Error
+        ? errorTextClasses
+        : vs === validationStatusMap.Success
+          ? successTextClasses
+          : neutralTextClasses,
+      props.disabled.value ? 'opacity-50 cursor-not-allowed' : '',
+      props.labelClass.value,
+    ])
+  })
+
+  return { labelClass, radioClass, wrapperClass }
+}

--- a/src/components/FwbRadio/composables/useRadioGroupClasses.ts
+++ b/src/components/FwbRadio/composables/useRadioGroupClasses.ts
@@ -1,0 +1,49 @@
+import { computed, type Ref } from 'vue'
+
+import { useMergeClasses } from '@/composables/useMergeClasses'
+import { type ValidationStatus, validationStatusMap } from '@/types/form'
+
+const defaultWrapperClasses = 'border-0 m-0 p-0 min-w-0'
+const defaultLegendClasses = 'mb-2 text-sm font-medium'
+const defaultHelperClasses = 'mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'
+
+const errorTextClasses = 'text-red-700 dark:text-red-500'
+const successTextClasses = 'text-green-700 dark:text-green-500'
+const neutralTextClasses = 'text-gray-900 dark:text-gray-300'
+
+export type UseRadioGroupClassesProps = {
+  legendClass: Ref<string | Record<string, boolean>>
+  validationStatus: Ref<ValidationStatus | undefined>
+  wrapperClass: Ref<string | Record<string, boolean>>
+}
+
+export function useRadioGroupClasses (props: UseRadioGroupClassesProps) {
+  const wrapperClass = computed(() => useMergeClasses([defaultWrapperClasses, props.wrapperClass.value]))
+
+  const legendClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultLegendClasses,
+      vs === validationStatusMap.Error
+        ? errorTextClasses
+        : vs === validationStatusMap.Success
+          ? successTextClasses
+          : neutralTextClasses,
+      props.legendClass.value,
+    ])
+  })
+
+  const validationMessageClass = computed(() => {
+    const vs = props.validationStatus.value
+    return useMergeClasses([
+      defaultHelperClasses,
+      vs === validationStatusMap.Success
+        ? successTextClasses
+        : vs === validationStatusMap.Error ? errorTextClasses : '',
+    ])
+  })
+
+  const helperMessageClass = computed(() => useMergeClasses([defaultHelperClasses]))
+
+  return { helperMessageClass, legendClass, validationMessageClass, wrapperClass }
+}

--- a/src/components/FwbRadio/tests/FwbRadio.spec.ts
+++ b/src/components/FwbRadio/tests/FwbRadio.spec.ts
@@ -1,0 +1,101 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbRadio from '../FwbRadio.vue'
+
+describe('FwbRadio', () => {
+  describe('label/radio structure', () => {
+    it('radio is inside the label element', () => {
+      const wrapper = mount(FwbRadio)
+      expect(wrapper.element.tagName).toBe('LABEL')
+      expect(wrapper.find('input[type="radio"]').exists()).toBe(true)
+    })
+
+    it('has a stable generated id on the radio input', () => {
+      const wrapper = mount(FwbRadio)
+      expect(wrapper.find('input[type="radio"]').attributes('id')).toBeDefined()
+    })
+
+    it('uses a user-provided id on the radio input', () => {
+      const wrapper = mount(FwbRadio, { attrs: { id: 'my-radio' } })
+      expect(wrapper.find('input[type="radio"]').attributes('id')).toBe('my-radio')
+    })
+
+    it('renders label text when label prop is provided', () => {
+      const wrapper = mount(FwbRadio, { props: { label: 'Option A' } })
+      expect(wrapper.find('label span').text()).toBe('Option A')
+    })
+
+    it('renders no label span when neither label prop nor default slot is provided', () => {
+      const wrapper = mount(FwbRadio)
+      expect(wrapper.find('label span').exists()).toBe(false)
+    })
+
+    it('renders slot content when default slot is provided', () => {
+      const wrapper = mount(FwbRadio, { slots: { default: 'I agree' } })
+      expect(wrapper.find('label span').text()).toBe('I agree')
+    })
+
+    it('slot content takes priority over label prop', () => {
+      const wrapper = mount(FwbRadio, {
+        props: { label: 'prop label' },
+        slots: { default: 'slot label' },
+      })
+      expect(wrapper.find('label span').text()).toBe('slot label')
+    })
+  })
+
+  describe('native attribute passthrough', () => {
+    it('passes extra attrs to the radio input, not the root label', () => {
+      const wrapper = mount(FwbRadio, { attrs: { form: 'signup', 'data-test': 'x' } })
+      const radio = wrapper.find('input[type="radio"]')
+      expect(radio.attributes('form')).toBe('signup')
+      expect(radio.attributes('data-test')).toBe('x')
+      expect(wrapper.element.getAttribute('form')).toBeNull()
+    })
+
+    it('forwards value attr to the radio', () => {
+      const wrapper = mount(FwbRadio, { props: { value: 'banana' } })
+      expect(wrapper.find('input[type="radio"]').attributes('value')).toBe('banana')
+    })
+
+    it('disabled prop reaches the radio input', () => {
+      const wrapper = mount(FwbRadio, { props: { disabled: true } })
+      expect(wrapper.find('input[type="radio"]').attributes('disabled')).toBeDefined()
+    })
+
+    it('name prop is set on the radio input', () => {
+      const wrapper = mount(FwbRadio, { props: { name: 'flavour' } })
+      expect(wrapper.find('input[type="radio"]').attributes('name')).toBe('flavour')
+    })
+  })
+
+  describe('aria-invalid', () => {
+    it('is absent when used standalone with no group', () => {
+      const wrapper = mount(FwbRadio)
+      expect(wrapper.find('input[type="radio"]').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('preserves a user-provided aria-invalid when no group is present', () => {
+      const wrapper = mount(FwbRadio, { attrs: { 'aria-invalid': 'grammar' } })
+      expect(wrapper.find('input[type="radio"]').attributes('aria-invalid')).toBe('grammar')
+    })
+  })
+
+  describe('styling props', () => {
+    it('applies class prop to the radio input', () => {
+      const wrapper = mount(FwbRadio, { props: { class: 'text-red-500' } })
+      expect(wrapper.find('input[type="radio"]').classes()).toContain('text-red-500')
+    })
+
+    it('applies wrapperClass to the root label element', () => {
+      const wrapper = mount(FwbRadio, { props: { wrapperClass: 'p-4' } })
+      expect(wrapper.element.classList).toContain('p-4')
+    })
+
+    it('applies labelClass to the label text span', () => {
+      const wrapper = mount(FwbRadio, { props: { label: 'Option', labelClass: 'font-bold' } })
+      expect(wrapper.find('label span').classes()).toContain('font-bold')
+    })
+  })
+})

--- a/src/components/FwbRadio/tests/FwbRadio.spec.ts
+++ b/src/components/FwbRadio/tests/FwbRadio.spec.ts
@@ -47,7 +47,7 @@ describe('FwbRadio', () => {
 
   describe('native attribute passthrough', () => {
     it('passes extra attrs to the radio input, not the root label', () => {
-      const wrapper = mount(FwbRadio, { attrs: { form: 'signup', 'data-test': 'x' } })
+      const wrapper = mount(FwbRadio, { attrs: { 'form': 'signup', 'data-test': 'x' } })
       const radio = wrapper.find('input[type="radio"]')
       expect(radio.attributes('form')).toBe('signup')
       expect(radio.attributes('data-test')).toBe('x')

--- a/src/components/FwbRadio/tests/FwbRadioGroup.spec.ts
+++ b/src/components/FwbRadio/tests/FwbRadioGroup.spec.ts
@@ -1,0 +1,202 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { h } from 'vue'
+
+import FwbRadio from '../FwbRadio.vue'
+import FwbRadioGroup from '../FwbRadioGroup.vue'
+
+const radioSlot = (props?: Record<string, unknown>) => () => h(FwbRadio, { label: 'Apple', value: 'apple', ...props })
+
+describe('FwbRadioGroup', () => {
+  describe('structure', () => {
+    it('renders a fieldset', () => {
+      const wrapper = mount(FwbRadioGroup, { props: { name: 'fruit' } })
+      expect(wrapper.element.tagName).toBe('FIELDSET')
+    })
+
+    it('renders a legend when label prop is provided', () => {
+      const wrapper = mount(FwbRadioGroup, { props: { name: 'fruit', label: 'Pick a fruit' } })
+      expect(wrapper.find('legend').text()).toBe('Pick a fruit')
+    })
+
+    it('renders legend slot content when provided', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit' },
+        slots: { legend: 'Rich <strong>legend</strong>' },
+      })
+      expect(wrapper.find('legend').html()).toContain('<strong>legend</strong>')
+    })
+
+    it('legend slot takes priority over label prop', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', label: 'prop label' },
+        slots: { legend: 'slot label' },
+      })
+      expect(wrapper.find('legend').text()).toBe('slot label')
+    })
+
+    it('renders no legend when neither label nor legend slot is provided', () => {
+      const wrapper = mount(FwbRadioGroup, { props: { name: 'fruit' } })
+      expect(wrapper.find('legend').exists()).toBe(false)
+    })
+  })
+
+  describe('provide/inject — name', () => {
+    it('provides name to child FwbRadio so name prop on radio can be omitted', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit' },
+        slots: { default: radioSlot() },
+      })
+      expect(wrapper.find('input[type="radio"]').attributes('name')).toBe('fruit')
+    })
+
+    it('child radio name prop overrides group name', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit' },
+        slots: { default: radioSlot({ name: 'override' }) },
+      })
+      expect(wrapper.find('input[type="radio"]').attributes('name')).toBe('override')
+    })
+  })
+
+  describe('provide/inject — validationStatus', () => {
+    it('sets aria-invalid on child radio inputs when validationStatus is "error"', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error' },
+        slots: { default: radioSlot() },
+      })
+      expect(wrapper.find('input[type="radio"]').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('does not set aria-invalid on child radios when validationStatus is "success"', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'success' },
+        slots: { default: radioSlot() },
+      })
+      expect(wrapper.find('input[type="radio"]').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('slots', () => {
+    it('renders validationMessage slot', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error' },
+        slots: { validationMessage: 'Required field' },
+      })
+      expect(wrapper.text()).toContain('Required field')
+    })
+
+    it('renders helper slot', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit' },
+        slots: { helper: 'Choose one option' },
+      })
+      expect(wrapper.text()).toContain('Choose one option')
+    })
+  })
+
+  describe('aria-describedby', () => {
+    it('is absent when no validationMessage or helper slots are provided', () => {
+      const wrapper = mount(FwbRadioGroup, { props: { name: 'fruit' } })
+      expect(wrapper.element.getAttribute('aria-describedby')).toBeNull()
+    })
+
+    it('points to the helper paragraph id when helper slot is provided', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit' },
+        slots: { helper: 'Hint' },
+      })
+      const helperP = wrapper.find('p')
+      expect(wrapper.element.getAttribute('aria-describedby')).toBe(helperP.attributes('id'))
+    })
+
+    it('points to the validationMessage paragraph id when that slot is provided', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error' },
+        slots: { validationMessage: 'Required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.element.getAttribute('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+
+    it('includes both IDs when both slots are rendered', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error' },
+        slots: { validationMessage: 'Required', helper: 'Choose one' },
+      })
+      const describedby = wrapper.element.getAttribute('aria-describedby') ?? ''
+      const ids = describedby.split(' ')
+      expect(ids).toHaveLength(2)
+      ids.forEach((id: string) => expect(wrapper.find(`#${id}`).exists()).toBe(true))
+    })
+  })
+
+  describe('validation styling', () => {
+    it('applies error color to legend when validationStatus is "error"', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', label: 'Pick fruit', validationStatus: 'error' },
+      })
+      expect(wrapper.find('legend').classes()).toContain('text-red-700')
+    })
+
+    it('applies success color to legend when validationStatus is "success"', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', label: 'Pick fruit', validationStatus: 'success' },
+      })
+      expect(wrapper.find('legend').classes()).toContain('text-green-700')
+    })
+
+    it('applies neutral color to legend when validationStatus is not set', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', label: 'Pick fruit' },
+      })
+      expect(wrapper.find('legend').classes()).toContain('text-gray-900')
+    })
+
+    it('applies error color to validationMessage text', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error' },
+        slots: { validationMessage: 'Required' },
+      })
+      expect(wrapper.find('p').classes()).toContain('text-red-700')
+    })
+
+    it('applies error color to child radio label text when validationStatus is "error"', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error' },
+        slots: { default: radioSlot() },
+      })
+      expect(wrapper.find('label span').classes()).toContain('text-red-700')
+    })
+
+    it('applies success color to child radio label text when validationStatus is "success"', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'success' },
+        slots: { default: radioSlot() },
+      })
+      expect(wrapper.find('label span').classes()).toContain('text-green-700')
+    })
+
+    it('applies neutral color to child radio label text when validationStatus is not set', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit' },
+        slots: { default: radioSlot() },
+      })
+      expect(wrapper.find('label span').classes()).toContain('text-gray-900')
+    })
+  })
+
+  describe('styling props', () => {
+    it('applies wrapperClass to the fieldset', () => {
+      const wrapper = mount(FwbRadioGroup, { props: { name: 'fruit', wrapperClass: 'p-4' } })
+      expect(wrapper.element.classList).toContain('p-4')
+    })
+
+    it('applies legendClass to the legend', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', label: 'Pick fruit', legendClass: 'font-bold' },
+      })
+      expect(wrapper.find('legend').classes()).toContain('font-bold')
+    })
+  })
+})

--- a/src/components/FwbRadio/types.ts
+++ b/src/components/FwbRadio/types.ts
@@ -1,6 +1,5 @@
-import type { InjectionKey, Ref } from 'vue'
-
 import type { ValidationStatus } from '@/types/form'
+import type { InjectionKey, Ref } from 'vue'
 
 export interface RadioProps {
   class?: string | Record<string, boolean>
@@ -8,7 +7,7 @@ export interface RadioProps {
   label?: string
   labelClass?: string | Record<string, boolean>
   name?: string
-  value?: string
+  value?: string | number | boolean | object
   wrapperClass?: string | Record<string, boolean>
 }
 

--- a/src/components/FwbRadio/types.ts
+++ b/src/components/FwbRadio/types.ts
@@ -1,0 +1,24 @@
+import type { InjectionKey, Ref } from 'vue'
+
+import type { ValidationStatus } from '@/types/form'
+
+export interface RadioProps {
+  class?: string | Record<string, boolean>
+  disabled?: boolean
+  label?: string
+  labelClass?: string | Record<string, boolean>
+  name?: string
+  value?: string
+  wrapperClass?: string | Record<string, boolean>
+}
+
+export interface RadioGroupProps {
+  label?: string
+  legendClass?: string | Record<string, boolean>
+  name: string
+  validationStatus?: ValidationStatus
+  wrapperClass?: string | Record<string, boolean>
+}
+
+export const radioGroupNameKey: InjectionKey<Ref<string>> = Symbol('radioGroupName')
+export const radioGroupValidationStatusKey: InjectionKey<Ref<ValidationStatus | undefined>> = Symbol('radioGroupValidationStatus')

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export { default as FwbCheckbox } from '@/components/FwbCheckbox/FwbCheckbox.vue
 export { default as FwbFileInput } from '@/components/FwbFileInput/FwbFileInput.vue'
 export { default as FwbInput } from '@/components/FwbInput/FwbInput.vue'
 export { default as FwbRadio } from '@/components/FwbRadio/FwbRadio.vue'
+export { default as FwbRadioGroup } from '@/components/FwbRadio/FwbRadioGroup.vue'
 export { default as FwbRange } from '@/components/FwbRange/FwbRange.vue'
 export { default as FwbSelect } from '@/components/FwbSelect/FwbSelect.vue'
 export { default as FwbTextarea } from '@/components/FwbTextarea/FwbTextarea.vue'


### PR DESCRIPTION
## Summary

Brings `FwbRadio` to parity with the other refactored form components and introduces `FwbRadioGroup` — a semantic `<fieldset>`/`<legend>` wrapper that shares `name` and `validationStatus` with child radios via `provide`/`inject`.

## What's new

**New `FwbRadioGroup` component**
- Renders as `<fieldset>` with `<legend>` (semantically required for grouped radio buttons)
- `name` prop provided to all child `FwbRadio` inputs automatically via `InjectionKey` symbol — no need to repeat it on each radio
- `validationStatus` propagated to child radios for label colour and `aria-invalid`
- `aria-describedby` on the fieldset wired to rendered `helper` and `validationMessage` slot IDs via `useFormFieldIds`
- `legend`, `helper`, and `validationMessage` slots with styled paragraphs

**New props on `FwbRadioGroup`**
- `name` — **required**, shared across all child radios
- `label` — legend text (ignored when `legend` slot is used)
- `legendClass`, `wrapperClass` — per-element class passthrough (`String | Object`)
- `validationStatus` — drives legend/label colours, `aria-invalid` on child inputs, and `validationMessage` styling

**Refactored `FwbRadio`**
- Migrated to `defineModel` and `defineOptions({ inheritAttrs: false })` — extra attrs (`form`, `aria-label`, etc.) forward to `<input type="radio">`, not the root `<label>`
- `useElementAttributes` composable for stable generated IDs and attr passthrough
- `aria-invalid="true"` set automatically when inside a group with `validationStatus="error"`, absent otherwise
- `validationStatus` from group propagates to label text colour via `useRadioClasses` — same error/success/neutral scheme as `FwbCheckbox`
- New per-element props: `class`, `labelClass`, `wrapperClass`

**New `types.ts`**
- `RadioProps` and `RadioGroupProps` interfaces
- `radioGroupNameKey` and `radioGroupValidationStatusKey` typed `InjectionKey` symbols

## Tests

40 new tests across two spec files:

`FwbRadio.spec.ts` (16 tests) — root element is `<label>`, generated ID stability, user-provided ID override, label prop rendering, slot vs prop priority, extra attr forwarding to input (not root), `value`/`disabled`/`name` passthrough, `aria-invalid` absent standalone, user-provided `aria-invalid` preserved, `class`/`labelClass`/`wrapperClass` application.

`FwbRadioGroup.spec.ts` (24 tests) — fieldset structure, legend rendering (prop, slot, priority, absent), provide/inject name (child inherits group name; child prop overrides), provide/inject validationStatus (`aria-invalid` set on error, absent on success), `validationMessage`/`helper` slot rendering, `aria-describedby` (absent without slots, helper-only, validationMessage-only, both IDs space-joined), legend/validationMessage/child-radio-label colour for error/success/neutral, `wrapperClass`/`legendClass` application.

## Docs

Full rewrite aligned with other refactored form component docs:
- **Default** (standalone `v-model` with `name` prop), **Disabled**, **Radio group** (`FwbRadioGroup` with `v-for`), **Inline radio** (flex wrapper), **Radio with a link** (default slot for rich label), **Radio list group** (full-row clickability via negative-margin trick on `FwbListGroupItem`), **Horizontal list group** (`v-for` on `<li>`, padding on `wrapper-class` for full-row click), **Bordered radio** (border via `wrapper-class`, no wrapper divs), **Validation**, **Helper text**, **Styling** (amber/green theme showing all class props)
- Full API tables for both components with `:::tip` callouts for native attr passthrough and accessibility behaviour

## Breaking changes

**`inheritAttrs: false` — attr forwarding target changed**
Extra attributes previously fell through to the root `<label>` element. They now forward to `<input type="radio">`. This is the correct behaviour but may affect apps that relied on attrs landing on the wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `FwbRadioGroup` to group related radio buttons, including legend, helper text, and validation messages (success/error).
  * Improved `FwbRadio` behavior for v-model binding, label/slot rendering, and accessibility (group validation state).
  * Added new radio examples: grouped selection, helper text, bordered layout, validation states, inline, list (vertical/horizontal), and styling.

* **Documentation**
  * Expanded Vue Radio documentation with updated content, richer examples, and detailed component API guidance.

* **Tests**
  * Added unit tests covering rendering, slots/props precedence, validation/ARIA, and attribute forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->