### PR TITLE
chore: fix linter warnings

### DIFF
--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleCustomInput.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleCustomInput.vue
@@ -25,10 +25,10 @@
         class="mb-4"
         @search="handleSearch"
       >
-        <template #suffix="{ loading, clear }">
+        <template #suffix="{ loading: isLoading, clear }">
           <div class="flex items-center space-x-2">
             <div
-              v-if="loading"
+              v-if="isLoading"
               class="w-4 h-4 border-2 border-purple-600 border-t-transparent rounded-full animate-spin"
             />
             <button
@@ -98,10 +98,10 @@
           display="name"
           placeholder="Search products..."
         >
-          <template #suffix="{ loading }">
+          <template #suffix="{ loading: isLoading }">
             <div class="flex items-center">
               <svg
-                v-if="loading"
+                v-if="isLoading"
                 class="w-5 h-5 text-purple-600 animate-spin"
                 fill="none"
                 viewBox="0 0 100 101"
@@ -176,12 +176,12 @@ import { FwbAutocomplete } from '../../../../src/index'
 // Custom input component example
 const CustomInput = defineComponent({
   props: {
-    modelValue: String,
-    placeholder: String,
+    modelValue: { type: String, default: undefined },
+    placeholder: { type: String, default: undefined },
     disabled: Boolean,
-    prefixIcon: String,
-    theme: String,
-    class: String,
+    prefixIcon: { type: String, default: undefined },
+    theme: { type: String, default: undefined },
+    class: { type: String, default: undefined },
   },
   emits: ['update:modelValue', 'input', 'focus', 'keydown'],
   setup (props, { emit, attrs }) {

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleRemote.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleRemote.vue
@@ -102,7 +102,7 @@ const searchCountries = async (query: string) => {
       population: country.population,
       flag: country.flag,
     }))
-  } catch (err) {
+  } catch {
     error.value = 'Failed to search countries. Please try again.'
     countries.value = []
   } finally {

--- a/docs/components/radio/examples/FwbRadioExampleHelper.vue
+++ b/docs/components/radio/examples/FwbRadioExampleHelper.vue
@@ -1,8 +1,19 @@
 <template>
   <div class="vp-raw">
-    <fwb-radio-group name="shipping" label="Shipping method">
-      <fwb-radio v-model="picked" label="Standard (3–5 days)" value="standard" />
-      <fwb-radio v-model="picked" label="Express (1–2 days)" value="express" />
+    <fwb-radio-group
+      name="shipping"
+      label="Shipping method"
+    >
+      <fwb-radio
+        v-model="picked"
+        label="Standard (3–5 days)"
+        value="standard"
+      />
+      <fwb-radio
+        v-model="picked"
+        label="Express (1–2 days)"
+        value="express"
+      />
       <template #helper>
         Delivery times are estimates and may vary during peak seasons.
       </template>

--- a/docs/components/radio/examples/FwbRadioExampleValidation.vue
+++ b/docs/components/radio/examples/FwbRadioExampleValidation.vue
@@ -1,16 +1,40 @@
 <template>
   <div class="vp-raw space-y-6">
-    <fwb-radio-group name="fruit-success" label="Pick a fruit (success)" validation-status="success">
-      <fwb-radio v-model="picked1" label="Apple" value="apple" />
-      <fwb-radio v-model="picked1" label="Banana" value="banana" />
+    <fwb-radio-group
+      name="fruit-success"
+      label="Pick a fruit (success)"
+      validation-status="success"
+    >
+      <fwb-radio
+        v-model="picked1"
+        label="Apple"
+        value="apple"
+      />
+      <fwb-radio
+        v-model="picked1"
+        label="Banana"
+        value="banana"
+      />
       <template #validationMessage>
         <span class="font-medium">Great!</span> You selected a fruit.
       </template>
     </fwb-radio-group>
 
-    <fwb-radio-group name="fruit-error" label="Pick a fruit (error)" validation-status="error">
-      <fwb-radio v-model="picked2" label="Apple" value="apple" />
-      <fwb-radio v-model="picked2" label="Banana" value="banana" />
+    <fwb-radio-group
+      name="fruit-error"
+      label="Pick a fruit (error)"
+      validation-status="error"
+    >
+      <fwb-radio
+        v-model="picked2"
+        label="Apple"
+        value="apple"
+      />
+      <fwb-radio
+        v-model="picked2"
+        label="Banana"
+        value="banana"
+      />
       <template #validationMessage>
         <span class="font-medium">Required!</span> Please select a fruit to continue.
       </template>

--- a/src/components/FwbFooter/FwbFooterBrand.vue
+++ b/src/components/FwbFooter/FwbFooterBrand.vue
@@ -22,10 +22,10 @@ import { twMerge } from 'tailwind-merge'
 import { useAttrs } from 'vue'
 
 interface IFooterProps {
-  href: string
-  src: string
+  href?: string
+  src?: string
   alt?: string
-  name: string
+  name?: string
   imageClass?: string
   nameClass?: string
   aClass?: string

--- a/src/components/FwbFooter/FwbFooterLink.vue
+++ b/src/components/FwbFooter/FwbFooterLink.vue
@@ -18,7 +18,7 @@ import { twMerge } from 'tailwind-merge'
 import { resolveComponent, useAttrs } from 'vue'
 
 interface IFooterLinkProps {
-  href: string
+  href?: string
   aClass?: string
   component?: string
 }

--- a/src/components/FwbSidebar/FwbSidebarItemGroup.vue
+++ b/src/components/FwbSidebar/FwbSidebarItemGroup.vue
@@ -8,7 +8,7 @@
 const borderClasses = 'pt-4 mt-4 space-y-2 font-medium border-t border-gray-200 dark:border-gray-700'
 withDefaults(
   defineProps<{
-    border: boolean
+    border?: boolean
   }>(),
   {
     border: false,


### PR DESCRIPTION
## Summary

Reduces ESLint warnings from 51 → 21. All remaining warnings are `@typescript-eslint/no-explicit-any` deferred to per-component refactors.

### Changes

**`vue/no-required-prop-with-default`** — props that have `withDefaults` values must be marked optional:
- `FwbFooterBrand`: `href`, `src`, `name` → `href?`, `src?`, `name?`
- `FwbFooterLink`: `href` → `href?`
- `FwbSidebarItemGroup`: `border` → `border?`

**`no-unused-vars`**:
- `FwbAutocompleteExampleRemote`: removed unused `err` catch binding (changed to bare `catch`)

**`vue/no-template-shadow`**:
- `FwbAutocompleteExampleCustomInput`: `#suffix="{ loading }"` slot params shadowed the component-level `loading` ref — renamed via destructuring alias to `{ loading: isLoading }`

**`vue/require-default-prop`**:
- `FwbAutocompleteExampleCustomInput`: inline `defineComponent` props (`modelValue`, `placeholder`, `prefixIcon`, `theme`, `class`) lacked defaults — added `default: undefined` to each optional string prop

**`vue/max-attributes-per-line`** (auto-fixed):
- `FwbRadioExampleHelper`, `FwbRadioExampleValidation`: attribute formatting only, no logic changes

## Test plan

- [x] `npm run lint` — 0 errors, 21 warnings (down from 51)
- [x] `npm run build:types` — clean
- [x] `npm run test` — 275/275 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Component props for Footer brand, link, and Sidebar item group elements relaxed from required to optional, enhancing component flexibility without changing runtime behavior.

* **Chores**
  * Documentation examples updated with improved code formatting and organization across autocomplete and radio components.
  * Error handling in remote search examples refined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->