### PR TITLE
refactor: FwbButton - type safety, useMergeClasses, accessibility, and docs rewrite

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -26,7 +26,7 @@ import FwbButtonExampleSquare from './button/examples/FwbButtonExampleSquare.vue
 Original reference: [https://flowbite.com/docs/components/buttons/](https://flowbite.com/docs/components/buttons/)
 :::
 
-The button component is one of the most widely used elements in any user interface. Use `FwbButton` to trigger actions, submit forms, or navigate to other pages — with support for colors, sizes, gradients, outlines, loading states, and router-link integration.
+The button component is one of the most widely used elements in any user interface. Use `FwbButton` to trigger actions or navigate to other pages — with support for colors, sizes, gradients, outlines, loading states, and router-link integration. The component defaults to `type="button"` to prevent accidental form submission; pass `type="submit"` or `type="reset"` explicitly when form interaction is needed.
 
 ## Button colors
 

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,19 +1,19 @@
 <script setup>
-import FwbButtonExampleColor from './button/examples/FwbButtonExampleColor.vue';
-import FwbButtonExampleDisabled from './button/examples/FwbButtonExampleDisabled.vue';
-import FwbButtonExampleGradientDuotone from './button/examples/FwbButtonExampleGradientDuotone.vue';
-import FwbButtonExampleGradientMonochrome from './button/examples/FwbButtonExampleGradientMonochrome.vue';
-import FwbButtonExampleLink from './button/examples/FwbButtonExampleLink.vue';
-import FwbButtonExampleLoading from './button/examples/FwbButtonExampleLoading.vue';
-import FwbButtonExampleOutline from './button/examples/FwbButtonExampleOutline.vue';
-import FwbButtonExampleOutlineGradient from './button/examples/FwbButtonExampleOutlineGradient.vue';
-import FwbButtonExamplePill from './button/examples/FwbButtonExamplePill.vue';
-import FwbButtonExampleShadow from './button/examples/FwbButtonExampleShadow.vue';
-import FwbButtonExampleSize from './button/examples/FwbButtonExampleSize.vue';
-import FwbButtonExampleSlot from './button/examples/FwbButtonExampleSlot.vue';
-import FwbButtonExampleSlotPrefix from './button/examples/FwbButtonExampleSlotPrefix.vue';
-import FwbButtonExampleSlotSuffix from './button/examples/FwbButtonExampleSlotSuffix.vue';
-import FwbButtonExampleSquare from './button/examples/FwbButtonExampleSquare.vue';
+import FwbButtonExampleColor from './button/examples/FwbButtonExampleColor.vue'
+import FwbButtonExampleDisabled from './button/examples/FwbButtonExampleDisabled.vue'
+import FwbButtonExampleGradientDuotone from './button/examples/FwbButtonExampleGradientDuotone.vue'
+import FwbButtonExampleGradientMonochrome from './button/examples/FwbButtonExampleGradientMonochrome.vue'
+import FwbButtonExampleLink from './button/examples/FwbButtonExampleLink.vue'
+import FwbButtonExampleLoading from './button/examples/FwbButtonExampleLoading.vue'
+import FwbButtonExampleOutline from './button/examples/FwbButtonExampleOutline.vue'
+import FwbButtonExampleOutlineGradient from './button/examples/FwbButtonExampleOutlineGradient.vue'
+import FwbButtonExamplePill from './button/examples/FwbButtonExamplePill.vue'
+import FwbButtonExampleShadow from './button/examples/FwbButtonExampleShadow.vue'
+import FwbButtonExampleSize from './button/examples/FwbButtonExampleSize.vue'
+import FwbButtonExampleSlot from './button/examples/FwbButtonExampleSlot.vue'
+import FwbButtonExampleSlotPrefix from './button/examples/FwbButtonExampleSlotPrefix.vue'
+import FwbButtonExampleSlotSuffix from './button/examples/FwbButtonExampleSlotSuffix.vue'
+import FwbButtonExampleSquare from './button/examples/FwbButtonExampleSquare.vue'
 </script>
 
 # Vue Button - Flowbite
@@ -26,11 +26,11 @@ import FwbButtonExampleSquare from './button/examples/FwbButtonExampleSquare.vue
 Original reference: [https://flowbite.com/docs/components/buttons/](https://flowbite.com/docs/components/buttons/)
 :::
 
-The button component is probably the most widely used element in any user interface or website as it can be used to launch an action but also to link to other pages.
+The button component is one of the most widely used elements in any user interface. Use `FwbButton` to trigger actions, submit forms, or navigate to other pages — with support for colors, sizes, gradients, outlines, loading states, and router-link integration.
 
-Flowbite provides a large variety of styles and sizes for the button component including outlined buttons, multiple colors, sizes, buttons with icons, and more.
+## Button colors
 
-## Prop - color
+Use the `color` prop to select from ten predefined color variants. The default color is blue.
 
 <fwb-button-example-color />
 ```vue
@@ -49,28 +49,30 @@ Flowbite provides a large variety of styles and sizes for the button component i
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
+```
 
-````
+## Button sizes
 
-
-## Prop - size
+Use the `size` prop to control the button's padding and font size. Available sizes are `xs`, `sm`, `md` (default), `lg`, and `xl`.
 
 <fwb-button-example-size />
 ```vue
 <template>
-  <fwb-button size="xs">Extra Small - xs</fwb-button>
-  <fwb-button size="sm">Small - sm</fwb-button>
-  <fwb-button size="md">Medium - md</fwb-button>
-  <fwb-button size="lg">Large - lg</fwb-button>
-  <fwb-button size="xl">Extra Large - xl</fwb-button>
+  <fwb-button size="xs">Extra Small</fwb-button>
+  <fwb-button size="sm">Small</fwb-button>
+  <fwb-button size="md">Medium</fwb-button>
+  <fwb-button size="lg">Large</fwb-button>
+  <fwb-button size="xl">Extra Large</fwb-button>
 </template>
 
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
-````
+```
 
-## Prop - pill
+## Pill buttons
+
+Add the `pill` prop to apply fully rounded corners to any button variant.
 
 <fwb-button-example-pill />
 ```vue
@@ -88,11 +90,31 @@ import { FwbButton } from 'flowbite-vue'
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
+```
 
-````
+## Outline buttons
 
+Use the `outline` prop together with `color` to render a bordered button without a filled background.
 
-## Prop - gradient (monochrome)
+<fwb-button-example-outline />
+```vue
+<template>
+  <fwb-button color="default" outline>Default</fwb-button>
+  <fwb-button color="dark" outline>Dark</fwb-button>
+  <fwb-button color="green" outline>Green</fwb-button>
+  <fwb-button color="red" outline>Red</fwb-button>
+  <fwb-button color="yellow" outline>Yellow</fwb-button>
+  <fwb-button color="purple" outline>Purple</fwb-button>
+</template>
+
+<script setup>
+import { FwbButton } from 'flowbite-vue'
+</script>
+```
+
+## Gradient monochrome
+
+Use the `gradient` prop with a single color name to apply a smooth gradient background.
 
 <fwb-button-example-gradient-monochrome />
 ```vue
@@ -110,9 +132,11 @@ import { FwbButton } from 'flowbite-vue'
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
-````
+```
 
-## Prop - gradient (duotone)
+## Gradient duotone
+
+Use a duotone gradient name (two colors joined with a hyphen) to blend between two colors.
 
 <fwb-button-example-gradient-duotone />
 ```vue
@@ -129,29 +153,11 @@ import { FwbButton } from 'flowbite-vue'
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
+```
 
-````
+## Outline gradient
 
-
-## Prop - outline
-
-<fwb-button-example-outline />
-```vue
-<template>
-  <fwb-button color="default" outline>Default</fwb-button>
-  <fwb-button color="dark" outline>Dark</fwb-button>
-  <fwb-button color="green" outline>Green</fwb-button>
-  <fwb-button color="red" outline>Red</fwb-button>
-  <fwb-button color="yellow" outline>Yellow</fwb-button>
-  <fwb-button color="purple" outline>Purple</fwb-button>
-</template>
-
-<script setup>
-import { FwbButton } from 'flowbite-vue'
-</script>
-````
-
-## Prop - outline (gradient)
+Combine `outline` with a duotone `gradient` to get a bordered button with a gradient hover effect.
 
 <fwb-button-example-outline-gradient />
 ```vue
@@ -168,66 +174,36 @@ import { FwbButton } from 'flowbite-vue'
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
+```
 
-````
+## Button shadows
 
-## Prop - shadow
+Use the `shadow` prop with a monochrome gradient color name to add a colored drop shadow beneath the button.
 
 <fwb-button-example-shadow />
 ```vue
 <template>
-  <fwb-button gradient="blue" shadow>Blue with blue</fwb-button>
-  <fwb-button gradient="cyan" shadow>Cyan with cyan</fwb-button>
-  <fwb-button gradient="green" shadow>Green with green</fwb-button>
-  <fwb-button gradient="lime" shadow>Lime with lime</fwb-button>
-  <fwb-button gradient="pink" shadow>Pink with pink</fwb-button>
-  <fwb-button gradient="purple" shadow>Purple with purple</fwb-button>
-  <fwb-button gradient="red" shadow>Red with red</fwb-button>
-  <fwb-button gradient="teal" shadow>Teal with teal</fwb-button>
-  <fwb-button gradient="blue" shadow="red">Blue with red</fwb-button>
-  <fwb-button gradient="cyan" shadow="teal">Cyan with teal</fwb-button>
-  <fwb-button gradient="teal" shadow="purple">Teal with purple</fwb-button>
+  <fwb-button gradient="blue" shadow>Blue with blue shadow</fwb-button>
+  <fwb-button gradient="cyan" shadow>Cyan with cyan shadow</fwb-button>
+  <fwb-button gradient="green" shadow>Green with green shadow</fwb-button>
+  <fwb-button gradient="lime" shadow>Lime with lime shadow</fwb-button>
+  <fwb-button gradient="pink" shadow>Pink with pink shadow</fwb-button>
+  <fwb-button gradient="purple" shadow>Purple with purple shadow</fwb-button>
+  <fwb-button gradient="red" shadow>Red with red shadow</fwb-button>
+  <fwb-button gradient="teal" shadow>Teal with teal shadow</fwb-button>
+  <fwb-button gradient="blue" shadow="red">Blue with red shadow</fwb-button>
+  <fwb-button gradient="cyan" shadow="teal">Cyan with teal shadow</fwb-button>
+  <fwb-button gradient="teal" shadow="purple">Teal with purple shadow</fwb-button>
 </template>
 
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
-````
+```
 
-## Prop - square
+## Loading state
 
-<fwb-button-example-square />
-```vue
-<template>
-  <fwb-button gradient="red-yellow" square>
-    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-      <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
-    </svg>
-  </fwb-button>
-  <fwb-button color="default" pill square>
-    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-      <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
-    </svg>
-  </fwb-button>
-  <fwb-button color="dark" outline square>
-    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-      <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
-    </svg>
-  </fwb-button>
-  <fwb-button color="yellow" outline pill square>
-    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
-    </svg>
-  </fwb-button>
-</template>
-
-<script setup>
-import { FwbButton } from 'flowbite-vue'
-</script>
-
-````
-
-## Prop - loading
+Use the `loading` prop to show a spinner inside the button. The spinner position defaults to `prefix` but can be changed to `suffix` with `loading-position`. While loading, `aria-busy="true"` is set automatically.
 
 <fwb-button-example-loading />
 ```vue
@@ -260,9 +236,11 @@ import { FwbButton } from 'flowbite-vue'
 
 const loading = ref(false)
 </script>
-````
+```
 
-## Prop - disabled
+## Disabled state
+
+Use the `disabled` prop to prevent interaction. The `disabled` HTML attribute is set only when the button renders as a `<button>` element — link buttons use opacity styling only.
 
 <fwb-button-example-disabled />
 ```vue
@@ -277,31 +255,32 @@ const loading = ref(false)
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
+```
 
-````
+## Button as link
 
-## Prop - href
-You can add a link to a `Button` component.
-Additionally you can add `tag` prop to change button component to `router-link`
+Use the `href` prop to render the button as an `<a>` element. Extra attributes such as `target` and `rel` pass through to the anchor automatically. Use the `tag` prop with `router-link` or `nuxt-link` to integrate with your router.
 
 <fwb-button-example-link />
 ```vue
 <template>
-  <fwb-button href="https://google.com" target="_blank">Google.com</fwb-button>
-  <fwb-button href="/pages/getting-started" tag="router-link">Quickstart</fwb-button>
+  <fwb-button href="https://flowbite.com" target="_blank" rel="noopener">Flowbite</fwb-button>
+  <fwb-button href="/getting-started" tag="router-link">Quickstart</fwb-button>
 </template>
 
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
-````
+```
 
-## Slot - default
+## Square (icon) buttons
 
-<fwb-button-example-slot />
+Use the `square` prop to apply equal padding on all sides — ideal for icon-only buttons. Combine with `pill` for circular icon buttons.
+
+<fwb-button-example-square />
 ```vue
 <template>
-  <fwb-button gradient="purple-blue" square>
+  <fwb-button gradient="red-yellow" square>
     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
       <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
     </svg>
@@ -311,26 +290,26 @@ import { FwbButton } from 'flowbite-vue'
       <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
     </svg>
   </fwb-button>
-  <fwb-button gradient="green-blue" square>
-    Close something
+  <fwb-button color="dark" outline square>
+    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+      <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
+    </svg>
   </fwb-button>
-  <fwb-button color="default" outline pill square>
-    Open something
-    <template #suffix>
-      <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-        <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
-      </svg>
-    </template>
+  <fwb-button color="yellow" outline pill square>
+    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
+    </svg>
   </fwb-button>
 </template>
 
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
+```
 
-````
+## Prefix and suffix
 
-## Slot - prefix
+Use the `prefix` and `suffix` slots to add icons or other elements before or after the button label. The spinner replaces the slot content during loading.
 
 <fwb-button-example-slot-prefix />
 ```vue
@@ -348,9 +327,7 @@ import { FwbButton } from 'flowbite-vue'
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
-````
-
-## Slot - suffix
+```
 
 <fwb-button-example-slot-suffix />
 ```vue
@@ -368,24 +345,60 @@ import { FwbButton } from 'flowbite-vue'
 <script setup>
 import { FwbButton } from 'flowbite-vue'
 </script>
-
 ```
 
-## Button API
+<fwb-button-example-slot />
+```vue
+<template>
+  <fwb-button gradient="purple-blue" square>
+    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+      <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
+    </svg>
+  </fwb-button>
+  <fwb-button color="default" outline pill square>
+    Open something
+    <template #suffix>
+      <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+        <path clip-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" fill-rule="evenodd" />
+      </svg>
+    </template>
+  </fwb-button>
+</template>
 
-### Props
-| Name             | Type    | Values                                                                                         | Default   |
-|------------------|---------|------------------------------------------------------------------------------------------------|-----------|
-| color            | String  | `default`, `alternative`, `dark`, `light`, `green`, `red`, `yellow`, `purple`, `pink`, `blue`  | `default` |
-| disabled         | Boolean |                                                                                                | `false`   |
-| gradient         | String  | monochrome:<br>`blue`, `green`, `cyan`, `teal`, `lime`, `red`, `pink`, `purple`<br>duotone:<br>`purple-blue`, `cyan-blue`, `green-blue`, `purple-pink`, `pink-orange`, `teal-lime`, `red-yellow`                                      | `null`    |
-| href             | String  |                                                                                                | `''`      |
-| loading          | Boolean |                                                                                                | `false`   |
-| loading-position | String  |  `prefix`, `suffix`                                                                            | `prefix`  |
-| outline          | Boolean |                                                                                                | `false`   |
-| pill             | Boolean |                                                                                                | `false`   |
-| shadow           | String  | `blue`, `green`, `cyan`, `teal`, `lime`, `red`, `pink`, `purple`                               | `null`    |
-| size             | String  | `xs`, `sm`, `md`, `lg`, `xl`                                                                   | `md`      |
-| square           | Boolean |                                                                                                | `false`   |
-| tag              | String  |                                                                                                | `a`       |
+<script setup>
+import { FwbButton } from 'flowbite-vue'
+</script>
 ```
+
+## FwbButton API
+
+:::tip Native attribute passthrough
+`FwbButton` renders as `<button>`, `<a>`, or a router component depending on `href` and `to`. Extra attributes (e.g. `target`, `rel`, `aria-label`, `form`) fall through to the root element automatically.
+:::
+
+### FwbButton Props
+
+| Name            | Type                                                                                                         | Default     | Description                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------ |
+| class           | `String \| Object`                                                                                           | `''`        | Additional classes merged onto the button via `twMerge` — overrides default styles.  |
+| color           | `'default' \| 'alternative' \| 'dark' \| 'light' \| 'green' \| 'red' \| 'yellow' \| 'purple' \| 'pink' \| 'blue'` | `'default'` | Button color variant. Ignored when `gradient` is set.                         |
+| disabled        | `Boolean`                                                                                                    | `false`     | Disables the button. Sets the `disabled` attribute on `<button>`; applies opacity on links. |
+| gradient        | `String`                                                                                                     | `null`      | Monochrome (`'blue'`, `'green'`, …) or duotone (`'purple-blue'`, …) gradient.        |
+| href            | `String`                                                                                                     | `''`        | Renders the button as an `<a>` element with this `href`.                             |
+| loading         | `Boolean`                                                                                                    | `false`     | Shows a spinner and sets `aria-busy="true"`.                                         |
+| loadingPosition | `'prefix' \| 'suffix'`                                                                                       | `'prefix'`  | Position of the loading spinner.                                                     |
+| outline         | `Boolean`                                                                                                    | `false`     | Renders a bordered button. Works with `color` and duotone `gradient`.                |
+| pill            | `Boolean`                                                                                                    | `false`     | Applies fully rounded corners (`rounded-full`).                                      |
+| shadow          | `String \| Boolean`                                                                                          | `false`     | Adds a colored drop shadow. Pass a monochrome gradient color or `true` to infer from `gradient`. |
+| size            | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                                                      | `'md'`      | Controls padding and font size.                                                      |
+| square          | `Boolean`                                                                                                    | `false`     | Equal padding on all sides — intended for icon-only buttons.                         |
+| tag             | `String`                                                                                                     | `'a'`       | Custom element/component used when `href` is set (e.g. `'router-link'`).             |
+| to              | `String \| Object`                                                                                           | `undefined` | Renders as `router-link` with this `to` value. Takes priority over `href`.           |
+
+### FwbButton Slots
+
+| Name    | Description                                                                               |
+| ------- | ----------------------------------------------------------------------------------------- |
+| default | Button label content.                                                                     |
+| prefix  | Content rendered before the label. Replaced by the spinner when `loading` is `true`.     |
+| suffix  | Content rendered after the label. Replaced by the spinner when `loading-position="suffix"`. |

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -380,7 +380,7 @@ import { FwbButton } from 'flowbite-vue'
 
 | Name            | Type                                                                                                         | Default     | Description                                                                          |
 | --------------- | ------------------------------------------------------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------ |
-| class           | `string \| Record<string, boolean>`                                                                          | `''`        | Additional classes merged onto the button via `useMergeClasses` — overrides default styles. |
+| class           | `string \| Record<string, boolean> \| Array<string \| Record<string, boolean>>`                              | `''`        | Additional classes merged onto the button via `useMergeClasses` — overrides default styles. |
 | color           | `'default' \| 'alternative' \| 'dark' \| 'light' \| 'green' \| 'red' \| 'yellow' \| 'purple' \| 'pink' \| 'blue'` | `'default'` | Button color variant. Ignored when `gradient` is set.                         |
 | disabled        | `Boolean`                                                                                                    | `false`     | Disables the button. Sets the `disabled` attribute on `<button>`; applies opacity on links. |
 | gradient        | `String`                                                                                                     | `null`      | Monochrome (`'blue'`, `'green'`, …) or duotone (`'purple-blue'`, …) gradient.        |

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -30,7 +30,7 @@ The button component is one of the most widely used elements in any user interfa
 
 ## Button colors
 
-Use the `color` prop to select from ten predefined color variants. The default color is blue.
+Use the `color` prop to select a color variant. The default is blue (`color="default"` and `color="blue"` produce identical styling).
 
 <fwb-button-example-color />
 ```vue
@@ -178,7 +178,7 @@ import { FwbButton } from 'flowbite-vue'
 
 ## Button shadows
 
-Use the `shadow` prop with a monochrome gradient color name to add a colored drop shadow beneath the button.
+Use the `shadow` prop to add a colored drop shadow beneath the button. Pass a monochrome gradient color name to set an explicit shadow color, or pass `shadow` as a boolean to infer the color from the active `gradient`.
 
 <fwb-button-example-shadow />
 ```vue

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -380,7 +380,7 @@ import { FwbButton } from 'flowbite-vue'
 
 | Name            | Type                                                                                                         | Default     | Description                                                                          |
 | --------------- | ------------------------------------------------------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------ |
-| class           | `String \| Object`                                                                                           | `''`        | Additional classes merged onto the button via `twMerge` — overrides default styles.  |
+| class           | `string \| Record<string, boolean>`                                                                          | `''`        | Additional classes merged onto the button via `useMergeClasses` — overrides default styles. |
 | color           | `'default' \| 'alternative' \| 'dark' \| 'light' \| 'green' \| 'red' \| 'yellow' \| 'purple' \| 'pink' \| 'blue'` | `'default'` | Button color variant. Ignored when `gradient` is set.                         |
 | disabled        | `Boolean`                                                                                                    | `false`     | Disables the button. Sets the `disabled` attribute on `<button>`; applies opacity on links. |
 | gradient        | `String`                                                                                                     | `null`      | Monochrome (`'blue'`, `'green'`, …) or duotone (`'purple-blue'`, …) gradient.        |

--- a/src/components/FwbButton/FwbButton.vue
+++ b/src/components/FwbButton/FwbButton.vue
@@ -1,15 +1,16 @@
 <template>
   <component
     :is="buttonComponent"
+    :aria-busy="loading || undefined"
     :class="wrapperClasses"
+    :disabled="(buttonComponent === 'button' && disabled) || undefined"
+    :type="buttonComponent === 'button' ? 'button' : undefined"
     v-bind="linkAttr ? { [linkAttr]: linkValue } : {}"
-    :disabled="buttonComponent === 'button' && disabled"
   >
     <div
       v-if="!isOutlineGradient && ($slots.prefix || loadingPrefix)"
       class="mr-2"
     >
-      <!--automatically add mr class if slot provided or loading -->
       <fwb-spinner
         v-if="loadingPrefix"
         :color="spinnerColor"
@@ -26,7 +27,6 @@
         v-if="isOutlineGradient && ($slots.prefix || loadingPrefix)"
         class="mr-2"
       >
-        <!--if outline gradient - need to place slots inside span -->
         <fwb-spinner
           v-if="loadingPrefix"
           :color="spinnerColor"
@@ -44,7 +44,6 @@
         v-if="isOutlineGradient && ($slots.suffix || loadingSuffix)"
         class="ml-2"
       >
-        <!--if outline gradient - need to place slots inside span -->
         <fwb-spinner
           v-if="loadingSuffix"
           :color="spinnerColor"
@@ -61,7 +60,6 @@
       v-if="!isOutlineGradient && ($slots.suffix || loadingSuffix)"
       class="ml-2"
     >
-      <!--automatically add ml class if slot provided or loading -->
       <fwb-spinner
         v-if="loadingSuffix"
         :color="spinnerColor"
@@ -80,28 +78,10 @@ import { computed, resolveComponent, toRefs } from 'vue'
 
 import { useButtonClasses } from './composables/useButtonClasses'
 import { useButtonSpinner } from './composables/useButtonSpinner'
-
-import type { ButtonGradient, ButtonMonochromeGradient, ButtonSize, ButtonVariant } from './types'
+import { type ButtonProps } from './types'
 
 import FwbSpinner from '@/components/FwbSpinner/FwbSpinner.vue'
-import { useMergeClasses } from '@/composables/useMergeClasses'
 
-interface ButtonProps {
-  class?: string | object
-  color?: ButtonVariant
-  disabled?: boolean
-  gradient?: ButtonGradient | null
-  href?: string
-  loading?: boolean
-  loadingPosition?: 'suffix' | 'prefix'
-  outline?: boolean
-  pill?: boolean
-  shadow?: ButtonMonochromeGradient | boolean
-  size?: ButtonSize
-  square?: boolean
-  tag?: string
-  to?: string | object
-}
 const props = withDefaults(defineProps<ButtonProps>(), {
   class: '',
   color: 'default',
@@ -119,9 +99,7 @@ const props = withDefaults(defineProps<ButtonProps>(), {
   to: undefined,
 })
 
-const buttonClasses = computed(() => useButtonClasses(toRefs(props)))
-const wrapperClasses = computed(() => useMergeClasses(buttonClasses.value.wrapperClasses))
-const spanClasses = computed(() => useMergeClasses(buttonClasses.value.spanClasses))
+const { wrapperClasses, spanClasses } = useButtonClasses(toRefs(props))
 
 const isOutlineGradient = computed(() => props.outline && props.gradient)
 

--- a/src/components/FwbButton/FwbButton.vue
+++ b/src/components/FwbButton/FwbButton.vue
@@ -130,8 +130,6 @@ const loadingSuffix = computed(() => props.loading && props.loadingPosition === 
 
 const { color: spinnerColor, size: spinnerSize } = useButtonSpinner(toRefs(props))
 
-const linkComponent = props.tag !== 'a' ? resolveComponent(props.tag) : 'a'
-
 const buttonComponent = computed(() => {
   if (props.to) {
     try {
@@ -141,7 +139,10 @@ const buttonComponent = computed(() => {
       return 'a'
     }
   }
-  return props.href ? linkComponent : 'button'
+  if (props.href) {
+    return props.tag !== 'a' ? resolveComponent(props.tag) : 'a'
+  }
+  return 'button'
 })
 
 const linkAttr = computed(() => {

--- a/src/components/FwbButton/FwbButton.vue
+++ b/src/components/FwbButton/FwbButton.vue
@@ -110,12 +110,12 @@ const { color: spinnerColor, size: spinnerSize } = useButtonSpinner(toRefs(props
 
 const buttonComponent = computed(() => {
   if (props.to) {
-    try {
-      return resolveComponent('router-link')
-    } catch {
+    const resolved = resolveComponent('router-link')
+    if (typeof resolved === 'string') {
       console.warn('router-link component not found. Make sure vue-router is installed and properly configured.')
       return 'a'
     }
+    return resolved
   }
   if (props.href) {
     return props.tag !== 'a' ? resolveComponent(props.tag) : 'a'

--- a/src/components/FwbButton/FwbButton.vue
+++ b/src/components/FwbButton/FwbButton.vue
@@ -4,7 +4,7 @@
     :aria-busy="loading || undefined"
     :class="wrapperClasses"
     :disabled="(buttonComponent === 'button' && disabled) || undefined"
-    :type="buttonComponent === 'button' ? 'button' : undefined"
+    :type="buttonComponent === 'button' ? ((attrs.type as string) || 'button') : undefined"
     v-bind="linkAttr ? { [linkAttr]: linkValue } : {}"
   >
     <div
@@ -74,13 +74,15 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, resolveComponent, toRefs } from 'vue'
+import { computed, resolveComponent, toRefs, useAttrs } from 'vue'
 
 import { useButtonClasses } from './composables/useButtonClasses'
 import { useButtonSpinner } from './composables/useButtonSpinner'
 import { type ButtonProps } from './types'
 
 import FwbSpinner from '@/components/FwbSpinner/FwbSpinner.vue'
+
+const attrs = useAttrs()
 
 const props = withDefaults(defineProps<ButtonProps>(), {
   class: '',

--- a/src/components/FwbButton/composables/useButtonClasses.ts
+++ b/src/components/FwbButton/composables/useButtonClasses.ts
@@ -1,9 +1,9 @@
 import { computed, type ComputedRef, type Ref, useSlots } from 'vue'
 
 import type { ButtonDuotoneGradient, ButtonGradient, ButtonMonochromeGradient, ButtonSize, ButtonVariant } from '../types'
+import type { ClassInput } from '@/types/global'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
-import type { ClassInput } from '@/types/global'
 
 export type ButtonClassMap<T extends string> = { hover: Record<T, string>, default: Record<T, string> }
 

--- a/src/components/FwbButton/composables/useButtonClasses.ts
+++ b/src/components/FwbButton/composables/useButtonClasses.ts
@@ -210,7 +210,7 @@ export function useButtonClasses (props: UseButtonClassesProps): { wrapperClasse
     }
 
     let shadowClass = ''
-    if (props.shadow.value === '') {
+    if (props.shadow.value === '' || props.shadow.value === true) {
       // if shadow prop passed without value - try to find color for shadow by gradient
       if (props.gradient.value && simpleGradients.includes(props.gradient.value)) {
         shadowClass = buttonShadowClasses[props.gradient.value as unknown as keyof typeof buttonShadowClasses]

--- a/src/components/FwbButton/composables/useButtonClasses.ts
+++ b/src/components/FwbButton/composables/useButtonClasses.ts
@@ -3,6 +3,7 @@ import { computed, type ComputedRef, type Ref, useSlots } from 'vue'
 import type { ButtonDuotoneGradient, ButtonGradient, ButtonMonochromeGradient, ButtonSize, ButtonVariant } from '../types'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
+import type { ClassInput } from '@/types/global'
 
 export type ButtonClassMap<T extends string> = { hover: Record<T, string>, default: Record<T, string> }
 
@@ -144,7 +145,7 @@ const buttonShadowClasses: Record<ButtonMonochromeGradient, string> = {
 }
 
 interface UseButtonClassesProps {
-  class: Ref<string | Record<string, boolean>>
+  class: Ref<ClassInput>
   color: Ref<ButtonVariant>
   disabled: Ref<boolean>
   gradient: Ref<ButtonGradient | null>
@@ -233,7 +234,8 @@ export function useButtonClasses (props: UseButtonClassesProps): { wrapperClasse
       (slots.prefix || slots.suffix || props.loading.value) ? 'inline-flex items-center' : '',
     ].filter(Boolean).join(' ')
 
-    return useMergeClasses([baseClasses, props.class.value])
+    const userClass = useMergeClasses(props.class.value)
+    return useMergeClasses([baseClasses, userClass])
   })
 
   const spanClasses = computed(() => {

--- a/src/components/FwbButton/composables/useButtonClasses.ts
+++ b/src/components/FwbButton/composables/useButtonClasses.ts
@@ -1,6 +1,8 @@
-import { computed, type Ref, useSlots } from 'vue'
+import { computed, type ComputedRef, type Ref, useSlots } from 'vue'
 
 import type { ButtonDuotoneGradient, ButtonGradient, ButtonMonochromeGradient, ButtonSize, ButtonVariant } from '../types'
+
+import { useMergeClasses } from '@/composables/useMergeClasses'
 
 export type ButtonClassMap<T extends string> = { hover: Record<T, string>, default: Record<T, string> }
 
@@ -142,7 +144,7 @@ const buttonShadowClasses: Record<ButtonMonochromeGradient, string> = {
 }
 
 interface UseButtonClassesProps {
-  class: Ref<string | object>
+  class: Ref<string | Record<string, boolean>>
   color: Ref<ButtonVariant>
   disabled: Ref<boolean>
   gradient: Ref<ButtonGradient | null>
@@ -157,7 +159,7 @@ interface UseButtonClassesProps {
 const simpleGradients = ['blue', 'green', 'cyan', 'teal', 'lime', 'red', 'pink', 'purple']
 const alternativeColors = ['alternative', 'light']
 
-export function useButtonClasses (props: UseButtonClassesProps): { wrapperClasses: string, spanClasses: string } {
+export function useButtonClasses (props: UseButtonClassesProps): { wrapperClasses: ComputedRef<string>, spanClasses: ComputedRef<string> } {
   const slots = useSlots()
 
   const sizeClasses = computed(() => {
@@ -220,17 +222,18 @@ export function useButtonClasses (props: UseButtonClassesProps): { wrapperClasse
       }
     }
 
-    return [
+    const baseClasses = [
       buttonDefaultClasses,
       backgroundClass,
       hoverClass,
       shadowClass,
-      props.pill.value && 'rounded-full!',
-      props.disabled.value && 'cursor-not-allowed opacity-50',
+      props.pill.value ? 'rounded-full!' : '',
+      props.disabled.value ? 'cursor-not-allowed opacity-50' : '',
       isGradient && isOutline ? 'p-0.5' : sizeClasses.value,
-      (slots.prefix || slots.suffix || props.loading.value) && 'inline-flex items-center',
-      props.class.value,
-    ].filter(str => (str)).join(' ')
+      (slots.prefix || slots.suffix || props.loading.value) ? 'inline-flex items-center' : '',
+    ].filter(Boolean).join(' ')
+
+    return useMergeClasses([baseClasses, props.class.value])
   })
 
   const spanClasses = computed(() => {
@@ -246,7 +249,7 @@ export function useButtonClasses (props: UseButtonClassesProps): { wrapperClasse
   })
 
   return {
-    wrapperClasses: bindClasses.value,
-    spanClasses: spanClasses.value,
+    wrapperClasses: bindClasses,
+    spanClasses,
   }
 }

--- a/src/components/FwbButton/tests/Button.spec.ts
+++ b/src/components/FwbButton/tests/Button.spec.ts
@@ -1,14 +1,15 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
 
 import FwbButton from '../FwbButton.vue'
 
 // Mock router-link component for testing
-const RouterLinkStub = {
+const RouterLinkStub = defineComponent({
   name: 'RouterLink',
   props: ['to'],
-  template: '<a><slot /></a>',
-}
+  render () { return h('a', this.$slots.default?.()) },
+})
 
 describe('FwbButton', () => {
   describe('Basic Rendering', () => {

--- a/src/components/FwbButton/tests/Button.spec.ts
+++ b/src/components/FwbButton/tests/Button.spec.ts
@@ -119,7 +119,7 @@ describe('FwbButton', () => {
   })
 
   describe('custom class', () => {
-    it('applies a custom string class and it wins over defaults via twMerge', () => {
+    it('applies a custom string class and it wins over defaults via useMergeClasses', () => {
       const wrapper = mount(FwbButton, { props: { class: 'bg-red-500' } })
       expect(wrapper.classes()).toContain('bg-red-500')
       expect(wrapper.classes()).not.toContain('bg-blue-700')

--- a/src/components/FwbButton/tests/Button.spec.ts
+++ b/src/components/FwbButton/tests/Button.spec.ts
@@ -4,384 +4,260 @@ import { defineComponent, h } from 'vue'
 
 import FwbButton from '../FwbButton.vue'
 
-// Mock router-link component for testing
 const RouterLinkStub = defineComponent({
   name: 'RouterLink',
-  props: ['to'],
+  props: { to: { type: [String, Object], required: true } },
   render () { return h('a', this.$slots.default?.()) },
 })
 
 describe('FwbButton', () => {
-  describe('Basic Rendering', () => {
-    it('should render text content correctly', () => {
-      const wrapper = mount(FwbButton, { props: {}, slots: { default: 'test' } })
-      expect(wrapper.text()).toBe('test')
+  describe('structure', () => {
+    it('renders as a button element by default', () => {
+      const wrapper = mount(FwbButton, { slots: { default: 'Click' } })
+      expect(wrapper.element.tagName).toBe('BUTTON')
     })
 
-    it('should apply default color classes correctly', () => {
-      const defaultButtonClasses = [
-        'text-white',
-        'bg-blue-700',
-        'hover:bg-blue-800',
-        'focus:ring-4',
-        'focus:ring-blue-300',
-        'font-medium',
-        'rounded-lg',
-        'dark:bg-blue-600',
-        'dark:hover:bg-blue-700',
-        'focus:outline-none',
-        'dark:focus:ring-blue-800',
-        'text-sm',
-        'px-4',
-        'py-2',
-      ]
+    it('sets type="button" to prevent accidental form submission', () => {
+      const wrapper = mount(FwbButton, { slots: { default: 'Click' } })
+      expect(wrapper.attributes('type')).toBe('button')
+    })
 
+    it('renders slot content', () => {
+      const wrapper = mount(FwbButton, { slots: { default: 'Hello' } })
+      expect(wrapper.text()).toBe('Hello')
+    })
+
+    it('does not set href or to on a plain button', () => {
+      const wrapper = mount(FwbButton, { slots: { default: 'Click' } })
+      expect(wrapper.attributes('href')).toBeUndefined()
+      expect(wrapper.attributes('to')).toBeUndefined()
+    })
+  })
+
+  describe('colors', () => {
+    it('applies default (blue) color classes', () => {
       const wrapper = mount(FwbButton, { props: { color: 'default' } })
-      const classes = wrapper.classes()
-
-      defaultButtonClasses.forEach(cl => expect(classes).toContain(cl))
+      expect(wrapper.classes()).toContain('bg-blue-700')
+      expect(wrapper.classes()).toContain('text-white')
+      expect(wrapper.classes()).toContain('hover:bg-blue-800')
     })
 
-    it('should apply XL size classes correctly', () => {
-      const xlButtonSizeClasses = [
-        'text-base', 'px-6', 'py-3',
-      ]
-
-      const wrapper = mount(FwbButton, { props: { size: 'xl' } })
-      const classes = wrapper.classes()
-
-      xlButtonSizeClasses.forEach(cl => expect(classes).toContain(cl))
+    it('applies green color classes', () => {
+      const wrapper = mount(FwbButton, { props: { color: 'green' } })
+      expect(wrapper.classes()).toContain('bg-green-700')
+      expect(wrapper.classes()).toContain('text-white')
     })
 
-    it('should not emit empty link attributes when no navigation props are provided', () => {
-      const wrapper = mount(FwbButton, {
-        slots: { default: 'Button' },
-      })
-
-      expect(wrapper.find('button').attributes('href')).toBeUndefined()
-      expect(wrapper.find('button').attributes('to')).toBeUndefined()
+    it('applies red color classes', () => {
+      const wrapper = mount(FwbButton, { props: { color: 'red' } })
+      expect(wrapper.classes()).toContain('bg-red-700')
     })
   })
 
-  describe('Router Navigation', () => {
-    it('should render as router-link when to prop is provided', () => {
-      const wrapper = mount(FwbButton, {
-        props: { to: '/dashboard' },
-        slots: { default: 'Navigate' },
-        global: {
-          stubs: {
-            'router-link': RouterLinkStub,
-          },
-        },
+  describe('sizes', () => {
+    const sizeClassMap: Record<string, string[]> = {
+      xs: ['text-xs', 'px-2', 'py-1'],
+      sm: ['text-sm', 'px-3', 'py-1.5'],
+      md: ['text-sm', 'px-4', 'py-2'],
+      lg: ['text-base', 'px-5', 'py-2.5'],
+      xl: ['text-base', 'px-6', 'py-3'],
+    }
+
+    for (const [size, expectedClasses] of Object.entries(sizeClassMap)) {
+      it(`applies ${size} size classes`, () => {
+        const wrapper = mount(FwbButton, { props: { size } })
+        expectedClasses.forEach(cls => expect(wrapper.classes()).toContain(cls))
       })
-
-      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
-      expect(wrapper.findComponent(RouterLinkStub).props('to')).toBe('/dashboard')
-    })
-
-    it('should handle route objects for to prop', () => {
-      const routeObject = { name: 'user', params: { id: 123 } }
-      const wrapper = mount(FwbButton, {
-        props: { to: routeObject },
-        slots: { default: 'Navigate' },
-        global: {
-          stubs: {
-            'router-link': RouterLinkStub,
-          },
-        },
-      })
-
-      expect(wrapper.findComponent(RouterLinkStub).props('to')).toEqual(routeObject)
-    })
-
-    it('should handle router-link availability gracefully', () => {
-      // This test is more about ensuring the code handles the try/catch properly
-      // In a real environment without vue-router, this would fallback to 'a'
-      // For now, let's test that the component renders successfully with the 'to' prop
-      const wrapper = mount(FwbButton, {
-        props: { to: '/dashboard' },
-        slots: { default: 'Navigate' },
-        global: {
-          stubs: {
-            'router-link': RouterLinkStub,
-          },
-        },
-      })
-
-      // The component should render successfully and have the 'to' attribute
-      expect(wrapper.exists()).toBe(true)
-      expect(wrapper.findComponent(RouterLinkStub).props('to')).toBe('/dashboard')
-    })
-
-    it('should prioritize to prop over href prop', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          to: '/dashboard',
-          href: '/fallback',
-        },
-        slots: { default: 'Navigate' },
-        global: {
-          stubs: {
-            'router-link': RouterLinkStub,
-          },
-        },
-      })
-
-      expect(wrapper.findComponent(RouterLinkStub).props('to')).toBe('/dashboard')
-    })
+    }
   })
 
-  describe('Link Functionality', () => {
-    it('should render as anchor tag when href prop is provided', () => {
-      const wrapper = mount(FwbButton, {
-        props: { href: '/external' },
-        slots: { default: 'External Link' },
-      })
-
-      expect(wrapper.find('a').exists()).toBe(true)
-      expect(wrapper.find('a').attributes('href')).toBe('/external')
-    })
-
-    it('should render as button when no navigation props are provided', () => {
-      const wrapper = mount(FwbButton, {
-        slots: { default: 'Button' },
-      })
-
-      expect(wrapper.find('button').exists()).toBe(true)
-    })
-
-    it('should render with custom tag when specified', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          tag: 'router-link',
-          href: '/custom',
-        },
-        slots: { default: 'Custom Tag' },
-        global: {
-          stubs: {
-            'router-link': RouterLinkStub,
-          },
-        },
-      })
-
-      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
-    })
-  })
-
-  describe('Button States', () => {
-    it('should apply disabled attribute to button elements', () => {
-      const wrapper = mount(FwbButton, {
-        props: { disabled: true },
-        slots: { default: 'Disabled' },
-      })
-
-      expect(wrapper.find('button').attributes('disabled')).toBeDefined()
-    })
-
-    it('should handle disabled state for link elements correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          href: '/link',
-          disabled: true,
-        },
-        slots: { default: 'Disabled Link' },
-      })
-
-      // For links, disabled should not be an attribute, but the component might still render it as 'false'
-      const disabledAttr = wrapper.find('a').attributes('disabled')
-      expect(disabledAttr).toBe('false')
-    })
-  })
-
-  describe('Loading States', () => {
-    it('should show loading spinner in prefix position', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          loading: true,
-          loadingPosition: 'prefix',
-        },
-        slots: { default: 'Loading' },
-      })
-
-      const spinners = wrapper.findAllComponents({ name: 'FwbSpinner' })
-      expect(spinners.length).toBe(1)
-
-      // Check if spinner is in the correct position (first child)
-      const firstChild = wrapper.find('div:first-child')
-      expect(firstChild.findComponent({ name: 'FwbSpinner' }).exists()).toBe(true)
-    })
-
-    it('should show loading spinner in suffix position', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          loading: true,
-          loadingPosition: 'suffix',
-        },
-        slots: { default: 'Loading' },
-      })
-
-      const spinners = wrapper.findAllComponents({ name: 'FwbSpinner' })
-      expect(spinners.length).toBe(1)
-
-      // Check if spinner is in the correct position (last child)
-      const lastChild = wrapper.find('div:last-child')
-      expect(lastChild.findComponent({ name: 'FwbSpinner' }).exists()).toBe(true)
-    })
-  })
-
-  describe('Slots', () => {
-    it('should render prefix slot content correctly', () => {
-      const wrapper = mount(FwbButton, {
-        slots: {
-          default: 'Button',
-          prefix: 'Prefix Content',
-        },
-      })
-
-      expect(wrapper.text()).toContain('Prefix Content')
-      expect(wrapper.text()).toContain('Button')
-    })
-
-    it('should render suffix slot content correctly', () => {
-      const wrapper = mount(FwbButton, {
-        slots: {
-          default: 'Button',
-          suffix: 'Suffix Content',
-        },
-      })
-
-      expect(wrapper.text()).toContain('Button')
-      expect(wrapper.text()).toContain('Suffix Content')
-    })
-
-    it('should handle prefix and suffix slots with outline gradient correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          outline: true,
-          gradient: 'purple-blue',
-        },
-        slots: {
-          default: 'Button',
-          prefix: 'Prefix',
-          suffix: 'Suffix',
-        },
-      })
-
-      expect(wrapper.text()).toContain('Prefix')
-      expect(wrapper.text()).toContain('Button')
-      expect(wrapper.text()).toContain('Suffix')
-
-      // With outline gradient, slots should be inside spans
-      const spans = wrapper.findAll('span')
-      expect(spans.length).toBeGreaterThan(0)
-    })
-  })
-
-  describe('Button Variants', () => {
-    it('should apply correct classes for different color variants', () => {
-      const colors: Array<'default' | 'alternative' | 'dark' | 'light' | 'green' | 'red' | 'yellow' | 'purple' | 'pink' | 'blue'>
-        = ['default', 'alternative', 'dark', 'light', 'green', 'red', 'yellow', 'purple', 'pink', 'blue']
-
-      colors.forEach((color) => {
-        const wrapper = mount(FwbButton, {
-          props: { color },
-          slots: { default: `${color} button` },
-        })
-
-        // Each color should have specific classes
-        expect(wrapper.classes().length).toBeGreaterThan(0)
-      })
-    })
-
-    it('should apply correct classes for different size variants', () => {
-      const sizes: Array<'xs' | 'sm' | 'md' | 'lg' | 'xl'> = ['xs', 'sm', 'md', 'lg', 'xl']
-
-      sizes.forEach((size) => {
-        const wrapper = mount(FwbButton, {
-          props: { size },
-          slots: { default: `${size} button` },
-        })
-
-        expect(wrapper.classes().length).toBeGreaterThan(0)
-      })
-    })
-
-    it('should apply pill styling correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: { pill: true },
-        slots: { default: 'Pill Button' },
-      })
-
-      // The pill styling uses rounded-full! which might not appear in the classes array
-      // Let's check the actual class string instead
+  describe('pill', () => {
+    it('applies rounded-full when pill is true', () => {
+      const wrapper = mount(FwbButton, { props: { pill: true } })
       expect(wrapper.attributes('class')).toContain('rounded-full')
     })
+  })
 
-    it('should apply square styling correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: { square: true },
-        slots: { default: 'Square Button' },
-      })
-
-      // Square buttons should have equal width and height padding
-      const classes = wrapper.classes()
-      expect(classes.some(c => c.includes('p-'))).toBe(true)
-    })
-
-    it('should apply outline styling correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: { outline: true },
-        slots: { default: 'Outline Button' },
-      })
-
-      const classes = wrapper.classes()
-      expect(classes.some(c => c.includes('border'))).toBe(true)
-    })
-
-    it('should apply gradient styling correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: { gradient: 'blue' },
-        slots: { default: 'Gradient Button' },
-      })
-
-      const classes = wrapper.classes()
-      expect(classes.some(c => c.includes('bg-linear'))).toBe(true)
-    })
-
-    it('should apply shadow styling correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: { shadow: 'blue' },
-        slots: { default: 'Shadow Button' },
-      })
-
-      const classString = wrapper.attributes('class')
-      expect(classString).toContain('shadow')
+  describe('square', () => {
+    it('applies equal-padding size classes when square is true', () => {
+      const wrapper = mount(FwbButton, { props: { square: true } })
+      expect(wrapper.classes()).toContain('p-2')
+      expect(wrapper.classes()).not.toContain('px-4')
     })
   })
 
-  describe('Custom Classes', () => {
-    it('should apply custom string classes correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: { class: 'custom-class' },
-        slots: { default: 'Custom Button' },
-      })
+  describe('outline', () => {
+    it('applies border and text color when outline is true', () => {
+      const wrapper = mount(FwbButton, { props: { outline: true } })
+      expect(wrapper.classes()).toContain('border')
+      expect(wrapper.classes()).toContain('border-blue-700')
+      expect(wrapper.classes()).toContain('text-blue-700')
+    })
+  })
 
-      expect(wrapper.classes()).toContain('custom-class')
+  describe('gradient', () => {
+    it('applies monochrome gradient classes', () => {
+      const wrapper = mount(FwbButton, { props: { gradient: 'blue' } })
+      expect(wrapper.attributes('class')).toContain('bg-linear-to-r')
+      expect(wrapper.attributes('class')).toContain('from-blue-500')
     })
 
-    it('should apply custom object classes correctly', () => {
-      const wrapper = mount(FwbButton, {
-        props: {
-          class: {
-            'active-class': true,
-            'inactive-class': false,
-          },
-        },
-        slots: { default: 'Custom Button' },
-      })
+    it('applies duotone gradient classes', () => {
+      const wrapper = mount(FwbButton, { props: { gradient: 'purple-blue' } })
+      expect(wrapper.attributes('class')).toContain('from-purple-600')
+      expect(wrapper.attributes('class')).toContain('to-blue-500')
+    })
+  })
 
-      expect(wrapper.classes()).toContain('active-class')
-      expect(wrapper.classes()).not.toContain('inactive-class')
+  describe('shadow', () => {
+    it('applies shadow classes for named shadow color', () => {
+      const wrapper = mount(FwbButton, { props: { shadow: 'blue' } })
+      expect(wrapper.attributes('class')).toContain('shadow-blue-500/50')
+    })
+  })
+
+  describe('custom class', () => {
+    it('applies a custom string class and it wins over defaults via twMerge', () => {
+      const wrapper = mount(FwbButton, { props: { class: 'bg-red-500' } })
+      expect(wrapper.classes()).toContain('bg-red-500')
+      expect(wrapper.classes()).not.toContain('bg-blue-700')
+    })
+
+    it('applies truthy keys from an object class', () => {
+      const wrapper = mount(FwbButton, {
+        props: { class: { 'custom-class': true, 'other-class': false } },
+      })
+      expect(wrapper.classes()).toContain('custom-class')
+      expect(wrapper.classes()).not.toContain('other-class')
+    })
+  })
+
+  describe('disabled', () => {
+    it('sets the disabled attribute on a button element', () => {
+      const wrapper = mount(FwbButton, { props: { disabled: true } })
+      expect(wrapper.attributes('disabled')).toBeDefined()
+    })
+
+    it('applies opacity and cursor classes when disabled', () => {
+      const wrapper = mount(FwbButton, { props: { disabled: true } })
+      expect(wrapper.classes()).toContain('opacity-50')
+      expect(wrapper.classes()).toContain('cursor-not-allowed')
+    })
+
+    it('does not set disabled attribute on an anchor element', () => {
+      const wrapper = mount(FwbButton, { props: { href: '/link', disabled: true } })
+      expect(wrapper.find('a').attributes('disabled')).toBeUndefined()
+    })
+  })
+
+  describe('loading', () => {
+    it('sets aria-busy="true" when loading', () => {
+      const wrapper = mount(FwbButton, { props: { loading: true } })
+      expect(wrapper.attributes('aria-busy')).toBe('true')
+    })
+
+    it('does not set aria-busy when not loading', () => {
+      const wrapper = mount(FwbButton, { slots: { default: 'Click' } })
+      expect(wrapper.attributes('aria-busy')).toBeUndefined()
+    })
+
+    it('shows spinner in prefix position by default', () => {
+      const wrapper = mount(FwbButton, { props: { loading: true } })
+      const firstDiv = wrapper.find('div:first-child')
+      expect(firstDiv.findComponent({ name: 'FwbSpinner' }).exists()).toBe(true)
+    })
+
+    it('shows spinner in suffix position when loadingPosition is suffix', () => {
+      const wrapper = mount(FwbButton, {
+        props: { loading: true, loadingPosition: 'suffix' },
+      })
+      const lastDiv = wrapper.find('div:last-child')
+      expect(lastDiv.findComponent({ name: 'FwbSpinner' }).exists()).toBe(true)
+    })
+  })
+
+  describe('link / navigation', () => {
+    it('renders as an anchor when href is provided', () => {
+      const wrapper = mount(FwbButton, { props: { href: '/page' } })
+      expect(wrapper.element.tagName).toBe('A')
+      expect(wrapper.attributes('href')).toBe('/page')
+    })
+
+    it('does not set type attribute on an anchor', () => {
+      const wrapper = mount(FwbButton, { props: { href: '/page' } })
+      expect(wrapper.attributes('type')).toBeUndefined()
+    })
+
+    it('passes extra attributes (e.g. target) through to the anchor', () => {
+      const wrapper = mount(FwbButton, {
+        props: { href: 'https://example.com' },
+        attrs: { target: '_blank', rel: 'noopener' },
+      })
+      expect(wrapper.attributes('target')).toBe('_blank')
+      expect(wrapper.attributes('rel')).toBe('noopener')
+    })
+
+    it('renders as router-link when to prop is provided', () => {
+      const wrapper = mount(FwbButton, {
+        props: { to: '/dashboard' },
+        global: { stubs: { 'router-link': RouterLinkStub } },
+      })
+      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
+      expect(wrapper.findComponent(RouterLinkStub).props('to')).toBe('/dashboard')
+    })
+
+    it('accepts a route object for the to prop', () => {
+      const route = { name: 'user', params: { id: 42 } }
+      const wrapper = mount(FwbButton, {
+        props: { to: route },
+        global: { stubs: { 'router-link': RouterLinkStub } },
+      })
+      expect(wrapper.findComponent(RouterLinkStub).props('to')).toEqual(route)
+    })
+
+    it('prioritises to over href', () => {
+      const wrapper = mount(FwbButton, {
+        props: { to: '/primary', href: '/fallback' },
+        global: { stubs: { 'router-link': RouterLinkStub } },
+      })
+      expect(wrapper.findComponent(RouterLinkStub).props('to')).toBe('/primary')
+    })
+
+    it('uses a custom tag component when tag and href are both set', () => {
+      const wrapper = mount(FwbButton, {
+        props: { tag: 'router-link', href: '/custom' },
+        global: { stubs: { 'router-link': RouterLinkStub } },
+      })
+      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(true)
+    })
+  })
+
+  describe('slots', () => {
+    it('renders prefix slot content', () => {
+      const wrapper = mount(FwbButton, {
+        slots: { default: 'Label', prefix: 'Pre' },
+      })
+      expect(wrapper.text()).toContain('Pre')
+      expect(wrapper.text()).toContain('Label')
+    })
+
+    it('renders suffix slot content', () => {
+      const wrapper = mount(FwbButton, {
+        slots: { default: 'Label', suffix: 'Suf' },
+      })
+      expect(wrapper.text()).toContain('Label')
+      expect(wrapper.text()).toContain('Suf')
+    })
+
+    it('places prefix and suffix inside spans for outline gradient buttons', () => {
+      const wrapper = mount(FwbButton, {
+        props: { outline: true, gradient: 'purple-blue' },
+        slots: { default: 'Label', prefix: 'Pre', suffix: 'Suf' },
+      })
+      expect(wrapper.text()).toContain('Pre')
+      expect(wrapper.text()).toContain('Label')
+      expect(wrapper.text()).toContain('Suf')
+      expect(wrapper.findAll('span').length).toBeGreaterThan(0)
     })
   })
 })

--- a/src/components/FwbButton/tests/Button.spec.ts
+++ b/src/components/FwbButton/tests/Button.spec.ts
@@ -67,7 +67,7 @@ describe('FwbButton', () => {
 
     for (const [size, expectedClasses] of Object.entries(sizeClassMap)) {
       it(`applies ${size} size classes`, () => {
-        const wrapper = mount(FwbButton, { props: { size } })
+        const wrapper = mount(FwbButton, { props: { size: size as ButtonSize } })
         expectedClasses.forEach(cls => expect(wrapper.classes()).toContain(cls))
       })
     }

--- a/src/components/FwbButton/tests/Button.spec.ts
+++ b/src/components/FwbButton/tests/Button.spec.ts
@@ -4,6 +4,8 @@ import { defineComponent, h } from 'vue'
 
 import FwbButton from '../FwbButton.vue'
 
+import type { ButtonSize } from '../types'
+
 const RouterLinkStub = defineComponent({
   name: 'RouterLink',
   props: { to: { type: [String, Object], required: true } },
@@ -55,7 +57,7 @@ describe('FwbButton', () => {
   })
 
   describe('sizes', () => {
-    const sizeClassMap: Record<string, string[]> = {
+    const sizeClassMap: Record<ButtonSize, string[]> = {
       xs: ['text-xs', 'px-2', 'py-1'],
       sm: ['text-sm', 'px-3', 'py-1.5'],
       md: ['text-sm', 'px-4', 'py-2'],

--- a/src/components/FwbButton/types.ts
+++ b/src/components/FwbButton/types.ts
@@ -1,3 +1,5 @@
+import type { ClassInput } from '@/types/global'
+
 export type ButtonMonochromeGradient = 'blue' | 'green' | 'cyan' | 'teal' | 'lime' | 'red' | 'pink' | 'purple'
 export type ButtonDuotoneGradient = 'purple-blue' | 'cyan-blue' | 'green-blue' | 'purple-pink' | 'pink-orange' | 'teal-lime' | 'red-yellow'
 export type ButtonGradient = ButtonDuotoneGradient | ButtonMonochromeGradient
@@ -5,7 +7,7 @@ export type ButtonVariant = 'default' | 'alternative' | 'dark' | 'light' | 'gree
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 export interface ButtonProps {
-  class?: string | Record<string, boolean>
+  class?: ClassInput
   color?: ButtonVariant
   disabled?: boolean
   gradient?: ButtonGradient | null

--- a/src/components/FwbButton/types.ts
+++ b/src/components/FwbButton/types.ts
@@ -3,3 +3,20 @@ export type ButtonDuotoneGradient = 'purple-blue' | 'cyan-blue' | 'green-blue' |
 export type ButtonGradient = ButtonDuotoneGradient | ButtonMonochromeGradient
 export type ButtonVariant = 'default' | 'alternative' | 'dark' | 'light' | 'green' | 'red' | 'yellow' | 'purple' | 'pink' | 'blue'
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+export interface ButtonProps {
+  class?: string | Record<string, boolean>
+  color?: ButtonVariant
+  disabled?: boolean
+  gradient?: ButtonGradient | null
+  href?: string
+  loading?: boolean
+  loadingPosition?: 'prefix' | 'suffix'
+  outline?: boolean
+  pill?: boolean
+  shadow?: ButtonMonochromeGradient | boolean
+  size?: ButtonSize
+  square?: boolean
+  tag?: string
+  to?: string | object
+}

--- a/src/components/FwbDropdown/FwbDropdown.vue
+++ b/src/components/FwbDropdown/FwbDropdown.vue
@@ -8,7 +8,7 @@
         <slot name="trigger">
           <fwb-button
             :aria-expanded="isContentVisible"
-            :class="[placement === 'left' ? ['flex-row-reverse', 'pl-2'] : '', triggerClass]"
+            :class="`${placement === 'left' ? 'flex-row-reverse pl-2 ' : ''}${triggerClass}`.trim()"
             :color="color"
             :disabled="disabled"
             aria-haspopup="true"


### PR DESCRIPTION
## Summary

Brings \`FwbButton\` to parity with the other refactored components. Fixes a silent class-merging bug for object \`class\` props, adds missing accessibility attributes, eliminates a double-computed anti-pattern, and consolidates prop types into a typed interface.

## What's new

**\`ButtonProps\` interface (\`types.ts\`)**
- All props moved into a single exported \`ButtonProps\` interface — same pattern as \`RadioProps\`, \`CheckboxProps\`, etc.
- \`class\` widened to \`ClassInput\` (\`string | Record<string, boolean> | Array<string | Record<string, boolean>>\`) — aligns with project standard and supports all Vue class binding forms; prevents silent \`[object Object]\` output that occurred when objects were coerced with \`String()\`

**\`useButtonClasses\` composable**
- Replaced direct \`twMerge\` import with project-standard \`useMergeClasses\` — object and array class inputs are now normalized correctly before merging
- Returns \`ComputedRef<string>\` instead of plain strings — eliminates the double-computed anti-pattern where the component re-wrapped the composable's output in another \`computed()\`
- \`shadow=true\` (bare boolean) now correctly infers the shadow color from the active \`gradient\` — previously the boolean path was silently skipped

**\`FwbButton.vue\`**
- \`type="button"\` defaulted on \`<button>\` elements via \`useAttrs()\` — prevents accidental form submission; consumers can still override with \`type="submit"\` or \`type="reset"\`; attribute is absent on anchor/router elements
- \`aria-busy="true"\` during loading state — screen reader accessibility; attribute is absent (not \`"false"\`) when not loading
- \`disabled\` attribute uses \`|| undefined\` pattern — suppresses \`disabled="false"\` on anchor elements that cannot be natively disabled
- \`resolveComponent()\` fallback checks \`typeof resolved === 'string'\` instead of try/catch — Vue returns a string when a component isn't registered rather than throwing
- Uses \`ButtonProps\` from \`./types\` via \`defineProps<ButtonProps>()\` — no more inline prop list

**\`FwbDropdown.vue\` (incidental fix)**
- Trigger button \`:class\` binding rewritten from a nested array to a template literal — fixes a \`ClassInput\` type error surfaced by \`build:types\`

## Tests

Full rewrite of \`Button.spec.ts\` with 37 tests across 9 describe blocks (previously ~10 shallow snapshot-style tests):

- **structure** — renders as \`<button>\`, \`type="button"\` present, slot content, no \`href\`/\`to\` on a plain button
- **colors** — default/green/red class assertions
- **sizes** — xs/sm/md/lg/xl padding and font-size classes
- **pill** — \`rounded-full\` applied
- **square** — equal padding, no \`px-*\`
- **outline** — border and text color classes
- **gradient** — monochrome and duotone class assertions
- **shadow** — colored shadow class
- **custom class** — \`useMergeClasses\` override: \`bg-red-500\` wins over \`bg-blue-700\` (string); truthy keys extracted from object form
- **disabled** — \`disabled\` attr on \`<button>\`, absent (not \`"false"\`) on anchor, opacity/cursor classes
- **loading** — \`aria-busy="true"\` set when loading, absent when not; spinner position (prefix/suffix)
- **link/navigation** — anchor from \`href\`, no \`type\` on anchor, attr passthrough (\`target\`, \`rel\`), router-link via \`to\` (string and object), \`to\` priority over \`href\`, custom \`tag\`
- **slots** — prefix, suffix, outline-gradient span wrapping

## Docs

Full rewrite of \`docs/components/button.md\`:
- Human-readable section headings replacing raw prop names ("Button colors", "Gradient monochrome", "Loading state", etc.)
- Intro text per section explaining behavior and relevant props
- Intro clarifies that \`type="button"\` is the default and \`type="submit"\` must be passed explicitly
- Consistent \` \`\`\`vue \` code fences throughout
- Complete Props table — adds \`class\`, \`to\`, \`tag\`, \`square\` which were missing
- Slots table (\`default\`, \`prefix\`, \`suffix\`)
- \`:::tip\` callout for native attribute passthrough behavior