### PR TITLE
docs: systematic review and rewrite of all 39 component pages

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD001": false,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,5 @@
   "MD001": false,
   "MD013": false,
   "MD033": false,
-  "MD041": false,
-  "MD060": false
+  "MD041": false
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -45,35 +45,35 @@ function getComponents () {
     { text: 'Card', link: '/components/card.md' },
     { text: 'Carousel', link: '/components/carousel' },
     { text: 'Dropdown', link: '/components/dropdown' },
+    { text: 'Footer', link: '/components/footer' },
     { text: 'Jumbotron', link: '/components/jumbotron' },
-    { text: 'ListGroup', link: '/components/list-group' },
+    { text: 'List Group', link: '/components/list-group' },
+    { text: 'Modal', link: '/components/modal' },
+    { text: 'Navbar', link: '/components/navbar' },
     { text: 'Pagination', link: '/components/pagination' },
     { text: 'Progress', link: '/components/progress' },
     { text: 'Rating', link: '/components/rating' },
+    { text: 'Sidebar', link: '/components/sidebar' },
     { text: 'Spinner', link: '/components/spinner' },
     { text: 'Table', link: '/components/table' },
     { text: 'Tabs', link: '/components/tabs' },
     { text: 'Timeline', link: '/components/timeline' },
     { text: 'Toast', link: '/components/toast' },
     { text: 'Tooltip', link: '/components/tooltip' },
-    { text: 'Modal', link: '/components/modal' },
-    { text: 'Navbar', link: '/components/navbar' },
-    { text: 'Footer', link: '/components/footer' },
-    { text: 'Sidebar', link: '/components/sidebar' },
   ]
 }
 
 function getFormComponents () {
   return [
     { text: 'Autocomplete', link: '/components/autocomplete' },
-    { text: 'Input', link: '/components/input' },
+    { text: 'Checkbox', link: '/components/checkbox' },
     { text: 'File Input', link: '/components/fileInput' },
+    { text: 'Input', link: '/components/input' },
+    { text: 'Radio', link: '/components/radio' },
+    { text: 'Range', link: '/components/range' },
     { text: 'Select', link: '/components/select' },
     { text: 'Textarea', link: '/components/textarea' },
-    { text: 'Checkbox', link: '/components/checkbox' },
-    { text: 'Radio', link: '/components/radio' },
     { text: 'Toggle', link: '/components/toggle' },
-    { text: 'Range', link: '/components/range' },
   ]
 }
 
@@ -88,9 +88,9 @@ function getTypography () {
   return [
     { text: 'Blockquote', link: '/components/blockquote' },
     { text: 'Heading', link: '/components/heading' },
-    { text: 'Paragraph', link: '/components/paragraph' },
     { text: 'Image', link: '/components/image' },
     { text: 'Link', link: '/components/link' },
+    { text: 'Paragraph', link: '/components/paragraph' },
   ]
 }
 

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -8,7 +8,7 @@ import FwbAccordionExampleStyling from './accordion/examples/FwbAccordionExample
 
 # Accordion - Flowbite Vue
 
-#### Use the accordion component to show hidden information based on the collapse and expand state of the child elements using data attribute options
+#### Use the accordion component to show and hide content panels using a set of composable Vue sub-components
 
 ---
 

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -8,17 +8,22 @@ import FwbAccordionExampleStyling from './accordion/examples/FwbAccordionExample
 
 # Accordion - Flowbite Vue
 
-#### Use Tailwind CSS accordion component to show expanding content
+#### Use the accordion component to show hidden information based on the collapse and expand state of the child elements using data attribute options
+
 ---
 
-:::tip
+:::tip Accordion - Flowbite
 Original reference: [https://flowbite.com/docs/components/accordion/](https://flowbite.com/docs/components/accordion/)
 :::
 
+The accordion component is built from four composable sub-components: `FwbAccordion` as the root wrapper, `FwbAccordionPanel` for each collapsible section, `FwbAccordionHeader` for the clickable trigger, and `FwbAccordionContent` for the body. By default the first panel opens on render and only one panel can be open at a time.
+
 ## Basic Accordion
-A simple accordion example.
+
+The default accordion opens the first panel and collapses all others when a new panel is activated.
 
 <fwb-accordion-example />
+
 ```vue
 <template>
   <fwb-accordion>
@@ -79,10 +84,12 @@ import {
 </script>
 ```
 
-## Persistent Accordion Items
-By default, only one accordion item can be open at a time.  Use the `persistent` prop to enable the opening of multiple items concurrently.
+## Always Open
+
+Add the `persistent` prop to `FwbAccordion` to allow multiple panels to remain open simultaneously instead of collapsing when another is activated.
 
 <fwb-accordion-example-persistent />
+
 ```vue
 <template>
   <fwb-accordion persistent>
@@ -143,10 +150,12 @@ import {
 </script>
 ```
 
-## Flushed Accordion
-The `flushed` prop removes background color, side borders, and rounded corners, creating a flush appearance.
+## Flush Accordion
+
+Add the `flushed` prop to remove the background color, side borders, and rounded corners so the accordion blends flush with its surrounding content.
 
 <fwb-accordion-example-flushed />
+
 ```vue
 <template>
   <fwb-accordion flushed>
@@ -207,10 +216,12 @@ import {
 </script>
 ```
 
-## Initialy Collapsed
-The `collapsed` prop allows you to set an accordion to be fully collapsed by default.
+## Initially Collapsed
+
+Add the `collapsed` prop to start all panels closed. Without it, the first panel opens by default on render.
 
 <fwb-accordion-example-collapsed />
+
 ```vue
 <template>
   <fwb-accordion collapsed>
@@ -261,7 +272,6 @@ The `collapsed` prop allows you to set an accordion to be fully collapsed by def
   </fwb-accordion>
 </template>
 
-
 <script setup>
 import {
   FwbAccordion,
@@ -272,11 +282,12 @@ import {
 </script>
 ```
 
-## Styling Accordions
-Use dedicated `class` and `activeClass` props to style accordion components with Tailwind CSS. The `FwbAccordionPanel` component emits `show` and `hide` events on visibility change.
+## Custom Styling
 
-_Advanced styling example:_
+Use the `class` and `activeClass` props on `FwbAccordionPanel`, `FwbAccordionHeader`, and `FwbAccordionContent` to override default Tailwind classes. `FwbAccordionPanel` also emits `show` and `hide` events whenever its visibility changes, which is useful for driving reactive state in the parent.
+
 <fwb-accordion-example-styling />
+
 ```vue
 <template>
   <fwb-accordion>
@@ -315,37 +326,44 @@ const panels = ref([
   { isVisible: false, content: 'Lorem ipsum...' },
   { isVisible: false, content: 'Lorem ipsum...' },
 ])
-
 </script>
 ```
 
-## Accordion components API
+## Accordion component API
 
 ### FwbAccordion Props
-| Name  | Type             | Default |
-| ----- | ---------------- | ------- |
-| class | String \| Object | `''`    |
+
+| Name       | Type               | Default | Description                                                  |
+| ---------- | ------------------ | ------- | ------------------------------------------------------------ |
+| class      | `String \| Object` | `''`    | Applied to the accordion wrapper element.                    |
+| collapsed  | `Boolean`          | `false` | Starts all panels closed instead of opening the first.       |
+| flushed    | `Boolean`          | `false` | Removes background color, side borders, and rounded corners. |
+| persistent | `Boolean`          | `false` | Allows multiple panels to be open simultaneously.            |
 
 ### FwbAccordionPanel Props
-| Name        | Type             | Default |
-| ----------- | ---------------- | ------- |
-| class       | String \| Object | `''`    |
-| activeClass | String \| Object | `''`    |
+
+| Name        | Type               | Default | Description                                       |
+| ----------- | ------------------ | ------- | ------------------------------------------------- |
+| class       | `String \| Object` | `''`    | Applied to the panel wrapper element.             |
+| activeClass | `String \| Object` | `''`    | Applied to the panel wrapper when it is expanded. |
 
 ### FwbAccordionPanel Events
+
 | Name | Description                                       |
 | ---- | ------------------------------------------------- |
 | show | Emitted when panel visibility changes to visible. |
 | hide | Emitted when panel visibility changes to hidden.  |
 
 ### FwbAccordionHeader Props
-| Name        | Type             | Default |
-| ----------- | ---------------- | ------- |
-| class       | String \| Object | `''`    |
-| activeClass | String \| Object | `''`    |
+
+| Name        | Type               | Default | Description                                               |
+| ----------- | ------------------ | ------- | --------------------------------------------------------- |
+| class       | `String \| Object` | `''`    | Applied to the header button element.                     |
+| activeClass | `String \| Object` | `''`    | Applied to the header button when its panel is expanded.  |
 
 ### FwbAccordionContent Props
-| Name        | Type             | Default |
-| ----------- | ---------------- | ------- |
-| class       | String \| Object | `''`    |
-| activeClass | String \| Object | `''`    |
+
+| Name        | Type               | Default | Description                                            |
+| ----------- | ------------------ | ------- | ------------------------------------------------------ |
+| class       | `String \| Object` | `''`    | Applied to the content wrapper element.                |
+| activeClass | `String \| Object` | `''`    | Applied to the content wrapper when its panel is open. |

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -6,7 +6,7 @@ import FwbAccordionExamplePersistent from './accordion/examples/FwbAccordionExam
 import FwbAccordionExampleStyling from './accordion/examples/FwbAccordionExampleStyling.vue'
 </script>
 
-# Vue Accordion - Flowbite
+# Accordion - Flowbite Vue
 
 #### Use Tailwind CSS accordion component to show expanding content
 ---

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -11,12 +11,21 @@ import FwbAlertExampleType from './alert/examples/FwbAlertExampleType.vue'
 # Alert - Flowbite Vue
 
 #### Show contextual information to your users using alert elements based on Tailwind CSS
+
+---
+
+:::tip Alert - Flowbite
+Original reference: [https://flowbite.com/docs/components/alerts/](https://flowbite.com/docs/components/alerts/)
+:::
+
 The alert component can be used to provide information to your users such as success or error messages, but also highlighted information complementing the normal flow of paragraphs and headers on a page.
 
-## Default alert
-Use the following examples of alert components to show messages as feedback to your users.
+## Default Alert
+
+Use the `type` prop to set the alert color and intent. Available types are `info`, `warning`, `danger`, `dark`, and `success`.
 
 <fwb-alert-example-type />
+
 ```vue
 <template>
   <div class="grid gap-2">
@@ -43,10 +52,12 @@ import { FwbAlert } from 'flowbite-vue'
 </script>
 ```
 
-## Alerts with icon
-You can also include a descriptive icon to complement the message inside the alert component with the following example.
+## Alerts with Icon
+
+Add the `icon` prop to include a contextual icon that matches the alert type alongside the message.
 
 <fwb-alert-example-icon />
+
 ```vue
 <template>
   <div class="grid gap-2">
@@ -73,10 +84,12 @@ import { FwbAlert } from 'flowbite-vue'
 </script>
 ```
 
-## Bordered alerts
-Use this example to add a border accent to the alert component instead of just a plain background.
+## Bordered Alerts
+
+Add the `border` prop to apply a border accent to the alert instead of a plain background fill.
 
 <fwb-alert-example-border />
+
 ```vue
 <template>
   <div class="grid gap-2">
@@ -103,10 +116,12 @@ import { FwbAlert } from 'flowbite-vue'
 </script>
 ```
 
-## Border accent
-Use this example to add a border accent on top of the alert component for further visual distinction.
+## Border Accent
+
+Use Tailwind's `border-t-4` and `rounded-none` utility classes via the `class` prop to add a top border accent for additional visual distinction.
 
 <fwb-alert-example-border-accent />
+
 ```vue
 <template>
   <div class="vp-raw grid gap-2">
@@ -117,10 +132,10 @@ Use this example to add a border accent on top of the alert component for furthe
       Warning alert! Change a few things up and try submitting again.
     </fwb-alert>
     <fwb-alert class="border-t-4 rounded-none" icon type="danger">
-      Info Danger alert! Change a few things up and try submitting again.
+      Danger alert! Change a few things up and try submitting again.
     </fwb-alert>
     <fwb-alert class="border-t-4 rounded-none" icon type="dark">
-      Info Dark alert! Change a few things up and try submitting again.
+      Dark alert! Change a few things up and try submitting again.
     </fwb-alert>
     <fwb-alert class="border-t-4 rounded-none" icon type="success">
       Success alert! Change a few things up and try submitting again.
@@ -133,10 +148,12 @@ import { FwbAlert } from 'flowbite-vue'
 </script>
 ```
 
-## Alerts with list
-Use this example to show a list and a description inside an alert component.
+## Alerts with List
+
+Use the default slot to place structured content such as a heading and a list inside the alert component.
 
 <fwb-alert-example-list />
+
 ```vue
 <template>
   <div class="vp-raw grid gap-2">
@@ -165,13 +182,12 @@ import { FwbAlert } from 'flowbite-vue'
 ```
 
 ## Dismissing
-Use the following alert elements that are also dismissable.
+
+Add the `closable` prop to render a close button on the alert. Clicking it emits a `close` event that you can use to remove the alert from the DOM.
 
 <fwb-alert-example-dismissable />
+
 ```vue
-<script setup>
-import { Alert } from 'flowbite-vue'
-</script>
 <template>
   <div class="vp-raw grid gap-2">
     <fwb-alert closable icon type="info">
@@ -197,8 +213,9 @@ import { FwbAlert } from 'flowbite-vue'
 </script>
 ```
 
-## Additional content
-The following alert components can be used if you wish to disclose more information inside the element.
+## Additional Content
+
+Use the `icon`, `title`, and default slots together to build a richer alert layout with a heading, extended body text, and action buttons. The default slot exposes an `onCloseClick` handler for wiring up a dismiss button.
 
 <fwb-alert-example-custom-content />
 
@@ -264,25 +281,28 @@ import { FwbAlert, FwbButton } from 'flowbite-vue'
 </script>
 ```
 
-## API
+## Alert component API
 
-### Props
-| Name     | Values                                        | Default |
-|----------|-----------------------------------------------|---------|
-| type     | `info`, `danger`, `success`,`warning`, `dark` | `info`  |
-| closable | `boolean`                                     | `false` |
-| icon     | `boolean`                                     | `false` |
-| border   | `boolean`                                     | `false` |
+### FwbAlert Props
 
-### Events
-| Name  | Description          |
-|-------|----------------------|
-| close | Close button pressed |
+| Name     | Type                                                      | Default  | Description                                          |
+| -------- | --------------------------------------------------------- | -------- | ---------------------------------------------------- |
+| type     | `'info' \| 'danger' \| 'success' \| 'warning' \| 'dark'` | `'info'` | Sets the color scheme and semantic intent.           |
+| closable | `Boolean`                                                 | `false`  | Renders a close button on the alert.                 |
+| icon     | `Boolean`                                                 | `false`  | Renders a contextual icon matching the type.         |
+| border   | `Boolean`                                                 | `false`  | Adds a border accent instead of a plain background.  |
 
-### Slots
-| Name       | Description       |
-|------------|-------------------|
-| default    | alert content     |
-| close-icon | custom close icon |
-| icon       | custom icon       |
-| title      | title content     |
+### FwbAlert Events
+
+| Name  | Description                               |
+| ----- | ----------------------------------------- |
+| close | Emitted when the close button is clicked. |
+
+### FwbAlert Slots
+
+| Name       | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| default    | Alert body content. Exposes `onCloseClick` for wiring up a dismiss button.   |
+| close-icon | Custom icon for the close button.                                            |
+| icon       | Custom icon replacing the default type icon.                                 |
+| title      | Title content rendered above the body.                                       |

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -8,7 +8,7 @@ import FwbAlertExampleList from './alert/examples/FwbAlertExampleList.vue'
 import FwbAlertExampleType from './alert/examples/FwbAlertExampleType.vue'
 </script>
 
-# Vue Alert - Flowbite
+# Alert - Flowbite Vue
 
 #### Show contextual information to your users using alert elements based on Tailwind CSS
 The alert component can be used to provide information to your users such as success or error messages, but also highlighted information complementing the normal flow of paragraphs and headers on a page.

--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -21,6 +21,8 @@ The autocomplete component supports real-time filtering, keyboard navigation, re
 
 ## Default
 
+Use `v-model` to bind the selected value, `options` to provide the list, `display` to control what text is shown, and `search-fields` to define which fields to filter against.
+
 <fwb-autocomplete-example />
 
 ```vue
@@ -52,6 +54,8 @@ const countries = [
 ```
 
 ## Sizes
+
+Use the `size` prop to control the input padding and font size. Accepts `'sm'`, `'md'` (default), `'lg'`, and `'xl'`.
 
 <fwb-autocomplete-example-size />
 
@@ -115,6 +119,8 @@ const countries = [
 
 ## Disabled
 
+Add the `disabled` prop to prevent user interaction and visually indicate the field is unavailable.
+
 <fwb-autocomplete-example-disabled />
 
 ```vue
@@ -146,8 +152,7 @@ const countries = [
 
 ## Validation
 
-- Set validation status via `validationStatus` prop, which accepts `'success'` or `'error'`.
-- Add validation message via `validationMessage` slot.
+Set `validationStatus` to `'success'` or `'error'` to apply the corresponding colour scheme. Use the `validationMessage` slot to render feedback text below the input.
 
 <fwb-autocomplete-example-validation />
 
@@ -196,6 +201,8 @@ const countries = [
 ```
 
 ## Slot - Helper
+
+Use the `helper` slot to render supplemental text below the input, such as a hint or privacy note.
 
 <fwb-autocomplete-example-helper />
 

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -11,7 +11,7 @@ import FwbAvatarExampleStatus from './avatar/examples/FwbAvatarExampleStatus.vue
 import FwbAvatarExampleStatusPosition from './avatar/examples/FwbAvatarExampleStatusPosition.vue'
 </script>
 
-# Vue Avatar - Flowbite
+# Avatar - Flowbite Vue
 Use the avatar component to show a visual representation of a user profile using an image element or SVG object based on multiple styles and sizes
 
 ## Default avatar

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -214,7 +214,7 @@ import { FwbAvatar } from 'flowbite-vue'
 
 ## Custom Placeholder Icon
 
-Use the `#placeholder` slot to replace the default silhouette with any SVG or element. This has no effect when `initials` is set.
+Use the `#placeholder` slot to replace the default silhouette with any SVG or element. The slot has no effect when `img` or `initials` is set — both take precedence and prevent the placeholder from rendering.
 
 <fwb-avatar-example-icon />
 

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -12,17 +12,28 @@ import FwbAvatarExampleStatusPosition from './avatar/examples/FwbAvatarExampleSt
 </script>
 
 # Avatar - Flowbite Vue
-Use the avatar component to show a visual representation of a user profile using an image element or SVG object based on multiple styles and sizes
 
-## Default avatar
-Use this example to create a circle and rounded avatar on an image element.
+#### Use the avatar component to show a visual representation of a user profile using an image element or SVG object based on multiple styles and sizes
+
+---
+
+:::tip Avatar - Flowbite
+Original reference: [https://flowbite.com/docs/components/avatar/](https://flowbite.com/docs/components/avatar/)
+:::
+
+The avatar component can be used to display a user's profile picture, initials placeholder, icon fallback, or a stacked group of avatars — with support for sizing, border rings, and online/offline status indicators.
+
+## Default Avatar
+
+Use the `img` prop to display a profile image. Add `rounded` for a pill shape instead of the default circle.
 
 <fwb-avatar-example />
+
 ```vue
 <template>
   <div class="flex justify-center space-x-4">
-    <fwb-avatar img="/images/avatar-1.jpg" />
-    <fwb-avatar img="/images/avatar-1.jpg" rounded />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" rounded />
   </div>
 </template>
 
@@ -32,32 +43,16 @@ import { FwbAvatar } from 'flowbite-vue'
 ```
 
 ## Bordered
-Use this example to create a circle and rounded avatar on an image element.
+
+Add the `bordered` prop to apply a ring around the avatar to make it stand out against surrounding content.
 
 <fwb-avatar-example-bordered />
+
 ```vue
 <template>
   <div class="flex justify-center space-x-4">
-    <fwb-avatar bordered img="/images/avatar-1.jpg" />
-    <fwb-avatar bordered img="/images/avatar-1.jpg" rounded />
-  </div></template>
-
-<script setup>
-import { FwbAvatar } from 'flowbite-vue'
-</script>
-```
-
-## Dot indicator
-Use a dot element relative to the avatar component as an indicator for the user (eg. online or offline status).
-
-<fwb-avatar-example-status />
-```vue
-<template>
-  <div class="flex justify-center space-x-4">
-    <fwb-avatar img="/images/avatar-1.jpg" status="online" />
-    <fwb-avatar img="/images/avatar-1.jpg" status="busy" />
-    <fwb-avatar img="/images/avatar-1.jpg" status="away" />
-    <fwb-avatar img="/images/avatar-1.jpg" status="offline" />
+    <fwb-avatar bordered img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
+    <fwb-avatar bordered img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" rounded />
   </div>
 </template>
 
@@ -66,56 +61,40 @@ import { FwbAvatar } from 'flowbite-vue'
 </script>
 ```
 
-## Dot indicator position
+## Dot Indicator
 
-<fwb-avatar-example-status-position />
+Use the `status` prop to show a coloured dot indicating the user's current availability — `online`, `busy`, `away`, or `offline`.
+
+<fwb-avatar-example-status />
+
 ```vue
 <template>
   <div class="flex justify-center space-x-4">
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      status-position="top-left"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      rounded
-      status-position="top-left"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      status-position="top-right"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      rounded
-      status-position="top-right"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      status-position="bottom-left"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      rounded
-      status-position="bottom-left"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      status-position="bottom-right"
-      status="online"
-    />
-    <fwb-avatar
-      img="/images/avatar-1.jpg"
-      rounded
-      status-position="bottom-right"
-      status="online"
-    />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="online" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="busy" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="away" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="offline" />
+  </div>
+</template>
+
+<script setup>
+import { FwbAvatar } from 'flowbite-vue'
+</script>
+```
+
+## Dot Indicator Position
+
+Use the `status-position` prop to control where the dot appears relative to the avatar. Accepts `top-right` (default), `top-left`, `bottom-right`, and `bottom-left`.
+
+<fwb-avatar-example-status-position />
+
+```vue
+<template>
+  <div class="flex justify-center space-x-4">
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="online" status-position="top-left" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="online" status-position="top-right" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="online" status-position="bottom-left" />
+    <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" status="online" status-position="bottom-right" />
   </div>
 </template>
 
@@ -125,17 +104,19 @@ import { FwbAvatar } from 'flowbite-vue'
 ```
 
 ## Sizes
-Choose from multiple sizing options for the avatar component from this example.
+
+Use the `size` prop to control the avatar dimensions. Accepts `xs`, `sm`, `md` (default), `lg`, and `xl`.
 
 <fwb-avatar-example-size />
+
 ```vue
 <template>
   <div class="flex justify-center items-center space-x-4">
-    <fwb-avatar size="xs" img="/images/avatar-1.jpg" />
-    <fwb-avatar size="sm" img="/images/avatar-1.jpg" />
-    <fwb-avatar size="md" img="/images/avatar-1.jpg" />
-    <fwb-avatar size="lg" img="/images/avatar-1.jpg" />
-    <fwb-avatar size="xl" img="/images/avatar-1.jpg" />
+    <fwb-avatar size="xs" img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
+    <fwb-avatar size="sm" img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
+    <fwb-avatar size="md" img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
+    <fwb-avatar size="lg" img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
+    <fwb-avatar size="xl" img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
   </div>
 </template>
 
@@ -144,13 +125,16 @@ import { FwbAvatar } from 'flowbite-vue'
 </script>
 ```
 
-## Alternative text
+## Alternative Text
+
+Use the `alt` prop to set the image's alternative text for accessibility. Defaults to `'Avatar'`.
 
 <fwb-avatar-example-alt />
+
 ```vue
 <template>
   <div class="flex justify-center">
-    <fwb-avatar alt="Alternative text" img="/images/avatar-1.jpg" />
+    <fwb-avatar alt="User profile picture" img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" />
   </div>
 </template>
 
@@ -159,26 +143,28 @@ import { FwbAvatar } from 'flowbite-vue'
 </script>
 ```
 
-## Stacked avatars
-Use this example if you want to stack a group of users by overlapping the avatar components.
+## Stacked Avatars
+
+Wrap multiple `FwbAvatar` components in `FwbAvatarStack` with the `stacked` prop to create an overlapping group. Use `FwbAvatarStackCounter` to show a count of additional users that don't fit.
 
 <fwb-avatar-example-stack />
+
 ```vue
 <template>
   <div class="grid gap-2">
     <fwb-avatar-stack>
-      <fwb-avatar img="/images/avatar-1.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-2.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-3.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-4.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-5.jpg" rounded stacked />
-    <fwb-avatar-stack>
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-2.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-3.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-4.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" rounded stacked />
     </fwb-avatar-stack>
-      <fwb-avatar img="/images/avatar-1.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-2.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-3.jpg" rounded stacked />
-      <fwb-avatar img="/images/avatar-4.jpg" rounded stacked />
-      <fwb-avatar-stack-counter href="#" total="99" />
+    <fwb-avatar-stack>
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-2.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-3.jpg" rounded stacked />
+      <fwb-avatar img="https://flowbite.com/docs/images/people/profile-picture-4.jpg" rounded stacked />
+      <fwb-avatar-stack-counter href="#" :total="99" />
     </fwb-avatar-stack>
   </div>
 </template>
@@ -188,9 +174,12 @@ import { FwbAvatar, FwbAvatarStack, FwbAvatarStackCounter } from 'flowbite-vue'
 </script>
 ```
 
-## Placeholder icon
+## Placeholder Icon
+
+When no `img` or `initials` prop is provided, a default person silhouette icon is shown as the avatar placeholder.
 
 <fwb-avatar-example-placeholder />
+
 ```vue
 <template>
   <div class="flex justify-center space-x-4">
@@ -204,9 +193,12 @@ import { FwbAvatar } from 'flowbite-vue'
 </script>
 ```
 
-## Placeholder initials
+## Placeholder Initials
+
+Use the `initials` prop to display text (typically one or two letters) as a placeholder instead of the default icon.
 
 <fwb-avatar-example-initials />
+
 ```vue
 <template>
   <div class="flex justify-center space-x-4">
@@ -220,13 +212,15 @@ import { FwbAvatar } from 'flowbite-vue'
 </script>
 ```
 
-## Alternative Placeholder Icon
-Use this example if you'd like to specify a different placeholder icon. Specify a `#placeholder` template slot to override the default placeholder icon. This has no effect if using initials.
+## Custom Placeholder Icon
+
+Use the `#placeholder` slot to replace the default silhouette with any SVG or element. This has no effect when `initials` is set.
 
 <fwb-avatar-example-icon />
+
 ```vue
 <template>
-  <div class="vp-raw flex justify-center space-x-4">
+  <div class="flex justify-center space-x-4">
     <fwb-avatar>
       <template #placeholder>
         <svg class="w-12 h-12" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -248,3 +242,32 @@ Use this example if you'd like to specify a different placeholder icon. Specify 
 import { FwbAvatar } from 'flowbite-vue'
 </script>
 ```
+
+## Avatar component API
+
+### FwbAvatar Props
+
+| Name           | Type                                                         | Default       | Description                                                  |
+| -------------- | ------------------------------------------------------------ | ------------- | ------------------------------------------------------------ |
+| alt            | `String`                                                     | `'Avatar'`    | Alt text for the image element.                              |
+| bordered       | `Boolean`                                                    | `false`       | Applies a ring border around the avatar.                     |
+| img            | `String`                                                     | `''`          | URL of the profile image. Shows placeholder when empty.      |
+| initials       | `String`                                                     | `null`        | Text displayed as placeholder instead of the default icon.   |
+| rounded        | `Boolean`                                                    | `false`       | Uses a rounded (pill) shape instead of a circle.             |
+| size           | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                      | `'md'`        | Controls the avatar dimensions.                              |
+| stacked        | `Boolean`                                                    | `false`       | Adds negative margin for use inside `FwbAvatarStack`.        |
+| status         | `'online' \| 'busy' \| 'away' \| 'offline'`                  | `null`        | Shows a coloured dot indicator for user availability.        |
+| statusPosition | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` | Controls the position of the status dot.                  |
+
+### FwbAvatar Slots
+
+| Name        | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| placeholder | Custom icon or element shown when no `img` or `initials` is set.   |
+
+### FwbAvatarStackCounter Props
+
+| Name  | Type     | Default | Description                                      |
+| ----- | -------- | ------- | ------------------------------------------------ |
+| total | `Number` | `1`     | Number displayed inside the counter badge.       |
+| href  | `String` | `'#'`   | URL the counter badge links to when clicked.     |

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -5,7 +5,7 @@ import FwbBadgeExampleLink from './badge/examples/FwbBadgeExampleLink.vue'
 import FwbBadgeExampleIcon from './badge/examples/FwbBadgeExampleIcon.vue'
 import FwbBadgeExampleIconOnly from './badge/examples/FwbBadgeExampleIconOnly.vue'
 </script>
-# Vue Badge - Flowbite
+# Badge - Flowbite Vue
 
 #### Use Tailwind CSS badges as elements to show counts or labels separately or inside other components
 ---

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -5,22 +5,25 @@ import FwbBadgeExampleLink from './badge/examples/FwbBadgeExampleLink.vue'
 import FwbBadgeExampleIcon from './badge/examples/FwbBadgeExampleIcon.vue'
 import FwbBadgeExampleIconOnly from './badge/examples/FwbBadgeExampleIconOnly.vue'
 </script>
+
 # Badge - Flowbite Vue
 
 #### Use Tailwind CSS badges as elements to show counts or labels separately or inside other components
+
 ---
 
-:::tip
+:::tip Badge - Flowbite
 Original reference: [https://flowbite.com/docs/components/badge/](https://flowbite.com/docs/components/badge/)
 :::
 
-The badge component can be used to complement other elements such as buttons or text elements as a label or to show the count of a given data, such as the number of comments for an article or how much time has passed by since a comment has been made.
-Alternatively, badges can also be used as standalone elements that link to a certain page by using the anchor tag instead of a span element.
+The badge component can be used to complement other elements such as buttons or text elements as a label or to show the count of a given data, such as the number of comments for an article or how much time has passed by since a comment has been made. Badges can also be used as standalone elements that link to a page by setting the `href` prop, which renders an anchor tag instead of a span.
 
-## Default badge
-Prop – type
+## Default Badge
+
+Use the `type` prop to set the badge colour. Available types are `default`, `dark`, `red`, `green`, `yellow`, `indigo`, `purple`, and `pink`.
 
 <fwb-badge-example />
+
 ```vue
 <template>
   <fwb-badge>Default</fwb-badge>
@@ -38,10 +41,12 @@ import { FwbBadge } from 'flowbite-vue'
 </script>
 ```
 
-## Large badges
-Prop – size
+## Sizes
+
+Use the `size` prop to control badge dimensions. `xs` is the default (smaller) size and `sm` is the larger option.
 
 <fwb-badge-example-size />
+
 ```vue
 <template>
   <fwb-badge size="xs">Default</fwb-badge>
@@ -59,11 +64,12 @@ import { FwbBadge } from 'flowbite-vue'
 </script>
 ```
 
-## Badges as links
-You can also use badges as anchor elements to link to another page.
-Prop – href
+## Badges as Links
+
+Set the `href` prop to render the badge as an `<a>` element, making the entire badge a clickable link.
 
 <fwb-badge-example-link />
+
 ```vue
 <template>
   <fwb-badge href="#">
@@ -79,11 +85,12 @@ import { FwbBadge } from 'flowbite-vue'
 </script>
 ```
 
-## Badges with icon
-You can also use SVG icons inside the badge elements.
-slot icon
+## Badges with Icon
+
+Use the `#icon` slot to place an SVG icon before the badge label.
 
 <fwb-badge-example-icon />
+
 ```vue
 <template>
   <fwb-badge>
@@ -109,9 +116,12 @@ import { FwbBadge } from 'flowbite-vue'
 </script>
 ```
 
-## Badge with icon only
+## Badge with Icon Only
+
+Omit the default slot content and use only the `#icon` slot to render an icon-only badge.
 
 <fwb-badge-example-icon-only />
+
 ```vue
 <template>
   <fwb-badge>
@@ -141,3 +151,20 @@ import { FwbBadge } from 'flowbite-vue'
 import { FwbBadge } from 'flowbite-vue'
 </script>
 ```
+
+## Badge component API
+
+### FwbBadge Props
+
+| Name | Type                                                                        | Default     | Description                                                    |
+| ---- | --------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------- |
+| type | `'default' \| 'dark' \| 'red' \| 'green' \| 'yellow' \| 'indigo' \| 'purple' \| 'pink'` | `'default'` | Sets the badge colour scheme. |
+| size | `'xs' \| 'sm'`                                                              | `'xs'`      | Controls badge padding and font size.                          |
+| href | `String`                                                                    | `null`      | When set, renders an `<a>` element instead of `<span>`.        |
+
+### FwbBadge Slots
+
+| Name    | Description                                     |
+| ------- | ----------------------------------------------- |
+| default | Badge label text.                               |
+| icon    | Icon rendered before the label.                 |

--- a/docs/components/blockquote.md
+++ b/docs/components/blockquote.md
@@ -5,7 +5,7 @@ import FwbBlockquoteAlignExample from './typography/blockquote/FwbBlockquoteAlig
 import FwbBlockquoteSizeExample from './typography/blockquote/FwbBlockquoteSizeExample.vue'
 </script>
 
-# Vue Blockquote - Flowbite
+# Blockquote - Flowbite Vue
 ---
 
 :::tip

--- a/docs/components/blockquote.md
+++ b/docs/components/blockquote.md
@@ -6,68 +6,113 @@ import FwbBlockquoteSizeExample from './typography/blockquote/FwbBlockquoteSizeE
 </script>
 
 # Blockquote - Flowbite Vue
+
+#### The blockquote component can be used to quote text content from an external source that can be used for testimonials, reviews, and quotes inside an article
+
 ---
 
-:::tip
+:::tip Blockquote - Flowbite
 Original reference: [https://flowbite.com/docs/typography/blockquote/](https://flowbite.com/docs/typography/blockquote/)
 :::
 
-## Get started with a collection of blockquote components when quoting external sources such as quotes inside an article, user reviews, and testimonials based on multiple examples of layouts, styles, and contexts.
+The blockquote component can be used to quote text content from an external source inside a `<fwb-blockquote>` element, with support for alignment, sizing, and a solid card style.
 
-## Default blockquote
+## Default Blockquote
 
-Use this example to quote an external source inside a `<fwb-blockquote>` component.
+Use the `FwbBlockquote` component to wrap a quoted passage. The default style renders italic bold text with no background.
 
 <fwb-blockquote-example/>
 
 ```vue
-<fwb-blockquote>
-    "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to complex dashboard. 
-    Perfect choice for your next SaaS application."
-</fwb-blockquote>
+<template>
+  <fwb-blockquote>
+    "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to complex dashboard. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+</template>
+
+<script setup>
+import { FwbBlockquote } from 'flowbite-vue'
+</script>
 ```
 
-## Solid background
-This example can be used as an alternative style to the default style by applying a solid background color with `type="solid"`.
+## Solid Background
+
+Use `type="solid"` to apply a solid background with a left border accent, useful for pulling quotes out of surrounding content.
 
 <fwb-blockquote-solid-example />
 
 ```vue
-<fwb-blockquote type="solid">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
+<template>
+  <fwb-blockquote type="solid">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+</template>
+
+<script setup>
+import { FwbBlockquote } from 'flowbite-vue'
+</script>
 ```
 
 ## Alignment
 
-Choose from the following examples the blockquote text alignment from starting from left, center to right based on the utility classes from Tailwind CSS.
+Use Tailwind's `text-left`, `text-center`, and `text-right` utility classes via the `class` prop to control blockquote text alignment.
 
 <fwb-blockquote-align-example />
+
 ```vue
-<fwb-blockquote class="text-left">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
-<fwb-blockquote class="text-center">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
-<fwb-blockquote class="text-right">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
+<template>
+  <fwb-blockquote class="text-left">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+  <fwb-blockquote class="text-center">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+  <fwb-blockquote class="text-right">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+</template>
+
+<script setup>
+import { FwbBlockquote } from 'flowbite-vue'
+</script>
 ```
 
 ## Size
 
-Choose from one of the multiple sizes for the default blockquote component based on the surrounding elements and sizes.
+Use Tailwind's text size utilities via the `class` prop to scale the blockquote to match the surrounding content hierarchy.
 
 <fwb-blockquote-size-example />
+
 ```vue
-<fwb-blockquote class="text-lg">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
-<fwb-blockquote class="text-xl">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
-<fwb-blockquote class="text-2xl">
-    "Flowbite is just awesome. Perfect choice for your next SaaS application.Perfect choice for your next SaaS application."
-</fwb-blockquote>
+<template>
+  <fwb-blockquote class="text-lg">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+  <fwb-blockquote class="text-xl">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+  <fwb-blockquote class="text-2xl">
+    "Flowbite is just awesome. Perfect choice for your next SaaS application."
+  </fwb-blockquote>
+</template>
+
+<script setup>
+import { FwbBlockquote } from 'flowbite-vue'
+</script>
 ```
+
+## Blockquote component API
+
+### FwbBlockquote Props
+
+| Name  | Type                   | Default     | Description                                                              |
+| ----- | ---------------------- | ----------- | ------------------------------------------------------------------------ |
+| type  | `'default' \| 'solid'` | `'default'` | `solid` adds a background fill and left border accent.                   |
+| cite  | `String`               | `''`        | Sets the native HTML `cite` attribute — a URL identifying the source.    |
+| class | `String`               | `''`        | Additional Tailwind classes applied to the `<blockquote>` element.       |
+
+### FwbBlockquote Slots
+
+| Name    | Description           |
+| ------- | --------------------- |
+| default | The quoted text body. |

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -3,14 +3,25 @@ import FwbBreadcrumbExample from './breadcrumb/examples/FwbBreadcrumbExample.vue
 import FwbBreadcrumbExampleSolid from './breadcrumb/examples/FwbBreadcrumbExampleSolid.vue'
 import FwbBreadcrumbExampleCustomIcons from './breadcrumb/examples/FwbBreadcrumbExampleCustomIcons.vue'
 </script>
+
 # Breadcrumb - Flowbite Vue
-The breadcrumb component is an important part of any website or application that can be used to show the current location of a page in a hierarchical structure of pages.
 
-Flowbite includes two styles of breadcrumb elements, one that has a transparent background and a few more that come with a background in different colors.
+#### Show the location of the current page in a hierarchical structure using the Tailwind CSS breadcrumb components
 
-## Default breadcrumb
+---
+
+:::tip Breadcrumb - Flowbite
+Original reference: [https://flowbite.com/docs/components/breadcrumb/](https://flowbite.com/docs/components/breadcrumb/)
+:::
+
+The breadcrumb component is an important part of any website or application that can be used to show the current location of a page in a hierarchical structure of pages. Flowbite Vue includes two styles — one with a transparent background and one with a solid background color.
+
+## Default Breadcrumb
+
+Use `FwbBreadcrumb` as a wrapper and `FwbBreadcrumbItem` for each crumb. Add the `home` prop on the first item to show a home icon, and `href` to make any item a link.
 
 <fwb-breadcrumb-example />
+
 ```vue
 <template>
   <fwb-breadcrumb>
@@ -33,7 +44,10 @@ import { FwbBreadcrumb, FwbBreadcrumbItem } from 'flowbite-vue'
 
 ## Solid Breadcrumb
 
+Add the `solid` prop to `FwbBreadcrumb` to apply a filled background with a border and shadow, making the breadcrumb stand out from the page.
+
 <fwb-breadcrumb-example-solid />
+
 ```vue
 <template>
   <fwb-breadcrumb solid>
@@ -56,7 +70,10 @@ import { FwbBreadcrumb, FwbBreadcrumbItem } from 'flowbite-vue'
 
 ## Custom Icons
 
+Use the `#home-icon` slot to replace the default home icon, and the `#arrow-icon` slot to replace the default chevron separator between items.
+
 <fwb-breadcrumb-example-custom-icons />
+
 ```vue
 <template>
   <fwb-breadcrumb>
@@ -91,3 +108,26 @@ import { FwbBreadcrumb, FwbBreadcrumbItem } from 'flowbite-vue'
 import { FwbBreadcrumb, FwbBreadcrumbItem } from 'flowbite-vue'
 </script>
 ```
+
+## Breadcrumb component API
+
+### FwbBreadcrumb Props
+
+| Name  | Type      | Default | Description                                                              |
+| ----- | --------- | ------- | ------------------------------------------------------------------------ |
+| solid | `Boolean` | `false` | Applies a filled background, border, and shadow to the breadcrumb trail. |
+
+### FwbBreadcrumbItem Props
+
+| Name | Type      | Default | Description                                                        |
+| ---- | --------- | ------- | ------------------------------------------------------------------ |
+| href | `String`  | `null`  | When set, renders the item as an `<a>` element instead of `<span>`. |
+| home | `Boolean` | `false` | Marks this item as the home crumb and renders the home icon.        |
+
+### FwbBreadcrumbItem Slots
+
+| Name       | Description                                              |
+| ---------- | -------------------------------------------------------- |
+| default    | The crumb label text.                                    |
+| home-icon  | Custom icon shown when `home` is `true`.                 |
+| arrow-icon | Custom separator icon shown before non-home items.       |

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -3,7 +3,7 @@ import FwbBreadcrumbExample from './breadcrumb/examples/FwbBreadcrumbExample.vue
 import FwbBreadcrumbExampleSolid from './breadcrumb/examples/FwbBreadcrumbExampleSolid.vue'
 import FwbBreadcrumbExampleCustomIcons from './breadcrumb/examples/FwbBreadcrumbExampleCustomIcons.vue'
 </script>
-# Vue Breadcrumb - Flowbite
+# Breadcrumb - Flowbite Vue
 The breadcrumb component is an important part of any website or application that can be used to show the current location of a page in a hierarchical structure of pages.
 
 Flowbite includes two styles of breadcrumb elements, one that has a transparent background and a few more that come with a background in different colors.

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -9,7 +9,7 @@ const FwbButtonGroupExampleDropdown = defineClientComponent(() => {
 })
 </script>
 
-# Vue Button Group - Flowbite
+# Button Group - Flowbite Vue
 
 #### Button groups are a Tailwind CSS powered set of buttons sticked together in a horizontal line
 

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -15,15 +15,18 @@ const FwbButtonGroupExampleDropdown = defineClientComponent(() => {
 
 ---
 
-:::tip
+:::tip Button Group - Flowbite
 Original reference: [https://flowbite.com/docs/components/button-group/](https://flowbite.com/docs/components/button-group/)
 :::
 
-The button group component from Flowbite can be used to stack together multiple buttons and links inside a single element.
+The button group component can be used to stack multiple `FwbButton` elements and dropdowns together in a single inline group. Border-radius adjustments are handled automatically — the first child gets a left-rounded corner, the last gets a right-rounded corner, and everything in between is square.
 
-## Basic example
+## Default Button Group
+
+Wrap any number of `FwbButton` components inside `FwbButtonGroup` to join them into a single horizontal unit. Each button retains its own `color` and other props.
 
 <fwb-button-group-example />
+
 ```vue
 <template>
   <fwb-button-group>
@@ -39,9 +42,12 @@ import { FwbButtonGroup, FwbButton } from 'flowbite-vue'
 </script>
 ```
 
-## Buttons with icons
+## Buttons with Icons
+
+Use `FwbButton`'s `#suffix` or `#prefix` slots to add icons to individual buttons within the group. This is useful for toolbar-style controls where text and icon cues appear together.
 
 <fwb-button-group-example-icon />
+
 ```vue
 <template>
   <fwb-button-group>
@@ -64,10 +70,12 @@ import { FwbButtonGroup, FwbButton } from 'flowbite-vue'
 </script>
 ```
 
-## Grouping buttons and dropdowns
+## Grouping Buttons and Dropdowns
 
-You can also mix buttons with dropdowns inside the button group.
+Mix `FwbButton` and `FwbDropdown` components inside `FwbButtonGroup` to combine actions with contextual menus in a single control.
+
 <fwb-button-group-example-dropdown />
+
 ```vue
 <template>
   <fwb-button-group>
@@ -91,6 +99,14 @@ You can also mix buttons with dropdowns inside the button group.
 </template>
 
 <script setup>
-  import { FwbButtonGroup, FwbButton, FwbDropdown, FwbListGroupItem, FwbListGroup } from 'flowbite-vue'
+import { FwbButtonGroup, FwbButton, FwbDropdown, FwbListGroupItem, FwbListGroup } from 'flowbite-vue'
 </script>
 ```
+
+## Button Group component API
+
+### FwbButtonGroup Slots
+
+| Name    | Description                                                                      |
+| ------- | -------------------------------------------------------------------------------- |
+| default | One or more `FwbButton` or `FwbDropdown` elements to render as a joined group.   |

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -16,7 +16,7 @@ import FwbButtonExampleSlotSuffix from './button/examples/FwbButtonExampleSlotSu
 import FwbButtonExampleSquare from './button/examples/FwbButtonExampleSquare.vue'
 </script>
 
-# Vue Button - Flowbite
+# Button - Flowbite Vue
 
 #### Use the button component inside forms, as links, social login, payment options with support for multiple styles, colors, sizes, gradients, and shadows
 

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -22,7 +22,7 @@ import FwbButtonExampleSquare from './button/examples/FwbButtonExampleSquare.vue
 
 ---
 
-:::tip
+:::tip Button - Flowbite
 Original reference: [https://flowbite.com/docs/components/buttons/](https://flowbite.com/docs/components/buttons/)
 :::
 
@@ -370,7 +370,7 @@ import { FwbButton } from 'flowbite-vue'
 </script>
 ```
 
-## FwbButton API
+## Button component API
 
 :::tip Native attribute passthrough
 `FwbButton` renders as `<button>`, `<a>`, or a router component depending on `href` and `to`. Extra attributes (e.g. `target`, `rel`, `aria-label`, `form`) fall through to the root element automatically.

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -3,33 +3,37 @@ import FwbCardExample from './card/examples/FwbCardExample.vue'
 import FwbCardExampleImage from './card/examples/FwbCardExampleImage.vue'
 import FwbCardExampleHorizontal from './card/examples/FwbCardExampleHorizontal.vue'
 </script>
+
 # Card - Flowbite Vue
 
 #### Get started with a large variety of Tailwind CSS card examples for your web project
 
 ---
 
-:::tip
+:::tip Card - Flowbite
 Original reference: [https://flowbite.com/docs/components/card/](https://flowbite.com/docs/components/card/)
 :::
 
-Use these responsive card components to show data entries and information to your users in multiple forms and contexts such as for your blog, application, user profiles, and more.
+Use these responsive card components to show data entries and information to your users in multiple forms and contexts such as for your blog, application, user profiles, and more. The card supports three layout variants: default, image, and horizontal.
 
-## Prop - default
+## Default Card
+
+Use the `FwbCard` component to wrap any content in a rounded, shadowed card. Set `href` to make the entire card a clickable link rendered as an `<a>` element.
 
 <fwb-card-example />
+
 ```vue
 <template>
-    <fwb-card href="#" class="w-sm">
-      <div class="p-5">
-        <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-          Noteworthy technology acquisitions 2021
-        </h5>
-        <p class="font-normal text-gray-700 dark:text-gray-400">
-          Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-        </p>
-      </div>
-    </fwb-card>
+  <fwb-card href="#" class="w-sm">
+    <div class="p-5">
+      <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+        Noteworthy technology acquisitions 2021
+      </h5>
+      <p class="font-normal text-gray-700 dark:text-gray-400">
+        Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+      </p>
+    </div>
+  </fwb-card>
 </template>
 
 <script setup>
@@ -37,26 +41,29 @@ import { FwbCard } from 'flowbite-vue'
 </script>
 ```
 
-## Prop - image
+## Card with Image
+
+Set `variant="image"` and provide `img-src` to display a top image above the card content. Use `img-alt` to describe the image for accessibility.
 
 <fwb-card-example-image />
+
 ```vue
 <template>
-    <fwb-card
-      img-alt="Desk"
-      img-src="https://flowbite.com/docs/images/blog/image-1.jpg"
-      variant="image"
-      class="w-md"
-    >
-      <div class="p-5">
-        <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-          Noteworthy technology acquisitions 2021
-        </h5>
-        <p class="font-normal text-gray-700 dark:text-gray-400">
-          Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-        </p>
-      </div>
-    </fwb-card>
+  <fwb-card
+    img-alt="Desk"
+    img-src="https://flowbite.com/docs/images/blog/image-1.jpg"
+    variant="image"
+    class="w-md"
+  >
+    <div class="p-5">
+      <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+        Noteworthy technology acquisitions 2021
+      </h5>
+      <p class="font-normal text-gray-700 dark:text-gray-400">
+        Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+      </p>
+    </div>
+  </fwb-card>
 </template>
 
 <script setup>
@@ -64,29 +71,50 @@ import { FwbCard } from 'flowbite-vue'
 </script>
 ```
 
-## Prop - horizontal
+## Horizontal Card
+
+Set `variant="horizontal"` to place the image on the left side and the content on the right, suitable for blog previews and media cards.
 
 <fwb-card-example-horizontal />
+
 ```vue
 <template>
-    <fwb-card
-      img-alt="Desk"
-      img-src="https://flowbite.com/docs/images/blog/image-4.jpg"
-      variant="horizontal"
-      class="w-lg"
-    >
-      <div class="p-5">
-        <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-          Noteworthy technology acquisitions 2021
-        </h5>
-        <p class="font-normal text-gray-700 dark:text-gray-400">
-          Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-        </p>
-      </div>
-    </fwb-card>
+  <fwb-card
+    img-alt="Desk"
+    img-src="https://flowbite.com/docs/images/blog/image-4.jpg"
+    variant="horizontal"
+    class="w-lg"
+  >
+    <div class="p-5">
+      <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+        Noteworthy technology acquisitions 2021
+      </h5>
+      <p class="font-normal text-gray-700 dark:text-gray-400">
+        Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+      </p>
+    </div>
+  </fwb-card>
 </template>
 
 <script setup>
 import { FwbCard } from 'flowbite-vue'
 </script>
 ```
+
+## Card component API
+
+### FwbCard Props
+
+| Name    | Type                                   | Default     | Description                                                         |
+| ------- | -------------------------------------- | ----------- | ------------------------------------------------------------------- |
+| href    | `String`                               | `''`        | When set, renders the card as an `<a>` element linking to this URL. |
+| imgAlt  | `String`                               | `''`        | Alt text for the card image. Used with `variant="image"` or `"horizontal"`. |
+| imgSrc  | `String`                               | `''`        | URL of the image displayed on the card.                             |
+| variant | `'default' \| 'image' \| 'horizontal'` | `'default'` | Controls card layout. `image` adds a top image; `horizontal` places the image on the left. |
+| class   | `String`                               | `''`        | Additional Tailwind classes applied to the card wrapper.            |
+
+### FwbCard Slots
+
+| Name    | Description              |
+| ------- | ------------------------ |
+| default | The card body content.   |

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -24,7 +24,7 @@ Use the `FwbCard` component to wrap any content in a rounded, shadowed card. Set
 
 ```vue
 <template>
-  <fwb-card href="#" class="w-sm">
+  <fwb-card href="#" class="min-w-sm">
     <div class="p-5">
       <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
         Noteworthy technology acquisitions 2021
@@ -53,7 +53,7 @@ Set `variant="image"` and provide `img-src` to display a top image above the car
     img-alt="Desk"
     img-src="https://flowbite.com/docs/images/blog/image-1.jpg"
     variant="image"
-    class="w-md"
+    class="min-w-md"
   >
     <div class="p-5">
       <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -83,7 +83,7 @@ Set `variant="horizontal"` to place the image on the left side and the content o
     img-alt="Desk"
     img-src="https://flowbite.com/docs/images/blog/image-4.jpg"
     variant="horizontal"
-    class="w-lg"
+    class="min-w-lg"
   >
     <div class="p-5">
       <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -3,7 +3,7 @@ import FwbCardExample from './card/examples/FwbCardExample.vue'
 import FwbCardExampleImage from './card/examples/FwbCardExampleImage.vue'
 import FwbCardExampleHorizontal from './card/examples/FwbCardExampleHorizontal.vue'
 </script>
-# Vue Card - Flowbite
+# Card - Flowbite Vue
 
 #### Get started with a large variety of Tailwind CSS card examples for your web project
 

--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -139,3 +139,4 @@ const pictures = [
 | noIndicators  | `Boolean`                         | `false` | Hides the dot indicator buttons at the bottom of the carousel.    |
 | slide         | `Boolean`                         | `false` | Enables automatic slide advancement on mount.                     |
 | slideInterval | `Number`                          | `3000`  | Duration in milliseconds between auto-play slide transitions.     |
+| animation     | `Boolean`                         | `false` | Reserved for future slide transition animation (currently has no effect). |

--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -139,4 +139,3 @@ const pictures = [
 | noIndicators  | `Boolean`                         | `false` | Hides the dot indicator buttons at the bottom of the carousel.    |
 | slide         | `Boolean`                         | `false` | Enables automatic slide advancement on mount.                     |
 | slideInterval | `Number`                          | `3000`  | Duration in milliseconds between auto-play slide transitions.     |
-| animation     | `Boolean`                         | `false` | Reserved for slide transition animation (currently unused).       |

--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -6,7 +6,7 @@ import FwbCarouselExampleSlideInterval from './carousel/examples/FwbCarouselExam
 import FwbCarouselExampleWithoutControls from './carousel/examples/FwbCarouselExampleWithoutControls.vue'
 import FwbCarouselExampleWithoutIndicators from './carousel/examples/FwbCarouselExampleWithoutIndicators.vue'
 </script>
-# Vue Carousel - Flowbite
+# Carousel - Flowbite Vue
 
 Use the carousel component to slide through multiple elements and images using custom controls, indicators, intervals, and options
 

--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -1,18 +1,29 @@
 <script setup>
 import FwbCarouselExample from './carousel/examples/FwbCarouselExample.vue'
-import FwbCarouselExamplePictures from './carousel/examples/FwbCarouselExamplePictures.vue'
 import FwbCarouselExampleSlide from './carousel/examples/FwbCarouselExampleSlide.vue'
 import FwbCarouselExampleSlideInterval from './carousel/examples/FwbCarouselExampleSlideInterval.vue'
 import FwbCarouselExampleWithoutControls from './carousel/examples/FwbCarouselExampleWithoutControls.vue'
 import FwbCarouselExampleWithoutIndicators from './carousel/examples/FwbCarouselExampleWithoutIndicators.vue'
 </script>
+
 # Carousel - Flowbite Vue
 
-Use the carousel component to slide through multiple elements and images using custom controls, indicators, intervals, and options
+#### Use the carousel component to slide through multiple elements and images using custom controls, indicators, intervals, and options
 
-## Basic Carousel
+---
+
+:::tip Carousel - Flowbite
+Original reference: [https://flowbite.com/docs/components/carousel/](https://flowbite.com/docs/components/carousel/)
+:::
+
+The carousel component can be used to cycle through a series of images or content slides with support for navigation controls, pagination indicators, and configurable auto-play intervals.
+
+## Default Carousel
+
+Pass an array of `{ src, alt }` objects to the `pictures` prop to render a carousel with previous/next controls and dot indicators.
 
 <fwb-carousel-example />
+
 ```vue
 <template>
   <fwb-carousel :pictures="pictures" />
@@ -22,17 +33,19 @@ Use the carousel component to slide through multiple elements and images using c
 import { FwbCarousel } from 'flowbite-vue'
 
 const pictures = [
-  {src: '/images/img-1.svg', alt: 'Image 1'},
-  {src: '/images/img-2.svg', alt: 'Image 2'},
-  {src: '/images/img-3.svg', alt: 'Image 3'},
+  { src: '/images/img-1.svg', alt: 'Image 1' },
+  { src: '/images/img-2.svg', alt: 'Image 2' },
+  { src: '/images/img-3.svg', alt: 'Image 3' },
 ]
 </script>
 ```
 
+## Without Controls
 
-## Carousel without controls
+Add the `no-controls` prop to hide the previous/next navigation buttons and let users rely on indicator dots or auto-play to change slides.
 
 <fwb-carousel-example-without-controls />
+
 ```vue
 <template>
   <fwb-carousel no-controls :pictures="pictures" />
@@ -42,15 +55,19 @@ const pictures = [
 import { FwbCarousel } from 'flowbite-vue'
 
 const pictures = [
-  {src: '/images/img-1.svg', alt: 'Image 1'},
-  {src: '/images/img-2.svg', alt: 'Image 2'},
-  {src: '/images/img-3.svg', alt: 'Image 3'},
+  { src: '/images/img-1.svg', alt: 'Image 1' },
+  { src: '/images/img-2.svg', alt: 'Image 2' },
+  { src: '/images/img-3.svg', alt: 'Image 3' },
 ]
 </script>
 ```
-## Carousel without indicators
+
+## Without Indicators
+
+Add the `no-indicators` prop to hide the dot buttons at the bottom of the carousel.
 
 <fwb-carousel-example-without-indicators />
+
 ```vue
 <template>
   <fwb-carousel no-indicators :pictures="pictures" />
@@ -60,16 +77,19 @@ const pictures = [
 import { FwbCarousel } from 'flowbite-vue'
 
 const pictures = [
-  {src: '/images/img-1.svg', alt: 'Image 1'},
-  {src: '/images/img-2.svg', alt: 'Image 2'},
-  {src: '/images/img-3.svg', alt: 'Image 3'},
+  { src: '/images/img-1.svg', alt: 'Image 1' },
+  { src: '/images/img-2.svg', alt: 'Image 2' },
+  { src: '/images/img-3.svg', alt: 'Image 3' },
 ]
 </script>
 ```
 
-## Carousel with slide animation
+## Auto-play
+
+Add the `slide` prop to automatically advance through slides. The default interval is 3 seconds.
 
 <fwb-carousel-example-slide />
+
 ```vue
 <template>
   <fwb-carousel :pictures="pictures" slide />
@@ -79,42 +99,44 @@ const pictures = [
 import { FwbCarousel } from 'flowbite-vue'
 
 const pictures = [
-  {src: '/images/img-1.svg', alt: 'Image 1'},
-  {src: '/images/img-2.svg', alt: 'Image 2'},
-  {src: '/images/img-3.svg', alt: 'Image 3'},
+  { src: '/images/img-1.svg', alt: 'Image 1' },
+  { src: '/images/img-2.svg', alt: 'Image 2' },
+  { src: '/images/img-3.svg', alt: 'Image 3' },
 ]
 </script>
 ```
 
-## Carousel with slide and custom interval
+## Custom Interval
+
+Use `slide-interval` together with `slide` to control how long each slide stays visible, in milliseconds.
 
 <fwb-carousel-example-slide-interval />
 
 ```vue
 <template>
-  <fwb-carousel :pictures="pictures" slide :slide-interval="1000"/>
+  <fwb-carousel :pictures="pictures" slide :slide-interval="1000" />
 </template>
 
 <script setup>
 import { FwbCarousel } from 'flowbite-vue'
 
 const pictures = [
-  {src: '/images/img-1.svg', alt: 'Image 1'},
-  {src: '/images/img-2.svg', alt: 'Image 2'},
-  {src: '/images/img-3.svg', alt: 'Image 3'},
+  { src: '/images/img-1.svg', alt: 'Image 1' },
+  { src: '/images/img-2.svg', alt: 'Image 2' },
+  { src: '/images/img-3.svg', alt: 'Image 3' },
 ]
 </script>
 ```
 
-## Carousel API
+## Carousel component API
 
-### Props
+### FwbCarousel Props
 
-| Name          | Type    | Values                         | Default |
-|---------------|---------|--------------------------------|---------|
-| animation     | Boolean | `true`, `false`                | `false` |
-| noControls    | Boolean | `true`, `false`                | `false` |
-| noIndicators  | Boolean | `true`, `false`                | `false` |
-| pictures      | Array   | `[{source: '', alt: ''}, ...]` | `[]`    |
-| slide         | Boolean | `true`, `false`                | `false` |
-| slideInterval | Number  |                                | `3000`  |
+| Name          | Type                              | Default | Description                                                       |
+| ------------- | --------------------------------- | ------- | ----------------------------------------------------------------- |
+| pictures      | `Array<{ src: string, alt?: string }>` | `[]`    | Array of image objects to display as slides.                 |
+| noControls    | `Boolean`                         | `false` | Hides the previous and next navigation buttons.                   |
+| noIndicators  | `Boolean`                         | `false` | Hides the dot indicator buttons at the bottom of the carousel.    |
+| slide         | `Boolean`                         | `false` | Enables automatic slide advancement on mount.                     |
+| slideInterval | `Number`                          | `3000`  | Duration in milliseconds between auto-play slide transitions.     |
+| animation     | `Boolean`                         | `false` | Reserved for slide transition animation (currently unused).       |

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -14,13 +14,18 @@ import FwbCheckboxExampleValidation from './checkbox/examples/FwbCheckboxExample
 
 ---
 
-:::tip
+:::tip Checkbox - Flowbite
 Original reference: [https://flowbite.com/docs/forms/checkbox/](https://flowbite.com/docs/forms/checkbox/)
 :::
 
-## Default checkbox
+The checkbox component can be used to allow users to select one or more options in the form of a square box. It supports helper text, validation feedback, rich label content via a slot, and attribute passthrough to the native `<input>` element.
+
+## Default Checkbox
+
+Use `v-model` to bind the checked state and the `label` prop to set the visible label text.
 
 <fwb-checkbox-example />
+
 ```vue
 <template>
   <fwb-checkbox v-model="check" label="Default checkbox" />
@@ -36,9 +41,12 @@ const checked = ref(true)
 </script>
 ```
 
-## Disabled state
+## Disabled State
+
+Add the `disabled` prop to prevent the user from interacting with the checkbox.
 
 <fwb-checkbox-example-disabled />
+
 ```vue
 <template>
   <fwb-checkbox v-model="check" disabled label="Disabled checkbox" />
@@ -52,11 +60,12 @@ const check = ref(false)
 </script>
 ```
 
-## Checkbox with link
+## Checkbox with Link
 
 Use the default slot instead of the `label` prop when the label contains rich content such as links.
 
 <fwb-checkbox-example-link />
+
 ```vue
 <template>
   <fwb-checkbox v-model="check">
@@ -73,11 +82,12 @@ const check = ref(false)
 </script>
 ```
 
-## Checkbox group
+## Checkbox Group
 
 When using `v-model` with an array, pass the `:value` attribute on each checkbox. Selected values are added to or removed from the array automatically.
 
 <fwb-checkbox-example-group />
+
 ```vue
 <template>
   <div class="space-y-2">
@@ -107,6 +117,7 @@ const fruits = ['Apple', 'Banana', 'Orange', 'Strawberry']
 Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the checkbox.
 
 <fwb-checkbox-example-validation />
+
 ```vue
 <template>
   <fwb-checkbox v-model="check1" label="Terms accepted (success)" validation-status="success">
@@ -122,11 +133,12 @@ Use `validationStatus` together with the `validationMessage` slot to show succes
 </template>
 ```
 
-## Helper text
+## Helper Text
 
 Use the `helper` slot to show a hint below the checkbox.
 
 <fwb-checkbox-example-helper />
+
 ```vue
 <template>
   <fwb-checkbox v-model="check" label="Free shipping via Flowbite">
@@ -139,9 +151,10 @@ Use the `helper` slot to show a hint below the checkbox.
 
 ## Styling
 
-Use dedicated props to pass classes to individual elements.
+Use dedicated props to pass classes to individual elements inside the checkbox.
 
 <fwb-checkbox-example-styling />
+
 ```vue
 <template>
   <fwb-checkbox
@@ -162,15 +175,15 @@ Use dedicated props to pass classes to individual elements.
 `FwbCheckbox` sets `inheritAttrs: false` and forwards all extra attributes (e.g. `name`, `value`, `form`, `aria-label`) directly to the `<input type="checkbox">` element. Pass `:value` and `name` as regular attributes when using the checkbox in a group.
 :::
 
-| Name             | Type                           | Default     | Description                                                                      |
-| ---------------- | ------------------------------ | ----------- | -------------------------------------------------------------------------------- |
-| class            | `String \| Object`             | `''`        | Added to the checkbox input element.                                             |
-| disabled         | `Boolean`                      | `false`     | Disables the checkbox.                                                           |
-| label            | `String`                       | `''`        | Label text rendered next to the checkbox. Ignored when the default slot is used. |
-| labelClass       | `String \| Object`             | `''`        | Added to the label text element.                                                 |
-| modelValue       | `Boolean \| Array`             | `false`     | The current value (use with `v-model`). Pass an array for group checkboxes.      |
-| validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error colour styles to the label text.                        |
-| wrapperClass     | `String \| Object`             | `''`        | Added to the outer root `<div>`.                                                 |
+| Name             | Type                   | Default     | Description                                                                      |
+| ---------------- | ---------------------- | ----------- | -------------------------------------------------------------------------------- |
+| class            | `String \| Object`     | `''`        | Added to the checkbox input element.                                             |
+| disabled         | `Boolean`              | `false`     | Disables the checkbox.                                                           |
+| label            | `String`               | `''`        | Label text rendered next to the checkbox. Ignored when the default slot is used. |
+| labelClass       | `String \| Object`     | `''`        | Added to the label text element.                                                 |
+| modelValue       | `Boolean \| Array`     | `false`     | The current value (use with `v-model`). Pass an array for group checkboxes.      |
+| validationStatus | `'success' \| 'error'` | `undefined` | Applies success or error colour styles to the label text.                        |
+| wrapperClass     | `String \| Object`     | `''`        | Added to the outer root `<div>`.                                                 |
 
 :::tip Accessibility
 `aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop or default slot is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
@@ -178,8 +191,8 @@ Use dedicated props to pass classes to individual elements.
 
 ### FwbCheckbox Slots
 
-| Name              | Description                                                                        |
-| ----------------- | ---------------------------------------------------------------------------------- |
+| Name              | Description                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------ |
 | default           | Rich label content rendered next to the checkbox (takes priority over `label` prop). |
-| helper            | Helper text rendered below the checkbox.                                           |
-| validationMessage | Validation feedback rendered below the checkbox (styled by `validationStatus`).    |
+| helper            | Helper text rendered below the checkbox.                                             |
+| validationMessage | Validation feedback rendered below the checkbox (styled by `validationStatus`).      |

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -8,7 +8,7 @@ import FwbCheckboxExampleStyling from './checkbox/examples/FwbCheckboxExampleSty
 import FwbCheckboxExampleValidation from './checkbox/examples/FwbCheckboxExampleValidation.vue'
 </script>
 
-# Vue Checkbox - Flowbite
+# Checkbox - Flowbite Vue
 
 #### Use the checkbox component to allow users to select one or more options from a set, with support for validation, helper text, and accessible label linking
 

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -33,15 +33,18 @@ const FwbDropdownExampleCloseInside = defineClientComponent(() => {
 
 ---
 
-:::tip
+:::tip Dropdown - Flowbite
 Original reference: [https://flowbite.com/docs/components/dropdowns/](https://flowbite.com/docs/components/dropdowns/)
 :::
 
-The dropdown component can be used to show a list of menu items when clicking on an element such as a button and hiding it when focusing outside of the triggering element.
+The dropdown component can be used to show a list of menu items when clicking on an element such as a button, and hiding it when clicking outside of the triggering element.
 
-## Dropdown - placement
+## Placement
+
+Use the `placement` prop to control which side of the trigger the dropdown panel opens on. Accepted values are `top`, `right`, `bottom` (default), and `left`.
 
 <fwb-dropdown-example-placement />
+
 ```vue
 <template>
   <fwb-dropdown placement="top" text="Top">
@@ -67,7 +70,7 @@ The dropdown component can be used to show a list of menu items when clicking on
     </nav>
   </fwb-dropdown>
 
-<fwb-dropdown text="Bottom">
+  <fwb-dropdown text="Bottom">
     <nav class="py-2 text-sm text-gray-700 dark:text-gray-200">
       ...
     </nav>
@@ -85,11 +88,12 @@ import { FwbDropdown } from 'flowbite-vue'
 </script>
 ```
 
-## Dropdown - alignment
+## Alignment
 
-The property controls how the dropdown is aligned with the trigger
+Add the `align-to-end` prop to align the dropdown panel to the far edge of the trigger instead of the near edge.
 
 <fwb-dropdown-example-alignment />
+
 ```vue
 <template>
   <fwb-dropdown align-to-end placement="top" text="Top">
@@ -137,27 +141,30 @@ import { FwbDropdown } from 'flowbite-vue'
 </script>
 ```
 
-## Dropdown - with list group
+## With List Group
+
+Use `FwbListGroup` and `FwbListGroupItem` inside the dropdown for a styled menu that supports links, router links, and click handlers.
 
 <fwb-dropdown-example-list-group />
+
 ```vue
 <template>
-    <fwb-dropdown text="Menu" content-class="rounded-lg">
-      <fwb-list-group class="text-sm text-gray-700 dark:text-gray-200">
-        <fwb-list-group-item to="#">
-          Dashboard
-        </fwb-list-group-item>
-        <fwb-list-group-item href="#">
-          Settings
-        </fwb-list-group-item>
-        <fwb-list-group-item href="#">
-          Earnings
-        </fwb-list-group-item>
-        <fwb-list-group-item @click="signOut">
-          Sign out
-        </fwb-list-group-item>
-      </fwb-list-group>
-    </fwb-dropdown>
+  <fwb-dropdown text="Menu" content-class="rounded-lg">
+    <fwb-list-group class="text-sm text-gray-700 dark:text-gray-200">
+      <fwb-list-group-item to="#">
+        Dashboard
+      </fwb-list-group-item>
+      <fwb-list-group-item href="#">
+        Settings
+      </fwb-list-group-item>
+      <fwb-list-group-item href="#">
+        Earnings
+      </fwb-list-group-item>
+      <fwb-list-group-item @click="signOut">
+        Sign out
+      </fwb-list-group-item>
+    </fwb-list-group>
+  </fwb-dropdown>
 </template>
 
 <script setup>
@@ -165,13 +172,12 @@ import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
 
-## Dropdown - button colors
+## Button Colors
 
-::: tip
-Use `triggerClass` prop if you need more control over default trigger button.
-:::
+Use the `color` prop to change the trigger button colour. Use `triggerClass` for more granular control over the trigger button's classes.
 
 <fwb-dropdown-example-button-colors />
+
 ```vue
 <template>
   <fwb-dropdown text="Default" color="default">
@@ -216,9 +222,12 @@ import { FwbDropdown } from 'flowbite-vue'
 </script>
 ```
 
-## Dropdown - button group
+## In a Button Group
+
+Place `FwbDropdown` inside `FwbButtonGroup` to mix dropdowns with regular buttons in a single joined control.
 
 <fwb-dropdown-example-button-group />
+
 ```vue
 <template>
   <fwb-button-group>
@@ -250,9 +259,16 @@ import { FwbDropdown, FwbButtonGroup } from 'flowbite-vue'
 </script>
 ```
 
-## Dropdown - disabled
+## Disabled
+
+Add the `disabled` prop to prevent the trigger button from opening the dropdown panel.
+
+:::warning
+When using a custom trigger via the `#trigger` slot, you must also apply `disabled` to your trigger element manually. The `disabled` prop still ensures correct handling of the click state in the dropdown logic.
+:::
 
 <fwb-dropdown-example-disabled />
+
 ```vue
 <template>
   <fwb-dropdown text="Normal state">
@@ -268,19 +284,13 @@ import { FwbDropdown, FwbButtonGroup } from 'flowbite-vue'
 import { FwbDropdown } from 'flowbite-vue'
 </script>
 ```
-::: warning
-Please note that when using a custom trigger (via the trigger slot), you'll need to also implement the disabled state manually by passing the disabled prop to your trigger element. You should still use the disabled prop here to ensure correct handling of the disabled state in the dropdown click handler.
-:::
 
-## Dropdown - trigger
+## Custom Trigger
 
-Use dedicated `#trigger` slot to change trigger element according to your needs.
-
-::: tip
-You can use `triggerWrapperClass` prop if you need to change classes on the trigger wrapper element.
-:::
+Use the `#trigger` slot to replace the default button with any element. Use `triggerWrapperClass` to style the wrapper around the trigger.
 
 <fwb-dropdown-example-trigger />
+
 ```vue
 <template>
   <fwb-dropdown>
@@ -302,11 +312,12 @@ import { FwbDropdown } from 'flowbite-vue'
 </script>
 ```
 
-## Dropdown - close inside
+## Close Inside
 
-Use `closeInside` prop if you want dropdown to close on click on it's child.
+Add the `close-inside` prop to close the dropdown automatically when the user clicks anywhere inside the content panel.
 
 <fwb-dropdown-example-close-inside />
+
 ```vue
 <template>
   <fwb-dropdown text="Bottom" close-inside>
@@ -329,33 +340,34 @@ import { FwbDropdown } from 'flowbite-vue'
 </script>
 ```
 
-## API
+## Dropdown component API
 
-### Props
-| Name                | Description                                                                          | Values                                                                                        | Default                                 |
-| ------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | --------------------------------------- |
-| alignToEnd          | Reverses the alignment of the dropdown content                                       | Boolean                                                                                       | `false`                                 |
-| class               | Allows adding or overriding classes on the main dropdown wrapper                     | String                                                                                        | `''`                                    |
-| closeInside         | Allows closing the dropdown when clicking inside the contentWrapper                  | Boolean                                                                                       | `false`                                 |
-| color               | Button Variant<br>_(for default trigger)_                                            | `default`, `alternative`, `dark`, `light`, `green`, `red`, `yellow`, `purple`, `pink`, `blue` | `default`                               |
-| contentWrapperClass | Allows adding or overriding classes on the content wrapper                           | String                                                                                        | `''`                                    |
-| disabled            | Button state<br>_(for default trigger)_                                              | Boolean                                                                                       | `false`                                 |
-| placement           | Alignment of dropdown content                                                        | `top`, `right`, `bottom`, `left`                                                              | `bottom`                                |
-| text                | Button label<br>_(for default trigger)_                                              | String                                                                                        | `Dropdown`                              |
-| transition          | Custom transition name<br>_(requires custom transitions in CSS)_                     | String                                                                                        | Calculated based on current `placement` |
-| triggerClass        | Allows adding or overriding classes on the trigger button<br>_(for default trigger)_ | String                                                                                        | `''`                                    |
-| triggerWrapperClass | Allows adding or overriding classes on the trigger wrapper                           | String                                                                                        | `''`                                    |
+### FwbDropdown Props
 
+| Name                | Type                                                                                      | Default    | Description                                                                  |
+| ------------------- | ----------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------- |
+| alignToEnd          | `Boolean`                                                                                 | `false`    | Aligns the dropdown panel to the far edge of the trigger.                    |
+| class               | `String`                                                                                  | `''`       | Additional classes applied to the dropdown wrapper element.                  |
+| closeInside         | `Boolean`                                                                                 | `false`    | Closes the dropdown when clicking anywhere inside the content panel.         |
+| color               | `'default' \| 'alternative' \| 'dark' \| 'light' \| 'green' \| 'red' \| 'yellow' \| 'purple' \| 'pink' \| 'blue'` | `'default'` | Colour of the default trigger button. |
+| contentWrapperClass | `String`                                                                                  | `''`       | Additional classes applied to the content panel wrapper.                     |
+| disabled            | `Boolean`                                                                                 | `false`    | Disables the default trigger button and prevents the panel from opening.     |
+| placement           | `'top' \| 'right' \| 'bottom' \| 'left'`                                                 | `'bottom'` | Which side of the trigger the panel opens on.                                |
+| text                | `String`                                                                                  | `'Dropdown'` | Label text for the default trigger button.                                 |
+| transition          | `String`                                                                                  | `''`       | Custom Vue transition name. Defaults to a value calculated from `placement`. |
+| triggerClass        | `String`                                                                                  | `''`       | Additional classes applied to the default trigger button.                    |
+| triggerWrapperClass | `String`                                                                                  | `''`       | Additional classes applied to the trigger wrapper element.                   |
 
+### FwbDropdown Events
 
-### Events
-| Name | Description                 |
-| ---- | --------------------------- |
-| show | When the dropdown is opened |
-| hide | When the dropdown is closed |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| show | Emitted when the dropdown opens.  |
+| hide | Emitted when the dropdown closes. |
 
-### Slots
-| Name    | Description                                |
-| ------- | ------------------------------------------ |
-| trigger | replace button with custom trigger element |
-| default | dropdown content                           |
+### FwbDropdown Slots
+
+| Name    | Description                                                    |
+| ------- | -------------------------------------------------------------- |
+| default | The dropdown panel content.                                    |
+| trigger | Custom trigger element that replaces the default button.       |

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -149,7 +149,7 @@ Use `FwbListGroup` and `FwbListGroupItem` inside the dropdown for a styled menu 
 
 ```vue
 <template>
-  <fwb-dropdown text="Menu" content-class="rounded-lg">
+  <fwb-dropdown text="Menu" content-wrapper-class="rounded-lg">
     <fwb-list-group class="text-sm text-gray-700 dark:text-gray-200">
       <fwb-list-group-item to="#">
         Dashboard
@@ -169,6 +169,8 @@ Use `FwbListGroup` and `FwbListGroupItem` inside the dropdown for a styled menu 
 
 <script setup>
 import { FwbDropdown, FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
+
+const signOut = () => {}
 </script>
 ```
 

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -27,7 +27,7 @@ const FwbDropdownExampleCloseInside = defineClientComponent(() => {
 })
 </script>
 
-# Vue Dropdown - Flowbite
+# Dropdown - Flowbite Vue
 
 #### Get started with the dropdown component to show a list of menu items when clicking on the trigger element based on multiple layouts, styles, and placements
 

--- a/docs/components/fileInput.md
+++ b/docs/components/fileInput.md
@@ -11,7 +11,7 @@ import FwbFileInputExampleDropZonePlaceholder from './fileInput/examples/FwbFile
 import FwbFileInputExampleDropZoneMultiple from './fileInput/examples/FwbFileInputExampleDropZoneMultiple.vue'
 </script>
 
-# Vue FileInput - Flowbite
+# File Input - Flowbite Vue
 
 #### Get started with the file input component to let users upload one or more files from their device storage based on multiple styles and sizes
 

--- a/docs/components/fileInput.md
+++ b/docs/components/fileInput.md
@@ -23,7 +23,7 @@ Original reference: [https://flowbite.com/docs/forms/file-input/](https://flowbi
 
 The file input component can be used to upload one or more files from a device, with multiple sizes, styles, and variants built using the utility-first classes from Tailwind CSS including support for dark mode.
 
-## File upload example
+## Default File Input
 
 Get started with a simple file input component to let users upload a single file.
 
@@ -67,6 +67,8 @@ const file = ref(null)
 ```
 
 ## Disabled
+
+Add the `disabled` prop to prevent the user from interacting with the file input.
 
 <fwb-file-input-example-disabled />
 
@@ -209,7 +211,9 @@ const file = ref(null)
 </script>
 ```
 
-## Dropzone multiple
+## Dropzone Multiple
+
+Use the `multiple` prop together with `dropzone` to allow uploading several files at once via drag-and-drop.
 
 <fwb-file-input-example-drop-zone-multiple />
 

--- a/docs/components/flowbiteThemable/flowbiteThemable.md
+++ b/docs/components/flowbiteThemable/flowbiteThemable.md
@@ -9,7 +9,7 @@ const FlowbiteThemableExampleDropdown = defineClientComponent(() => {
 })
 </script>
 
-# Vue Themable Configuration - Flowbite
+# Themable Configuration - Flowbite Vue
 
 You can use this wrapper for styling components with no color prop(like tabs, dropdown etc.)
 

--- a/docs/components/flowbiteThemable/flowbiteThemable.md
+++ b/docs/components/flowbiteThemable/flowbiteThemable.md
@@ -11,7 +11,7 @@ const FlowbiteThemableExampleDropdown = defineClientComponent(() => {
 
 # Themable Configuration - Flowbite Vue
 
-You can use this wrapper for styling components with no color prop(like tabs, dropdown etc.)
+Use `FlowbiteThemable` to apply a theme color to child components that don't expose a direct `color` prop, or to propagate a shared theme across a group of components.
 
 :::warning
 WIP, Do not use it in production

--- a/docs/components/footer.md
+++ b/docs/components/footer.md
@@ -5,7 +5,7 @@ import FwbFooterExampleSocialMediaIcons from './footer/examples/FwbFooterExample
 import FwbFooterExampleSticky from './footer/examples/FwbFooterExampleSticky.vue'
 import FwbFooterExampleWithLogo from './footer/examples/FwbFooterExampleWithLogo.vue'
 </script>
-# Vue Footer - Flowbite
+# Footer - Flowbite Vue
 #### Use the footer section at the bottom of every page to show valuable information to your users, such as sitemap links, a copyright notice, and a logo
 
 The footer is one of the most underestimated sections of a website being located at the very bottom of every page, however, it can be used as a way to try to convince users to stay on your website if they haven’t found the information they’ve been looking for inside the main content area.

--- a/docs/components/footer.md
+++ b/docs/components/footer.md
@@ -5,15 +5,25 @@ import FwbFooterExampleSocialMediaIcons from './footer/examples/FwbFooterExample
 import FwbFooterExampleSticky from './footer/examples/FwbFooterExampleSticky.vue'
 import FwbFooterExampleWithLogo from './footer/examples/FwbFooterExampleWithLogo.vue'
 </script>
+
 # Footer - Flowbite Vue
+
 #### Use the footer section at the bottom of every page to show valuable information to your users, such as sitemap links, a copyright notice, and a logo
 
-The footer is one of the most underestimated sections of a website being located at the very bottom of every page, however, it can be used as a way to try to convince users to stay on your website if they haven’t found the information they’ve been looking for inside the main content area.
+---
 
-## Default footer
-Use this footer component to show a copyright notice and some helpful website links.
+:::tip Footer - Flowbite
+Original reference: [https://flowbite.com/docs/components/footer/](https://flowbite.com/docs/components/footer/)
+:::
+
+The footer component can be used to show brand information, sitemap links, a copyright notice, and social media icons at the bottom of every page. Use the `footer-type` prop to switch between layout presets.
+
+## Default Footer
+
+Use `FwbFooter` as a wrapper with `FwbFooterCopyright` and `FwbFooterLinkGroup` to build a simple footer with a copyright notice and navigation links.
 
 <fwb-footer-example />
+
 ```vue
 <template>
   <fwb-footer>
@@ -49,10 +59,12 @@ import {
 </script>
 ```
 
-## Footer with logo
-Use this component to show your brand’s logo, a few website links and the copyright notice on a second row.
+## Footer with Logo
+
+Use `footer-type="logo"` together with `FwbFooterBrand` to show a brand logo and name alongside navigation links and a copyright line.
 
 <fwb-footer-example-with-logo />
+
 ```vue
 <template>
   <fwb-footer footer-type="logo">
@@ -83,6 +95,7 @@ Use this component to show your brand’s logo, a few website links and the copy
 <script setup>
 import {
   FwbFooter,
+  FwbFooterBrand,
   FwbFooterCopyright,
   FwbFooterLink,
   FwbFooterLinkGroup,
@@ -90,10 +103,12 @@ import {
 </script>
 ```
 
-## Social media icons
-This footer component can be used to show your brand’s logo, multiple rows of website links, a copyright notice and social media profile icons including Twitter, Facebook, Instagram, and more.
+## Social Media Icons
+
+Use `footer-type="socialmedia"` with `FwbFooterIcon` to render social platform links alongside multi-column link groups and a copyright line.
 
 <fwb-footer-example-social-media-icons />
+
 ```vue
 <template>
   <fwb-footer footer-type="socialmedia">
@@ -105,12 +120,8 @@ This footer component can be used to show your brand’s logo, multiple rows of 
             Resources
           </h2>
           <fwb-footer-link-group class="flex flex-col items-start">
-            <fwb-footer-link class="mb-4" href="/">
-              Flowbite
-            </fwb-footer-link>
-            <fwb-footer-link class="mb-4" href="/">
-              Tailwind CSS
-            </fwb-footer-link>
+            <fwb-footer-link class="mb-4" href="/">Flowbite</fwb-footer-link>
+            <fwb-footer-link class="mb-4" href="/">Tailwind CSS</fwb-footer-link>
           </fwb-footer-link-group>
         </div>
         <div>
@@ -118,12 +129,8 @@ This footer component can be used to show your brand’s logo, multiple rows of 
             Follow us
           </h2>
           <fwb-footer-link-group class="flex flex-col items-start">
-            <fwb-footer-link class="mb-4" href="/">
-              GitHub
-            </fwb-footer-link>
-            <fwb-footer-link class="mb-4" href="/">
-              Discord
-            </fwb-footer-link>
+            <fwb-footer-link class="mb-4" href="/">GitHub</fwb-footer-link>
+            <fwb-footer-link class="mb-4" href="/">Discord</fwb-footer-link>
           </fwb-footer-link-group>
         </div>
         <div>
@@ -131,12 +138,8 @@ This footer component can be used to show your brand’s logo, multiple rows of 
             Legal
           </h2>
           <fwb-footer-link-group class="flex flex-col items-start">
-            <fwb-footer-link class="mb-4" href="/">
-              Privacy Policy
-            </fwb-footer-link>
-            <fwb-footer-link class="mb-4" href="/">
-              Terms & Conditions
-            </fwb-footer-link>
+            <fwb-footer-link class="mb-4" href="/">Privacy Policy</fwb-footer-link>
+            <fwb-footer-link class="mb-4" href="/">Terms &amp; Conditions</fwb-footer-link>
           </fwb-footer-link-group>
         </div>
       </div>
@@ -145,31 +148,7 @@ This footer component can be used to show your brand’s logo, multiple rows of 
     <div class="sm:flex sm:items-center sm:justify-between">
       <fwb-footer-copyright by="Flowbite™" href="/" />
       <div class="flex mt-4 space-x-6 sm:justify-center sm:mt-0">
-        <fwb-footer-icon href="/">
-          <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white" fill="currentColor" viewBox="0 0 24 24">
-            <path clip-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/">
-          <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white" fill="currentColor" viewBox="0 0 21 16" xmlns="http://www.w3.org/2000/svg">
-            <path d="M16.942 1.556a16.3 16.3 0 0 0-4.126-1.3 12.04 12.04 0 0 0-.529 1.1 15.175 15.175 0 0 0-4.573 0 11.585 11.585 0 0 0-.535-1.1 16.274 16.274 0 0 0-4.129 1.3A17.392 17.392 0 0 0 .182 13.218a15.785 15.785 0 0 0 4.963 2.521c.41-.564.773-1.16 1.084-1.785a10.63 10.63 0 0 1-1.706-.83c.143-.106.283-.217.418-.33a11.664 11.664 0 0 0 10.118 0c.137.113.277.224.418.33-.544.328-1.116.606-1.71.832a12.52 12.52 0 0 0 1.084 1.785 16.46 16.46 0 0 0 5.064-2.595 17.286 17.286 0 0 0-2.973-11.59ZM6.678 10.813a1.941 1.941 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.919 1.919 0 0 1 1.8 2.047 1.93 1.93 0 0 1-1.8 2.045Zm6.644 0a1.94 1.94 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.918 1.918 0 0 1 1.8 2.047 1.93 1.93 0 0 1-1.8 2.045Z" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/">
-          <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white" fill="currentColor" viewBox="0 0 20 17" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M20 1.892a8.178 8.178 0 0 1-2.355.635 4.074 4.074 0 0 0 1.8-2.235 8.344 8.344 0 0 1-2.605.98A4.13 4.13 0 0 0 13.85 0a4.068 4.068 0 0 0-4.1 4.038 4 4 0 0 0 .105.919A11.705 11.705 0 0 1 1.4.734a4.006 4.006 0 0 0 1.268 5.392 4.165 4.165 0 0 1-1.859-.5v.05A4.057 4.057 0 0 0 4.1 9.635a4.19 4.19 0 0 1-1.856.07 4.108 4.108 0 0 0 3.831 2.807A8.36 8.36 0 0 1 0 14.184 11.732 11.732 0 0 0 6.291 16 11.502 11.502 0 0 0 17.964 4.5c0-.177 0-.35-.012-.523A8.143 8.143 0 0 0 20 1.892Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/">
-          <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M10 .333A9.911 9.911 0 0 0 6.866 19.65c.5.092.678-.215.678-.477 0-.237-.01-1.017-.014-1.845-2.757.6-3.338-1.169-3.338-1.169a2.627 2.627 0 0 0-1.1-1.451c-.9-.615.07-.6.07-.6a2.084 2.084 0 0 1 1.518 1.021 2.11 2.11 0 0 0 2.884.823c.044-.503.268-.973.63-1.325-2.2-.25-4.516-1.1-4.516-4.9A3.832 3.832 0 0 1 4.7 7.068a3.56 3.56 0 0 1 .095-2.623s.832-.266 2.726 1.016a9.409 9.409 0 0 1 4.962 0c1.89-1.282 2.717-1.016 2.717-1.016.366.83.402 1.768.1 2.623a3.827 3.827 0 0 1 1.02 2.659c0 3.807-2.319 4.644-4.525 4.889a2.366 2.366 0 0 1 .673 1.834c0 1.326-.012 2.394-.012 2.72 0 .263.18.572.681.475A9.911 9.911 0 0 0 10 .333Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/">
-          <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M10 0a10 10 0 1 0 10 10A10.009 10.009 0 0 0 10 0Zm6.613 4.614a8.523 8.523 0 0 1 1.93 5.32 20.094 20.094 0 0 0-5.949-.274c-.059-.149-.122-.292-.184-.441a23.879 23.879 0 0 0-.566-1.239 11.41 11.41 0 0 0 4.769-3.366ZM8 1.707a8.821 8.821 0 0 1 2-.238 8.5 8.5 0 0 1 5.664 2.152 9.608 9.608 0 0 1-4.476 3.087A45.758 45.758 0 0 0 8 1.707ZM1.642 8.262a8.57 8.57 0 0 1 4.73-5.981A53.998 53.998 0 0 1 9.54 7.222a32.078 32.078 0 0 1-7.9 1.04h.002Zm2.01 7.46a8.51 8.51 0 0 1-2.2-5.707v-.262a31.64 31.64 0 0 0 8.777-1.219c.243.477.477.964.692 1.449-.114.032-.227.067-.336.1a13.569 13.569 0 0 0-6.942 5.636l.009.003ZM10 18.556a8.508 8.508 0 0 1-5.243-1.8 11.717 11.717 0 0 1 6.7-5.332.509.509 0 0 1 .055-.02 35.65 35.65 0 0 1 1.819 6.476 8.476 8.476 0 0 1-3.331.676Zm4.772-1.462A37.232 37.232 0 0 0 13.113 11a12.513 12.513 0 0 1 5.321.364 8.56 8.56 0 0 1-3.66 5.73h-.002Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
+        <fwb-footer-icon href="/">...</fwb-footer-icon>
       </div>
     </div>
   </fwb-footer>
@@ -178,123 +157,44 @@ This footer component can be used to show your brand’s logo, multiple rows of 
 <script setup>
 import {
   FwbFooter,
+  FwbFooterBrand,
   FwbFooterCopyright,
+  FwbFooterIcon,
   FwbFooterLink,
   FwbFooterLinkGroup,
 } from 'flowbite-vue'
 </script>
 ```
 
-## Sitemap links
-If you have a website with many pages you can use this footer component to show a sitemap spanning the entire width of a row followed below by a copyright notice and social media icons.
+## Sitemap Links
+
+Use `footer-type="sitemap"` to render a dark full-width footer with multi-column link groups, social icons, and a copyright notice.
 
 <fwb-footer-example-sitemap-links />
+
 ```vue
 <template>
   <fwb-footer footer-type="sitemap">
     <div class="grid grid-cols-2 gap-8 py-8 px-6 md:grid-cols-4">
       <div>
-        <h2 class="mb-6 text-sm font-semibold text-gray-400 uppercase">
-          Company
-        </h2>
+        <h2 class="mb-6 text-sm font-semibold text-gray-400 uppercase">Company</h2>
         <fwb-footer-link-group class="text-gray-300 flex flex-col items-start">
-          <fwb-footer-link class="mb-4" href="/">
-            About
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Careers
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Brand Center
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Blog
-          </fwb-footer-link>
+          <fwb-footer-link class="mb-4" href="/">About</fwb-footer-link>
+          <fwb-footer-link class="mb-4" href="/">Careers</fwb-footer-link>
         </fwb-footer-link-group>
       </div>
       <div>
-        <h2 class="mb-6 text-sm font-semibold uppercase text-gray-400">
-          Download
-        </h2>
+        <h2 class="mb-6 text-sm font-semibold uppercase text-gray-400">Legal</h2>
         <fwb-footer-link-group class="text-gray-300 flex flex-col items-start">
-          <fwb-footer-link class="mb-4" href="/">
-            Discord Server
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Twitter
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Facebook
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Contact Us
-          </fwb-footer-link>
-        </fwb-footer-link-group>
-      </div>
-      <div>
-        <h2 class="mb-6 text-sm font-semibold uppercase text-gray-400">
-          Legal
-        </h2>
-        <fwb-footer-link-group class="text-gray-300 flex flex-col items-start">
-          <fwb-footer-link class="mb-4" href="/">
-            Privacy Policy
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Licensing
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Terms & Conditions
-          </fwb-footer-link>
-        </fwb-footer-link-group>
-      </div>
-      <div>
-        <h2 class="mb-6 text-sm font-semibold uppercase text-gray-400">
-          Download
-        </h2>
-        <fwb-footer-link-group class="text-gray-300 flex flex-col items-start">
-          <fwb-footer-link class="mb-4" href="/">
-            iOS
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Android
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            Windows
-          </fwb-footer-link>
-          <fwb-footer-link class="mb-4" href="/">
-            MacOS
-          </fwb-footer-link>
+          <fwb-footer-link class="mb-4" href="/">Privacy Policy</fwb-footer-link>
+          <fwb-footer-link class="mb-4" href="/">Terms &amp; Conditions</fwb-footer-link>
         </fwb-footer-link-group>
       </div>
     </div>
     <div class="py-6 px-4 bg-gray-700 md:flex md:items-center md:justify-between">
       <fwb-footer-copyright by="Flowbite™" class="text-sm text-gray-300 sm:text-center" href="/" />
       <div class="flex mt-4 space-x-6 sm:justify-center md:mt-0">
-        <fwb-footer-icon href="/" sr-text="Facebook page">
-          <svg aria-hidden="true" class="w-4 h-4" fill="currentColor" viewBox="0 0 8 19" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M6.135 3H8V0H6.135a4.147 4.147 0 0 0-4.142 4.142V6H0v3h2v9.938h3V9h2.021l.592-3H5V3.591A.6.6 0 0 1 5.592 3h.543Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/" sr-text="Discord community">
-          <svg aria-hidden="true" class="w-4 h-4" fill="currentColor" viewBox="0 0 21 16" xmlns="http://www.w3.org/2000/svg">
-            <path d="M16.942 1.556a16.3 16.3 0 0 0-4.126-1.3 12.04 12.04 0 0 0-.529 1.1 15.175 15.175 0 0 0-4.573 0 11.585 11.585 0 0 0-.535-1.1 16.274 16.274 0 0 0-4.129 1.3A17.392 17.392 0 0 0 .182 13.218a15.785 15.785 0 0 0 4.963 2.521c.41-.564.773-1.16 1.084-1.785a10.63 10.63 0 0 1-1.706-.83c.143-.106.283-.217.418-.33a11.664 11.664 0 0 0 10.118 0c.137.113.277.224.418.33-.544.328-1.116.606-1.71.832a12.52 12.52 0 0 0 1.084 1.785 16.46 16.46 0 0 0 5.064-2.595 17.286 17.286 0 0 0-2.973-11.59ZM6.678 10.813a1.941 1.941 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.919 1.919 0 0 1 1.8 2.047 1.93 1.93 0 0 1-1.8 2.045Zm6.644 0a1.94 1.94 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.918 1.918 0 0 1 1.8 2.047 1.93 1.93 0 0 1-1.8 2.045Z" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/" sr-text="Twitter page">
-          <svg aria-hidden="true" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 17" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M20 1.892a8.178 8.178 0 0 1-2.355.635 4.074 4.074 0 0 0 1.8-2.235 8.344 8.344 0 0 1-2.605.98A4.13 4.13 0 0 0 13.85 0a4.068 4.068 0 0 0-4.1 4.038 4 4 0 0 0 .105.919A11.705 11.705 0 0 1 1.4.734a4.006 4.006 0 0 0 1.268 5.392 4.165 4.165 0 0 1-1.859-.5v.05A4.057 4.057 0 0 0 4.1 9.635a4.19 4.19 0 0 1-1.856.07 4.108 4.108 0 0 0 3.831 2.807A8.36 8.36 0 0 1 0 14.184 11.732 11.732 0 0 0 6.291 16 11.502 11.502 0 0 0 17.964 4.5c0-.177 0-.35-.012-.523A8.143 8.143 0 0 0 20 1.892Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/" sr-text="GitHub account">
-          <svg aria-hidden="true" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M10 .333A9.911 9.911 0 0 0 6.866 19.65c.5.092.678-.215.678-.477 0-.237-.01-1.017-.014-1.845-2.757.6-3.338-1.169-3.338-1.169a2.627 2.627 0 0 0-1.1-1.451c-.9-.615.07-.6.07-.6a2.084 2.084 0 0 1 1.518 1.021 2.11 2.11 0 0 0 2.884.823c.044-.503.268-.973.63-1.325-2.2-.25-4.516-1.1-4.516-4.9A3.832 3.832 0 0 1 4.7 7.068a3.56 3.56 0 0 1 .095-2.623s.832-.266 2.726 1.016a9.409 9.409 0 0 1 4.962 0c1.89-1.282 2.717-1.016 2.717-1.016.366.83.402 1.768.1 2.623a3.827 3.827 0 0 1 1.02 2.659c0 3.807-2.319 4.644-4.525 4.889a2.366 2.366 0 0 1 .673 1.834c0 1.326-.012 2.394-.012 2.72 0 .263.18.572.681.475A9.911 9.911 0 0 0 10 .333Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
-        <fwb-footer-icon href="/" sr-text="Dribbble account">
-          <svg aria-hidden="true" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M10 0a10 10 0 1 0 10 10A10.009 10.009 0 0 0 10 0Zm6.613 4.614a8.523 8.523 0 0 1 1.93 5.32 20.094 20.094 0 0 0-5.949-.274c-.059-.149-.122-.292-.184-.441a23.879 23.879 0 0 0-.566-1.239 11.41 11.41 0 0 0 4.769-3.366ZM8 1.707a8.821 8.821 0 0 1 2-.238 8.5 8.5 0 0 1 5.664 2.152 9.608 9.608 0 0 1-4.476 3.087A45.758 45.758 0 0 0 8 1.707ZM1.642 8.262a8.57 8.57 0 0 1 4.73-5.981A53.998 53.998 0 0 1 9.54 7.222a32.078 32.078 0 0 1-7.9 1.04h.002Zm2.01 7.46a8.51 8.51 0 0 1-2.2-5.707v-.262a31.64 31.64 0 0 0 8.777-1.219c.243.477.477.964.692 1.449-.114.032-.227.067-.336.1a13.569 13.569 0 0 0-6.942 5.636l.009.003ZM10 18.556a8.508 8.508 0 0 1-5.243-1.8 11.717 11.717 0 0 1 6.7-5.332.509.509 0 0 1 .055-.02 35.65 35.65 0 0 1 1.819 6.476 8.476 8.476 0 0 1-3.331.676Zm4.772-1.462A37.232 37.232 0 0 0 13.113 11a12.513 12.513 0 0 1 5.321.364 8.56 8.56 0 0 1-3.66 5.73h-.002Z" fill-rule="evenodd" />
-          </svg>
-        </fwb-footer-icon>
+        <fwb-footer-icon href="/" sr-text="Facebook page">...</fwb-footer-icon>
       </div>
     </div>
   </fwb-footer>
@@ -304,16 +204,19 @@ If you have a website with many pages you can use this footer component to show 
 import {
   FwbFooter,
   FwbFooterCopyright,
+  FwbFooterIcon,
   FwbFooterLink,
   FwbFooterLinkGroup,
 } from 'flowbite-vue'
 </script>
 ```
 
-## Sticky footer
-Use this example to set create a sticky footer by using a fixed position to the bottom of the document page as the user scrolls up or down the main content area.
+## Sticky Footer
+
+Add the `sticky` prop to fix the footer to the bottom of the viewport regardless of scroll position.
 
 <fwb-footer-example-sticky />
+
 ```vue
 <template>
   <fwb-footer sticky>
@@ -323,18 +226,10 @@ Use this example to set create a sticky footer by using a fixed position to the 
       copyright-message="All Rights Reserved."
     />
     <fwb-footer-link-group>
-      <fwb-footer-link href="#">
-        About
-      </fwb-footer-link>
-      <fwb-footer-link href="#">
-        Privacy Policy
-      </fwb-footer-link>
-      <fwb-footer-link href="#">
-        Licensing
-      </fwb-footer-link>
-      <fwb-footer-link href="#">
-        Contact
-      </fwb-footer-link>
+      <fwb-footer-link href="#">About</fwb-footer-link>
+      <fwb-footer-link href="#">Privacy Policy</fwb-footer-link>
+      <fwb-footer-link href="#">Licensing</fwb-footer-link>
+      <fwb-footer-link href="#">Contact</fwb-footer-link>
     </fwb-footer-link-group>
   </fwb-footer>
 </template>
@@ -348,3 +243,67 @@ import {
 } from 'flowbite-vue'
 </script>
 ```
+
+## Footer component API
+
+### FwbFooter Props
+
+| Name       | Type                                               | Default     | Description                                             |
+| ---------- | -------------------------------------------------- | ----------- | ------------------------------------------------------- |
+| footerType | `'default' \| 'logo' \| 'socialmedia' \| 'sitemap'` | `'default'` | Controls the background and padding preset of the footer. |
+| sticky     | `Boolean`                                          | `false`     | Fixes the footer to the bottom of the viewport.         |
+
+### FwbFooterBrand Props
+
+| Name       | Type     | Default | Description                                                     |
+| ---------- | -------- | ------- | --------------------------------------------------------------- |
+| href       | `String` | `''`    | URL the brand logo and name link to.                            |
+| src        | `String` | `''`    | URL of the brand logo image.                                    |
+| alt        | `String` | `''`    | Alt text for the logo image.                                    |
+| name       | `String` | `''`    | Brand name displayed next to the logo.                          |
+| imageClass | `String` | `''`    | Additional classes applied to the `<img>` element.              |
+| nameClass  | `String` | `''`    | Additional classes applied to the brand name text element.      |
+| aClass     | `String` | `''`    | Additional classes applied to the wrapping `<a>` element.       |
+
+### FwbFooterCopyright Props
+
+| Name             | Type              | Default                    | Description                                                            |
+| ---------------- | ----------------- | -------------------------- | ---------------------------------------------------------------------- |
+| by               | `String`          | `''`                       | Brand name displayed in the copyright notice.                          |
+| href             | `String`          | `''`                       | When set, renders the brand name as a link to this URL.                |
+| year             | `String \| Number` | current year               | Copyright year displayed before the brand name.                        |
+| copyrightMessage | `String`          | `'All Rights Reserved.'`   | Text appended after the brand name.                                    |
+| aClass           | `String`          | `''`                       | Additional classes applied to the brand name `<a>` or `<span>`.        |
+
+### FwbFooterIcon Props
+
+| Name      | Type     | Default | Description                                                       |
+| --------- | -------- | ------- | ----------------------------------------------------------------- |
+| href      | `String` | `''`    | When set, renders the icon wrapper as an `<a>` element.           |
+| srText    | `String` | `''`    | Visually hidden text for screen readers (e.g. "Facebook page").   |
+
+### FwbFooterIcon Slots
+
+| Name    | Description                         |
+| ------- | ----------------------------------- |
+| default | The SVG icon or element to display. |
+
+### FwbFooterLink Props
+
+| Name      | Type     | Default | Description                                                                        |
+| --------- | -------- | ------- | ---------------------------------------------------------------------------------- |
+| href      | `String` | `''`    | URL the link navigates to.                                                         |
+| component | `String` | `'a'`   | Root element tag. Use `'router-link'` for Vue Router integration.                  |
+| aClass    | `String` | `''`    | Additional classes applied to the link element.                                    |
+
+### FwbFooterLink Slots
+
+| Name    | Description      |
+| ------- | ---------------- |
+| default | The link label.  |
+
+### FwbFooterLinkGroup Slots
+
+| Name    | Description                                               |
+| ------- | --------------------------------------------------------- |
+| default | One or more `FwbFooterLink` elements rendered as a group. |

--- a/docs/components/footer.md
+++ b/docs/components/footer.md
@@ -148,7 +148,7 @@ Use `footer-type="socialmedia"` with `FwbFooterIcon` to render social platform l
     <div class="sm:flex sm:items-center sm:justify-between">
       <fwb-footer-copyright by="Flowbite™" href="/" />
       <div class="flex mt-4 space-x-6 sm:justify-center sm:mt-0">
-        <fwb-footer-icon href="/">...</fwb-footer-icon>
+        <fwb-footer-icon href="/" sr-text="Visit us">...</fwb-footer-icon>
       </div>
     </div>
   </fwb-footer>

--- a/docs/components/heading.md
+++ b/docs/components/heading.md
@@ -9,7 +9,7 @@ import FwbHExampleColor from './typography/heading/FwbHExampleColor.vue'
 import FwbHExampleCustom from './typography/heading/FwbHExampleCustom.vue'
 </script>
 
-# Vue Heading - Flowbite
+# Heading - Flowbite Vue
 
 #### The heading component defines six levels of title elements from H1 to H6 that are used as titles and subtitles on a web page based on multiple styles and layouts
 

--- a/docs/components/heading.md
+++ b/docs/components/heading.md
@@ -13,10 +13,19 @@ import FwbHExampleCustom from './typography/heading/FwbHExampleCustom.vue'
 
 #### The heading component defines six levels of title elements from H1 to H6 that are used as titles and subtitles on a web page based on multiple styles and layouts
 
-## Heading one (H1)
+---
 
-Use the `tag="h1"` as the most important text element to indicate the title of your web page.
+:::tip Heading - Flowbite
+Original reference: [https://flowbite.com/docs/typography/headings/](https://flowbite.com/docs/typography/headings/)
+:::
 
+The heading component can be used to render H1–H6 title elements with Tailwind CSS utility classes, available in multiple colors and with support for custom class overrides.
+
+## Heading 1
+
+Use `tag="h1"` for the most important text element on a page, typically the page title. Each page should have only one H1.
+
+<fwb-h-example-level1 />
 
 ```vue
 <template>
@@ -27,12 +36,12 @@ Use the `tag="h1"` as the most important text element to indicate the title of y
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-level1 />
 
+## Heading 2
 
-## Heading two (H2)
+Use `tag="h2"` as the main subtitle for major page sections.
 
-The H2 tag can be used as subtitles of the page’s sections.
+<fwb-h-example-level2 />
 
 ```vue
 <template>
@@ -43,12 +52,12 @@ The H2 tag can be used as subtitles of the page’s sections.
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-level2 />
 
+## Heading 3
 
-## Heading three (H3)
+Use `tag="h3"` inside sections that already have an H2 to create a third level of hierarchy.
 
-Use the H3 tags inside sections that already have a H2 available.
+<fwb-h-example-level3 />
 
 ```vue
 <template>
@@ -59,12 +68,12 @@ Use the H3 tags inside sections that already have a H2 available.
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-level3 />
 
+## Heading 4
 
-## Heading four (H4)
+Use `tag="h4"` after H2 and H3 tags are already present and you need deeper nesting.
 
-The H4 can be generally used after H2 and H3 tags are already present and you need a more in-depth hierarchy.
+<fwb-h-example-level4 />
 
 ```vue
 <template>
@@ -75,12 +84,12 @@ The H4 can be generally used after H2 and H3 tags are already present and you ne
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-level4 />
 
+## Heading 5
 
-## Heading five (H5)
+Use `tag="h5"` in longer articles with multiple heading levels already in use, or in sidebars.
 
-The H5 tag is most often used in longer articles with other heading already available or in sidebars.
+<fwb-h-example-level5 />
 
 ```vue
 <template>
@@ -91,12 +100,12 @@ The H5 tag is most often used in longer articles with other heading already avai
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-level5 />
 
+## Heading 6
 
-## Heading six (H6)
+Use `tag="h6"` for the deepest heading level in a complex content hierarchy.
 
-Using the H6 tag is quite rare because it means that you’ve already used all heading from H1 to H5, but you can still use it if you have a very complex article with lots of headings.
+<fwb-h-example-level6 />
 
 ```vue
 <template>
@@ -107,29 +116,28 @@ Using the H6 tag is quite rare because it means that you’ve already used all h
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-level6 />
-
 
 ## Color
 
-Use the `color` prop to set the text color.
+Use the `color` prop to override the default text color with any Tailwind text color utility.
+
+<fwb-h-example-color />
 
 ```vue
 <template>
-  <fwb-heading color="text-green-400">Green eading</fwb-heading>
+  <fwb-heading color="text-green-400">Green heading</fwb-heading>
 </template>
 
 <script setup>
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-color />
 
+## Custom Classes
 
-## Custom classes
+Pass additional Tailwind utilities via the `class` attribute to further customize the heading appearance.
 
-Use the `class` attribute to apply the tailwind classes.
-
+<fwb-h-example-custom />
 
 ```vue
 <template>
@@ -140,4 +148,19 @@ Use the `class` attribute to apply the tailwind classes.
 import { FwbHeading } from 'flowbite-vue'
 </script>
 ```
-<fwb-h-example-custom />
+
+## Heading component API
+
+### FwbHeading Props
+
+| Name       | Type                                       | Default                          | Description                                                                              |
+| ---------- | ------------------------------------------ | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| tag        | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h1'`                    | The HTML heading element to render.                                                      |
+| color      | `String`                                   | `'text-gray-900 dark:text-white'` | Tailwind text color utility applied to the heading.                                     |
+| customSize | `String`                                   | `''`                             | Overrides the default size and weight classes (e.g. `text-5xl font-extrabold` for H1).  |
+
+### FwbHeading Slots
+
+| Name    | Description              |
+| ------- | ------------------------ |
+| default | The heading text content. |

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -11,9 +11,19 @@ import FwbImgExampleCustom from './typography/image/FwbImgExampleCustom.vue'
 
 #### The image component can be used to embed images inside the web page in articles and sections based on multiple styles, sizes, layouts and hover animations
 
-## Default image
+---
 
-Use this example to show the a responsive image that won’t grow beyond the maximum original width.
+:::tip Images - Flowbite
+Original reference: [https://flowbite.com/docs/typography/images/](https://flowbite.com/docs/typography/images/)
+:::
+
+The image component can be used to display responsive images with support for captions, custom sizes, alignment, grayscale filters, and hover effects — all styled with Tailwind CSS utility classes.
+
+## Default Image
+
+Use `FwbImg` to render a responsive image that won't grow beyond its original width. Provide `src` and `alt` for basic usage.
+
+<fwb-img-example />
 
 ```vue
 <template>
@@ -27,11 +37,12 @@ Use this example to show the a responsive image that won’t grow beyond the max
 import { FwbImg } from 'flowbite-vue'
 </script>
 ```
-<fwb-img-example />
 
-## Image caption
+## Image Caption
 
-This example can be used to add a caption for the image often used inside articles. Use `caption-class` to override the cation.
+Use the `caption` prop to display a centered caption below the image, rendered inside a `<figcaption>` element. Use `captionClass` to override the caption styling.
+
+<fwb-img-example-caption />
 
 ```vue
 <template>
@@ -46,12 +57,12 @@ This example can be used to add a caption for the image often used inside articl
 import { FwbImg } from 'flowbite-vue'
 </script>
 ```
-<fwb-img-example-caption />
-
 
 ## Sizes
 
-Set the size of the image using the `w-size` and `h-size` or `max-w-size` utility classes from Tailwind CSS to set the width and height of the element.
+Use the `size` prop to apply a Tailwind max-width or width utility and constrain the image dimensions.
+
+<fwb-img-example-size />
 
 ```vue
 <template>
@@ -66,11 +77,12 @@ Set the size of the image using the `w-size` and `h-size` or `max-w-size` utilit
 import { FwbImg } from 'flowbite-vue'
 </script>
 ```
-<fwb-img-example-size />
 
 ## Alignment
 
-Align the image component to the center or right side of the document page using `mx-auto` and `ml-auto` margin styles.
+Use the `alignment` prop to apply a Tailwind margin utility such as `mx-auto` (center) or `ml-auto` (right) to position the image horizontally.
+
+<fwb-img-example-align />
 
 ```vue
 <template>
@@ -86,11 +98,12 @@ Align the image component to the center or right side of the document page using
 import { FwbImg } from 'flowbite-vue'
 </script>
 ```
-<fwb-img-example-align />
 
 ## Grayscale
 
-Use the filter option and apply a grayscale to the image element using the grayscale class.
+Use `imgClass` to apply Tailwind filter utilities. The example below uses `grayscale` by default and removes it on hover.
+
+<fwb-img-example-grayscale />
 
 ```vue
 <template>
@@ -106,11 +119,12 @@ Use the filter option and apply a grayscale to the image element using the grays
 import { FwbImg } from 'flowbite-vue'
 </script>
 ```
-<fwb-img-example-grayscale />
 
-## Custom classes
+## Custom Classes
 
-Use the `img-class` prop to apply tailwind classes.
+Use the `imgClass` prop to apply any Tailwind utility classes directly to the `<img>` element.
+
+<fwb-img-example-custom />
 
 ```vue
 <template>
@@ -126,4 +140,17 @@ Use the `img-class` prop to apply tailwind classes.
 import { FwbImg } from 'flowbite-vue'
 </script>
 ```
-<fwb-img-example-custom />
+
+## Image component API
+
+### FwbImg Props
+
+| Name         | Type     | Default                                                    | Description                                                                          |
+| ------------ | -------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| alt          | `String` | `''`                                                       | Alt text for the image element.                                                      |
+| alignment    | `String` | `''`                                                       | Tailwind margin utility for horizontal positioning (e.g. `mx-auto`, `ml-auto`).      |
+| caption      | `String` | `''`                                                       | When set, wraps the image in a `<figure>` and renders a `<figcaption>`.              |
+| captionClass | `String` | `'mt-2 text-sm text-center text-gray-500 dark:text-gray-400'` | Tailwind classes applied to the `<figcaption>` element.                          |
+| imgClass     | `String` | `'h-auto'`                                                 | Additional Tailwind classes applied directly to the `<img>` element.                 |
+| size         | `String` | `'max-w-full'`                                             | Tailwind size utility applied to both the image and the figure wrapper (if shown).   |
+| src          | `String` | `''`                                                       | URL of the image to display.                                                         |

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -7,7 +7,7 @@ import FwbImgExampleGrayscale from './typography/image/FwbImgExampleGrayscale.vu
 import FwbImgExampleCustom from './typography/image/FwbImgExampleCustom.vue'
 </script>
 
-# Vue Images - Flowbite
+# Images - Flowbite Vue
 
 #### The image component can be used to embed images inside the web page in articles and sections based on multiple styles, sizes, layouts and hover animations
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -13,7 +13,7 @@ import FwbInputExampleTypes from './input/examples/FwbInputExampleTypes.vue'
 import FwbInputExampleValidation from './input/examples/FwbInputExampleValidation.vue'
 </script>
 
-# Vue Input Field - Flowbite
+# Input Field - Flowbite Vue
 
 #### Get started with a collection of input fields built with Tailwind CSS to start accepting data from the user based on multiple sizes, variants, and input types
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -27,7 +27,9 @@ The input field is an important part of the form element that can be used to cre
 
 On this page you will find all of the input types based on multiple variants, styles, colors, and sizes built with the utility classes from Tailwind CSS and components from Flowbite.
 
-## Input
+## Default Input
+
+Use `v-model` to bind the input value and the `label` prop to set the visible label text.
 
 <fwb-input-example />
 ```vue
@@ -48,7 +50,9 @@ const name = ref('')
 
 ```
 
-## Input sizes
+## Input Sizes
+
+Use the `size` prop to control the input's padding and font size. Available sizes are `sm`, `md` (default), `lg`, and `xl`.
 
 <fwb-input-example-size />
 ```vue
@@ -116,7 +120,9 @@ const url = ref('')
 
 ```
 
-## Disabled state
+## Disabled State
+
+Add the `disabled` prop to prevent the user from interacting with the input.
 
 <fwb-input-example-disabled />
 ```vue
@@ -212,6 +218,8 @@ const name = ref('')
 
 ## Slot - Helper
 
+Use the `helper` slot to render supplemental text below the input, such as privacy notices or format hints.
+
 <fwb-input-example-helper />
 ```vue
 <template>
@@ -263,6 +271,8 @@ const name = ref('')
 ```
 
 ## Slot - Suffix
+
+Use the `suffix` slot to place an icon or button on the right side of the input, such as a search button.
 
 <fwb-input-example-suffix />
 ```vue

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -6,7 +6,7 @@ import FwbJumbotronBackgroundImageExample from './jumbotron/examples/FwbJumbotro
 import FwbJumbotronVideoExample from './jumbotron/examples/FwbJumbotronVideoExample.vue';
 </script>
 
-# Vue Jumbotron - Flowbite
+# Jumbotron - Flowbite Vue
 
 #### Use the jumbotron component to show a marketing message to your users based on a headline and image inside of a card box based on Tailwind CSS
 

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -1,9 +1,9 @@
 <script setup>
-import FwbJumbotronExample from './jumbotron/examples/FwbJumbotronExample.vue';
-import FwbJumbotronFormExample from './jumbotron/examples/FwbJumbotronFormExample.vue';
-import FwbJumbotronGradientExample from './jumbotron/examples/FwbJumbotronGradientExample.vue';
-import FwbJumbotronBackgroundImageExample from './jumbotron/examples/FwbJumbotronBackgroundImageExample.vue';
-import FwbJumbotronVideoExample from './jumbotron/examples/FwbJumbotronVideoExample.vue';
+import FwbJumbotronExample from './jumbotron/examples/FwbJumbotronExample.vue'
+import FwbJumbotronFormExample from './jumbotron/examples/FwbJumbotronFormExample.vue'
+import FwbJumbotronGradientExample from './jumbotron/examples/FwbJumbotronGradientExample.vue'
+import FwbJumbotronBackgroundImageExample from './jumbotron/examples/FwbJumbotronBackgroundImageExample.vue'
+import FwbJumbotronVideoExample from './jumbotron/examples/FwbJumbotronVideoExample.vue'
 </script>
 
 # Jumbotron - Flowbite Vue
@@ -12,314 +12,182 @@ import FwbJumbotronVideoExample from './jumbotron/examples/FwbJumbotronVideoExam
 
 ---
 
-:::tip
+:::tip Jumbotron - Flowbite
 Original reference: [https://flowbite.com/docs/components/jumbotron/](https://flowbite.com/docs/components/jumbotron/)
 :::
 
-The Jumbotron (hero) component can be used as the first section of your website with a focus on a marketing message to increase the likelihood of the user to continue browsing your website.
-
-This UI component features a heading title, a short description, an optional CTA button, background image, gradient or solid background color and it’s generally inside of a card element.
-
-The jumbotron component from Flowbite is responsive on all devices, natively supports dark mode and is coded with the utility classes from Tailwind CSS.
-
+The jumbotron (hero) component can be used as the first section of your website with a focus on a marketing message to increase the likelihood of the user to continue browsing. It features a heading, a short description, an optional CTA button, and supports background images, gradients, and video content.
 
 ## Default Jumbotron
-Use this default example to show a title, description, and two CTA buttons for the jumbotron component.
+
+Use `header-text` and `sub-text` props to define the heading and body copy. Place CTA buttons or any other content in the default slot.
 
 <fwb-jumbotron-example />
+
 ```vue
 <template>
-  <div
+  <fwb-jumbotron
+    header-text="We invest in the world's potential"
+    sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
   >
-    <fwb-jumbotron
-      header-text="We invest in the world’s potential"
-      sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
-    >
-      <div class="flex flex-col space-y-4 sm:flex-row sm:justify-center sm:space-y-0">
-        <a
-          href="#"
-          class="inline-flex justify-center items-center py-3 px-5 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900"
-        >
-          Get started
-          <svg
-            class="w-3.5 h-3.5 ml-2 rtl:rotate-180"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 14 10"
-          >
-            <path
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M1 5h12m0 0L9 1m4 4L9 9"
-            />
-          </svg>
-        </a>
-        <a
-          href="#"
-          class="inline-flex justify-center items-center py-3 px-5 sm:ml-4 text-base font-medium text-center text-gray-900 rounded-lg border border-gray-300 hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-white dark:border-gray-700 dark:hover:bg-gray-700 dark:focus:ring-gray-800"
-        >
-          Learn more
-        </a>
-      </div>
-    </fwb-jumbotron>
-  </div>
-</template>
-
-<script setup>
-import FwbJumbotron from '@/components/FwbJumbotron/FwbJumbotron.vue'
-</script>
-
-```
-
-## Background image
-Use this jumbotron to apply a background image with a darkening opacity effect to improve readability.
-
-<fwb-jumbotron-background-image-example />
-```vue
-<template>
-  <div
-  >
-    <fwb-jumbotron
-      class="bg-center bg-no-repeat bg-[url('https://flowbite.s3.amazonaws.com/docs/jumbotron/conference.jpg')] dark:bg-gray-700 bg-gray-700 bg-blend-multiply"
-      header-classes="text-white"
-      sub-text-classes="text-gray-300 dark:text-gray-300"
-      header-text="We invest in the world’s potential"
-      sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
-    >
-      <div class="flex flex-col space-y-4 sm:flex-row sm:justify-center sm:space-y-0">
-        <a
-          href="#"
-          class="inline-flex justify-center items-center py-3 px-5 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900"
-        >
-          Get started
-          <svg
-            class="w-3.5 h-3.5 ml-2 rtl:rotate-180"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 14 10"
-          >
-            <path
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M1 5h12m0 0L9 1m4 4L9 9"
-            />
-          </svg>
-        </a>
-        <a
-          href="#"
-          class="inline-flex justify-center hover:text-gray-900 items-center py-3 px-5 sm:ml-4 text-base font-medium text-center text-white rounded-lg border border-white hover:bg-gray-100 focus:ring-4 focus:ring-gray-400"
-        >
-          Learn more
-        </a>
-      </div>
-    </fwb-jumbotron>
-  </div>
-</template>
-
-<script setup>
-import FwbJumbotron from '@/components/FwbJumbotron/FwbJumbotron.vue'
-</script>
-
-```
-
-## Featured video
-This component can be used to feature a video together with a heading title, description, and CTA buttons.
-
-<fwb-jumbotron-video-example />
-```vue
-<template>
-  <div
-  >
-    <fwb-jumbotron
-      class="lg:py-8 px-4 "
-      header-classes="text-left"
-      sub-text-classes="lg:px-0"
-      header-text="We invest in the world’s potential"
-      sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
-    >
-      <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 mb-8">
-        <a
-          href="#"
-          class="inline-flex justify-center items-center py-3 px-5 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900"
-        >
-          Get started
-          <svg
-            class="w-3.5 h-3.5 ml-2 rtl:rotate-180"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 14 10"
-          >
-            <path
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M1 5h12m0 0L9 1m4 4L9 9"
-            />
-          </svg>
-        </a>
-        <a
-          href="#"
-          class="inline-flex justify-center items-center py-3 px-5 sm:ml-4 text-base font-medium text-center text-gray-900 rounded-lg border border-gray-300 hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-white dark:border-gray-700 dark:hover:bg-gray-700 dark:focus:ring-gray-800"
-        >
-          Learn more
-        </a>
-      </div>
-      <div>
-        <iframe
-          class="mx-auto w-full h-64 rounded-lg sm:h-96 shadow-xl"
-          src="https://www.youtube.com/embed/KaLxCiilHns"
-          title="YouTube video player"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-        />
-      </div>
-    </fwb-jumbotron>
-  </div>
-</template>
-
-<script setup>
-import FwbJumbotron from '@/components/FwbJumbotron/FwbJumbotron.vue'
-</script>
-
-```
-
-## Authentication form
-Use this component to show a sign in or register form as the first section of your website.
-
-<fwb-jumbotron-form-example />
-```vue
-<template>
-  <div
-  >
-    <fwb-jumbotron
-      class="lg:py-8 px-4 text-start "
-      header-classes="text-left"
-      sub-text-classes="lg:px-0"
-      header-text="We invest in the world’s potential"
-      sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
-    >
+    <div class="flex flex-col space-y-4 sm:flex-row sm:justify-center sm:space-y-0">
       <a
         href="#"
-        class="text-blue-600 dark:text-blue-500 hover:underline font-medium text-lg inline-flex items-center mb-8"
-      >Read more about our app
-        <svg
-          class="w-3.5 h-3.5 ms-2 rtl:rotate-180"
-          aria-hidden="true"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 14 10"
-        >
-          <path
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M1 5h12m0 0L9 1m4 4L9 9"
-          />
-        </svg>
+        class="inline-flex justify-center items-center py-3 px-5 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900"
+      >
+        Get started
       </a>
-      <div>
-        <div class="w-full p-6 space-y-8 sm:p-8 bg-white rounded-lg shadow-xl dark:bg-gray-800">
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-white">
-            Sign in to Flowbite
-          </h2>
-          <form
-            class="mt-8 space-y-6"
-            action="#"
-          >
-            <div>
-              <label
-                for="email"
-                class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
-              >Your email</label>
-              <input
-                id="email"
-                type="email"
-                name="email"
-                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                placeholder="name@company.com"
-                required
-              >
-            </div>
-            <div>
-              <label
-                for="password"
-                class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
-              >Your password</label>
-              <input
-                id="password"
-                type="password"
-                name="password"
-                placeholder="••••••••"
-                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                required
-              >
-            </div>
-            <div class="flex items-start">
-              <div class="flex items-center h-5">
-                <input
-                  id="remember"
-                  aria-describedby="remember"
-                  name="remember"
-                  type="checkbox"
-                  class="w-4 h-4 border-gray-300 rounded bg-gray-50 focus:ring-3 focus:ring-blue-300 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:bg-gray-700 dark:border-gray-600"
-                  required
-                >
-              </div>
-              <div class="ms-3 text-sm">
-                <label
-                  for="remember"
-                  class="font-medium text-gray-500 dark:text-gray-400"
-                >Remember this device</label>
-              </div>
-              <a
-                href="#"
-                class="ms-auto text-sm font-medium text-blue-600 hover:underline dark:text-blue-500"
-              >Lost Password?</a>
-            </div>
-            <button
-              type="submit"
-              class="w-full px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 sm:w-auto dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-            >
-              Login to your account
-            </button>
-            <div class="text-sm font-medium text-gray-900 dark:text-white">
-              Not registered yet? <a class="text-blue-600 hover:underline dark:text-blue-500">Create account</a>
-            </div>
-          </form>
-        </div>
-      </div>
-    </fwb-jumbotron>
-  </div>
+      <a
+        href="#"
+        class="inline-flex justify-center items-center py-3 px-5 sm:ml-4 text-base font-medium text-center text-gray-900 rounded-lg border border-gray-300 hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-white dark:border-gray-700 dark:hover:bg-gray-700 dark:focus:ring-gray-800"
+      >
+        Learn more
+      </a>
+    </div>
+  </fwb-jumbotron>
 </template>
 
 <script setup>
-import FwbJumbotron from '@/components/FwbJumbotron/FwbJumbotron.vue'
+import { FwbJumbotron } from 'flowbite-vue'
 </script>
-
 ```
 
-## API
+## Background Image
 
-### Props
-| Name           | Values                      | Default |
-|----------------|-----------------------------|---------|
-| headerLevel    | `1`, `2`, `3`,`4`, `5`, `6` | `1`     |
-| subText        | `string`                    | ``      |
-| subTextClasses | `string`                    | ``      |
-| headerText     | `string`                    | ``      |
-| headerClasses  | `string`                    | ``      |
+Use the `class` prop and Tailwind's `bg-[url(...)]` utility to apply a darkened background image. Override heading and sub-text colors via `headerClasses` and `subTextClasses`.
 
-### Slots
-| Name          | Description                  |
-|---------------|------------------------------|
-| default       | jumbotron content            |
+<fwb-jumbotron-background-image-example />
+
+```vue
+<template>
+  <fwb-jumbotron
+    class="bg-center bg-no-repeat bg-[url('https://flowbite.s3.amazonaws.com/docs/jumbotron/conference.jpg')] dark:bg-gray-700 bg-gray-700 bg-blend-multiply"
+    header-classes="text-white"
+    sub-text-classes="text-gray-300 dark:text-gray-300"
+    header-text="We invest in the world's potential"
+    sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
+  >
+    <div class="flex flex-col space-y-4 sm:flex-row sm:justify-center sm:space-y-0">
+      <a href="#" class="inline-flex justify-center items-center py-3 px-5 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
+        Get started
+      </a>
+      <a href="#" class="inline-flex justify-center hover:text-gray-900 items-center py-3 px-5 sm:ml-4 text-base font-medium text-center text-white rounded-lg border border-white hover:bg-gray-100 focus:ring-4 focus:ring-gray-400">
+        Learn more
+      </a>
+    </div>
+  </fwb-jumbotron>
+</template>
+
+<script setup>
+import { FwbJumbotron } from 'flowbite-vue'
+</script>
+```
+
+## Gradient Background
+
+Use a patterned SVG background and a gradient overlay via an absolutely-positioned element inside the default slot to create a gradient hero section.
+
+<fwb-jumbotron-gradient-example />
+
+```vue
+<template>
+  <fwb-jumbotron
+    header-text="We invest in the world's potential"
+    sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
+    class="relative bg-white bg-[url('https://flowbite.s3.amazonaws.com/docs/jumbotron/hero-pattern.svg')] dark:bg-gray-900 dark:bg-[url('https://flowbite.s3.amazonaws.com/docs/jumbotron/hero-pattern-dark.svg')]"
+  >
+    <form class="mx-auto w-full max-w-md">
+      <input type="email" class="block w-full rounded-lg border border-gray-300 bg-white p-4 text-sm" placeholder="Enter your email here..." required>
+    </form>
+    <div class="absolute left-0 top-0 z-0 size-full bg-linear-to-b from-blue-50 to-transparent dark:from-blue-900" />
+  </fwb-jumbotron>
+</template>
+
+<script setup>
+import { FwbJumbotron } from 'flowbite-vue'
+</script>
+```
+
+## Featured Video
+
+Place a video inside the default slot alongside CTA buttons to highlight media content in the hero section.
+
+<fwb-jumbotron-video-example />
+
+```vue
+<template>
+  <fwb-jumbotron
+    class="lg:py-8 px-4"
+    header-classes="text-left"
+    sub-text-classes="lg:px-0"
+    header-text="We invest in the world's potential"
+    sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
+  >
+    <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 mb-8">
+      <a href="#" class="inline-flex justify-center items-center py-3 px-5 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
+        Get started
+      </a>
+      <a href="#" class="inline-flex justify-center items-center py-3 px-5 sm:ml-4 text-base font-medium text-center text-gray-900 rounded-lg border border-gray-300 hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 dark:text-white dark:border-gray-700 dark:hover:bg-gray-700 dark:focus:ring-gray-800">
+        Learn more
+      </a>
+    </div>
+    <iframe
+      class="mx-auto w-full h-64 rounded-lg sm:h-96 shadow-xl"
+      src="https://www.youtube.com/embed/KaLxCiilHns"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    />
+  </fwb-jumbotron>
+</template>
+
+<script setup>
+import { FwbJumbotron } from 'flowbite-vue'
+</script>
+```
+
+## Authentication Form
+
+Use the jumbotron as a full-page hero background and place a sign-in card in the default slot.
+
+<fwb-jumbotron-form-example />
+
+```vue
+<template>
+  <fwb-jumbotron
+    class="lg:py-8 px-4 text-start"
+    header-classes="text-left"
+    sub-text-classes="lg:px-0"
+    header-text="We invest in the world's potential"
+    sub-text="Here at Flowbite we focus on markets where technology, innovation, and capital can unlock long-term value and drive economic growth."
+  >
+    <div class="w-full p-6 space-y-8 sm:p-8 bg-white rounded-lg shadow-xl dark:bg-gray-800">
+      <h2 class="text-2xl font-bold text-gray-900 dark:text-white">Sign in to Flowbite</h2>
+      <!-- form content -->
+    </div>
+  </fwb-jumbotron>
+</template>
+
+<script setup>
+import { FwbJumbotron } from 'flowbite-vue'
+</script>
+```
+
+## Jumbotron component API
+
+### FwbJumbotron Props
+
+| Name           | Type                           | Default | Description                                                                    |
+| -------------- | ------------------------------ | ------- | ------------------------------------------------------------------------------ |
+| headerLevel    | `1 \| 2 \| 3 \| 4 \| 5 \| 6`  | `1`     | HTML heading level rendered for the header text.                               |
+| headerText     | `String`                       | `''`    | The main heading text.                                                         |
+| headerClasses  | `String`                       | `''`    | Additional Tailwind classes applied to the heading element.                    |
+| subText        | `String`                       | `''`    | The body/description text displayed below the heading.                         |
+| subTextClasses | `String`                       | `''`    | Additional Tailwind classes applied to the sub-text wrapper.                   |
+
+### FwbJumbotron Slots
+
+| Name    | Description                                                             |
+| ------- | ----------------------------------------------------------------------- |
+| default | CTA buttons, forms, videos, or any other content below the description. |

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -8,9 +8,19 @@ import FwbAExampleCustom from './typography/link/FwbAExampleCustom.vue'
 
 #### The link component can be used to set hyperlinks from one page to another or to an external website when clicking on an inline text item, button, or card
 
-## Default link
+---
 
-Use this example to set default styles to an inline link element.
+:::tip Links - Flowbite
+Original reference: [https://flowbite.com/docs/typography/links/](https://flowbite.com/docs/typography/links/)
+:::
+
+The link component can be used to create styled anchor elements with Tailwind CSS utility classes, supporting inline text links and links embedded inside paragraphs.
+
+## Default Link
+
+Use `FwbA` to render an inline anchor element with the default brand color and a hover underline.
+
+<fwb-a-example />
 
 ```vue
 <template>
@@ -21,19 +31,17 @@ Use this example to set default styles to an inline link element.
 import { FwbA } from 'flowbite-vue'
 </script>
 ```
-<fwb-a-example />
 
-## Paragraph link
+## Paragraph Link
 
-Use this example to set a link inside a paragraph with an underline style.
+Use `FwbA` inside a `FwbP` component to create an inline link within a paragraph of text.
+
+<fwb-a-example-paragraph />
 
 ```vue
 <template>
   <fwb-p>
-    The free updates that will be provided is based on the <fwb-a href="#"
-    class="underline hover:no-underline">roadmap</fwb-a> that we have laid
-    out for this project. It is also possible that we will provide
-    extra updates outside of the roadmap as well.
+    The free updates that will be provided is based on the <fwb-a href="#" class="underline hover:no-underline">roadmap</fwb-a> that we have laid out for this project.
   </fwb-p>
 </template>
 
@@ -41,11 +49,12 @@ Use this example to set a link inside a paragraph with an underline style.
 import { FwbA, FwbP } from 'flowbite-vue'
 </script>
 ```
-<fwb-a-example-paragraph />
 
-## Custom classes
+## Custom Classes
 
-Use `class` attribute prop to apply the tailwind classes.
+Use the `color` prop to override the link text color, or the `class` attribute to apply any additional Tailwind utilities.
+
+<fwb-a-example-custom />
 
 ```vue
 <template>
@@ -56,4 +65,18 @@ Use `class` attribute prop to apply the tailwind classes.
 import { FwbA } from 'flowbite-vue'
 </script>
 ```
-<fwb-a-example-custom />
+
+## Link component API
+
+### FwbA Props
+
+| Name  | Type     | Default                                      | Description                                             |
+| ----- | -------- | -------------------------------------------- | ------------------------------------------------------- |
+| href  | `String` | `''`                                         | The URL the link navigates to.                          |
+| color | `String` | `'text-primary-600 dark:text-primary-500'`   | Tailwind text color utility applied to the link.        |
+
+### FwbA Slots
+
+| Name    | Description          |
+| ------- | -------------------- |
+| default | The link label text. |

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -4,7 +4,7 @@ import FwbAExampleParagraph from './typography/link/FwbAExampleParagraph.vue'
 import FwbAExampleCustom from './typography/link/FwbAExampleCustom.vue'
 </script>
 
-# Vue Links - Flowbite
+# Links - Flowbite Vue
 
 #### The link component can be used to set hyperlinks from one page to another or to an external website when clicking on an inline text item, button, or card
 

--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -5,7 +5,7 @@ import FwbListGroupExampleLink from './listGroup/examples/FwbListGroupExampleLin
 import FwbListGroupExampleIcon from './listGroup/examples/FwbListGroupExampleIcon.vue'
 </script>
 
-# Vue List Group - Flowbite
+# List Group - Flowbite Vue
 
 #### Use the list group component to display a series of items, buttons or links inside a single element
 

--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -11,15 +11,18 @@ import FwbListGroupExampleIcon from './listGroup/examples/FwbListGroupExampleIco
 
 ---
 
-:::tip
+:::tip List Group - Flowbite
 Original reference: [https://flowbite.com/docs/components/list-group/](https://flowbite.com/docs/components/list-group/)
 :::
 
-The list group component can be used to display a series of elements, buttons or links inside a single card component similar to a sidebar.
+The list group component can be used to display a series of elements, buttons, or links inside a single card component — similar to a sidebar or menu.
 
-## Default
+## Default List Group
+
+Use `FwbListGroup` as a wrapper and place `FwbListGroupItem` elements inside it to render a basic bordered list.
 
 <fwb-list-group-example />
+
 ```vue
 <template>
   <fwb-list-group>
@@ -36,12 +39,12 @@ import { FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
 
-## Links
+## Link Items
 
-:::tip
-`href` prop is used for external links. `to` prop is used for internal links. `target` prop is used to set the target attribute for external links, the hover effect is automatically enabled.
-:::
+Use the `href` prop for external links or the `to` prop for Vue Router navigation. Items with either prop automatically receive hover styling. Use `target` to control the link target (e.g. `_blank`). Add the `active` prop to highlight the currently selected item.
+
 <fwb-list-group-example-link />
+
 ```vue
 <template>
   <fwb-list-group>
@@ -65,9 +68,12 @@ import { FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
 
-## Icon
+## Items with Icons
+
+Use the `prefix` slot to render an icon before the item label, or the `suffix` slot to render one after it.
 
 <fwb-list-group-example-icon />
+
 ```vue
 <template>
   <fwb-list-group>
@@ -111,9 +117,12 @@ import { FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
 
-## Disabled
+## Disabled Items
+
+Add the `disabled` prop to a `FwbListGroupItem` to apply muted styles and prevent interaction.
 
 <fwb-list-group-example-disabled />
+
 ```vue
 <template>
   <fwb-list-group>
@@ -156,3 +165,30 @@ import { FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 import { FwbListGroup, FwbListGroupItem } from 'flowbite-vue'
 </script>
 ```
+
+## List Group component API
+
+### FwbListGroup Slots
+
+| Name    | Description                                  |
+| ------- | -------------------------------------------- |
+| default | One or more `FwbListGroupItem` components.   |
+
+### FwbListGroupItem Props
+
+| Name     | Type              | Default  | Description                                                                         |
+| -------- | ----------------- | -------- | ----------------------------------------------------------------------------------- |
+| active   | `Boolean`         | `false`  | Highlights the item as the currently active entry.                                  |
+| disabled | `Boolean`         | `false`  | Applies muted styles and prevents interaction.                                      |
+| href     | `String`          | `null`   | Renders the item as an `<a>` and sets the `href` attribute.                         |
+| tag      | `String`          | `'li'`   | Override the root element tag (e.g. `'button'`, `'router-link'`, `'nuxt-link'`).   |
+| target   | `String`          | `'_self'` | Sets the `target` attribute when `href` is used.                                   |
+| to       | `String \| Object` | `null`  | Renders the item as a `<RouterLink>` and sets the `to` prop.                        |
+
+### FwbListGroupItem Slots
+
+| Name    | Description                                  |
+| ------- | -------------------------------------------- |
+| default | The item label content.                      |
+| prefix  | Icon or element rendered before the label.   |
+| suffix  | Icon or element rendered after the label.    |

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -13,17 +13,18 @@ import FwbModalExampleFocusTrap from './modal/examples/FwbModalExampleFocusTrap.
 
 ---
 
-:::tip
+:::tip Modal - Flowbite
 Original reference: [https://flowbite.com/docs/components/modal/](https://flowbite.com/docs/components/modal/)
 :::
 
-The modal component can be used as an interactive dialog on top of the main content area of the website to show notifications and gather information using form elements from your website users.
+The modal component can be used as an interactive dialog on top of the main content area to show notifications, confirmations, or gather input from your users. Use `v-if` to control visibility and listen to the `close` event to dismiss it.
 
-Get started with multiple sizes, colors, and styles built with the utility classes from Tailwind CSS and the components from Flowbite.
+## Default Modal
 
-## Default modal
+Use the `header`, `body`, and `footer` slots to compose the modal content. Wire up a reactive boolean and toggle it from a button to open and close the modal.
 
 <fwb-modal-example />
+
 ```vue
 <template>
   <fwb-button @click="showModal">
@@ -41,7 +42,7 @@ Get started with multiple sizes, colors, and styles built with the utility class
         With less than a month to go before the European Union enacts new consumer privacy laws for its citizens, companies around the world are updating their terms of service agreements to comply.
       </p>
       <p class="text-base leading-relaxed text-gray-500 dark:text-gray-400">
-        The European Union’s General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is meant to ensure a common set of data rights in the European Union. It requires organizations to notify users as soon as possible of high-risk data breaches that could personally affect them.
+        The European Union's General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is meant to ensure a common set of data rights in the European Union. It requires organizations to notify users as soon as possible of high-risk data breaches that could personally affect them.
       </p>
     </template>
     <template #footer>
@@ -74,13 +75,10 @@ function showModal () {
 
 ## Size
 
-You can use four different modal sizing options starting from small to extra large, but keep in mind that the width of these modals will remain the same when browsing on smaller devices.
-
-`xs`, `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`
-
-The default value is: `2xl`
+Use the `size` prop to control the maximum width of the modal. Available values are `xs`, `sm`, `md`, `lg`, `xl`, `2xl` (default), `3xl`, `4xl`, `5xl`, `6xl`, and `7xl`.
 
 <fwb-modal-example-size />
+
 ```vue
 <template>
   <fwb-modal size="xs" />
@@ -96,13 +94,10 @@ import { FwbModal } from 'flowbite-vue'
 
 ## Position
 
-The `position` prop allows you to control the placement of the modal on the screen, taking into account RTL (Right-to-Left) mode. You can choose from the following options:
-
-`top-start`, `top-center`, `top-end`, `center-start`, `center`, `center-end`, `bottom-start`, `bottom-center`, `bottom-end`
-
-The default value is: `center`
+Use the `position` prop to control where on the screen the modal appears. The default is `center`. Available positions are `top-start`, `top-center`, `top-end`, `center-start`, `center`, `center-end`, `bottom-start`, `bottom-center`, and `bottom-end`. RTL direction is handled automatically.
 
 <fwb-modal-example-position />
+
 ```vue
 <template>
   <fwb-modal position="top-start" />
@@ -123,17 +118,10 @@ import { FwbModal } from 'flowbite-vue'
 
 ## Escapable
 
-The escapable property is true by default to improve user experience and accessibility.
-
-This means that you may close the modal by
-
- - Using the close button on the modal
- - Clicking outside of the modal
- - Pressing the escape key
-
-In some situations, your user may be required to interact with the modal content. If this is the case, you can set the `not-escapable` property to `true`. The developer can then choose when they want to close the modal.
+By default the modal can be dismissed by clicking the close button, clicking outside the modal content, or pressing the `Escape` key. Set `not-escapable` to `true` to disable the outside-click and Escape key behaviours — the developer then controls when to close it programmatically.
 
 <fwb-modal-example-escapable />
+
 ```vue
 <template>
   <fwb-modal />
@@ -147,9 +135,10 @@ import { FwbModal } from 'flowbite-vue'
 
 ## Persistent
 
-Clicking outside of the element or pressing esc key will not send `close` event.
+Set `persistent` to `true` to prevent the `close` event from firing when the user clicks outside the modal or presses Escape. The close button is also hidden. Use this when the user must interact with the modal content before it can be dismissed.
 
 <fwb-modal-example-persistent />
+
 ```vue
 <template>
   <fwb-modal persistent />
@@ -162,9 +151,10 @@ import { FwbModal } from 'flowbite-vue'
 
 ## Focus Trap
 
-You can enable focus trapping by setting the `focus-trap` prop to `true`. This keeps the focus within the modal, preventing users from tabbing to elements outside of it, which improves accessibility. esc key will still close the modal.
+Set `focus-trap` to `true` to keep keyboard focus inside the modal while it is open, preventing users from tabbing to elements in the background. The `Escape` key still closes the modal unless `not-escapable` or `persistent` is set.
 
 <fwb-modal-example-focus-trap />
+
 ```vue
 <template>
   <fwb-modal />
@@ -176,28 +166,36 @@ import { FwbModal } from 'flowbite-vue'
 </script>
 ```
 
-## API
+## Modal component API
 
-### Props:
+### FwbModal Props
 
-| Name         | Values                                                                                                                      | Default  |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------- | -------- |
-| size         | `xs`, `sm`, `md`,`lg`, `xl`, `2xl`, `3xl`, `4xl`, `5xl`, `6xl`, `7xl`                                                       | `2xl`    |
-| position     | `top-start`, `top-center`, `top-end`, `center-start`, `center`, `center-end`, `bottom-start`, `bottom-center`, `bottom-end` | `center` |
-| notEscapable | `true`, `false`                                                                                                             | `false`  |
-| persistent   | `true`, `false`                                                                                                             | `false`  |
-| focusTrap    | `true`, `false`                                                                                                             | `false`  |
-| overlayClass | String \| Object                                                                                                            | `''`     |
-| layoutClass  | String \| Object                                                                                                            | `''`     |
-| wrapperClass | String \| Object                                                                                                            | `''`     |
-| headerClass  | String \| Object                                                                                                            | `''`     |
-| bodyClass    | String \| Object                                                                                                            | `''`     |
-| footerClass  | String \| Object                                                                                                            | `''`     |
+| Name         | Type                                                                                                                         | Default    | Description                                                                       |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------- |
+| bodyClass    | `String \| Object`                                                                                                           | `''`       | Additional classes applied to the body wrapper.                                   |
+| focusTrap    | `Boolean`                                                                                                                    | `false`    | Traps keyboard focus inside the modal while it is open.                           |
+| footerClass  | `String \| Object`                                                                                                           | `''`       | Additional classes applied to the footer wrapper.                                 |
+| headerClass  | `String \| Object`                                                                                                           | `''`       | Additional classes applied to the header wrapper.                                 |
+| layoutClass  | `String \| Object`                                                                                                           | `''`       | Additional classes applied to the layout positioning wrapper.                     |
+| notEscapable | `Boolean`                                                                                                                    | `false`    | Disables closing via outside click or Escape key (close button still shown).      |
+| overlayClass | `String \| Object`                                                                                                           | `''`       | Additional classes applied to the overlay backdrop element.                       |
+| persistent   | `Boolean`                                                                                                                    | `false`    | Hides the close button and prevents all passive dismiss behaviours.               |
+| position     | `'top-start' \| 'top-center' \| 'top-end' \| 'center-start' \| 'center' \| 'center-end' \| 'bottom-start' \| 'bottom-center' \| 'bottom-end'` | `'center'` | Controls where the modal is positioned on screen. |
+| size         | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl' \| '3xl' \| '4xl' \| '5xl' \| '6xl' \| '7xl'`                              | `'2xl'`    | Controls the maximum width of the modal panel.                                    |
+| wrapperClass | `String \| Object`                                                                                                           | `''`       | Additional classes applied to the modal panel wrapper.                            |
 
+### FwbModal Events
 
-### Events:
+| Name          | Description                                                                             |
+| ------------- | --------------------------------------------------------------------------------------- |
+| close         | Emitted when the close button is clicked, Escape is pressed, or the overlay is clicked. |
+| click:outside | Emitted when the user clicks outside the modal content area.                            |
 
-| Name            | Type                                                                             |
-| --------------- | -------------------------------------------------------------------------------- |
-| `close`         | Clicked on the close button, pressed `Esc`, or clicked outside the modal content |
-| `click:outside` | Clicked outside the modal content                                                |
+### FwbModal Slots
+
+| Name       | Description                                                                          |
+| ---------- | ------------------------------------------------------------------------------------ |
+| header     | Content rendered inside the modal header bar, next to the close button.              |
+| body       | Main content area of the modal.                                                      |
+| footer     | Content rendered inside the modal footer. The footer is hidden when this slot is empty. |
+| close-icon | Replaces the default X icon inside the close button.                                 |

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -7,7 +7,7 @@ import FwbModalExamplePosition from './modal/examples/FwbModalExamplePosition.vu
 import FwbModalExampleFocusTrap from './modal/examples/FwbModalExampleFocusTrap.vue'
 </script>
 
-# Vue Modal - Flowbite
+# Modal - Flowbite Vue
 
 #### Use the modal component to show interactive dialogs and notifications to your website users available in multiple sizes, colors, and styles
 

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -3,14 +3,26 @@ import FwbNavbarExample from './navbar/examples/FwbNavbarExample.vue'
 import FwbNavbarExampleSolid from './navbar/examples/FwbNavbarExampleSolid.vue'
 import FwbNavbarExampleActionButton from './navbar/examples/FwbNavbarExampleActionButton.vue'
 import FwbNavbarExampleCustomMobileIcon from './navbar/examples/FwbNavbarExampleCustomMobileIcon.vue'
-
 </script>
-# Navbar - Flowbite Vue
-The navbar component can be used to show a list of navigation links positioned on the top side of your page based on multiple layouts, sizes, and dropdowns
 
-## Default navbar
+# Navbar - Flowbite Vue
+
+#### Use the navbar component to show a list of navigation links positioned on the top side of your page based on multiple layouts, sizes, and dropdowns
+
+---
+
+:::tip Navbar - Flowbite
+Original reference: [https://flowbite.com/docs/components/navbar/](https://flowbite.com/docs/components/navbar/)
+:::
+
+The navbar component can be used to create a responsive navigation bar at the top of your page with support for a logo, navigation links, a collapsible mobile menu, and an optional call-to-action button.
+
+## Default Navbar
+
+Use `FwbNavbar` as the outer shell, `FwbNavbarLogo` in the `logo` slot, and `FwbNavbarLink` components inside `FwbNavbarCollapse` in the default slot. The default slot exposes `isShowMenu` to wire up the collapse visibility.
 
 <fwb-navbar-example />
+
 ```vue
 <template>
   <fwb-navbar>
@@ -48,9 +60,12 @@ import {
 </script>
 ```
 
-## Solid navbar
+## Solid Navbar
+
+Add the `solid` prop to switch from the default white navbar to a solid gray background with a dark mode variant.
 
 <fwb-navbar-example-solid />
+
 ```vue
 <template>
   <fwb-navbar solid>
@@ -88,9 +103,12 @@ import {
 </script>
 ```
 
-## Navbar with action button
+## Navbar with Action Button
+
+Use the `right-side` slot to place a button or any other element on the right side of the navbar, shown alongside the links on desktop and hidden on mobile.
 
 <fwb-navbar-example-action-button />
+
 ```vue
 <template>
   <fwb-navbar>
@@ -134,9 +152,12 @@ import {
 </script>
 ```
 
-## Navbar with custom mobile icon
+## Navbar with Custom Mobile Icon
+
+Use the `menu-icon` slot to replace the default hamburger icon on the mobile toggle button with any SVG or custom element.
 
 <fwb-navbar-example-custom-mobile-icon />
+
 ```vue
 <template>
   <fwb-navbar>
@@ -178,3 +199,73 @@ import {
 } from 'flowbite-vue'
 </script>
 ```
+
+## Navbar component API
+
+### FwbNavbar Props
+
+| Name    | Type      | Default | Description                                              |
+| ------- | --------- | ------- | -------------------------------------------------------- |
+| class   | `String`  | `''`    | Additional classes applied to the `<nav>` element.       |
+| rounded | `Boolean` | `false` | Adds a rounded style to the navbar container.            |
+| solid   | `Boolean` | `false` | Applies a solid gray background instead of white.        |
+| sticky  | `Boolean` | `false` | Fixes the navbar to the top of the viewport.             |
+
+### FwbNavbar Slots
+
+| Name       | Description                                                                        |
+| ---------- | ---------------------------------------------------------------------------------- |
+| default    | Navigation content. Exposes `{ isShowMenu: boolean }` for wiring up the collapse. |
+| logo       | Brand logo area, typically a `FwbNavbarLogo` component.                            |
+| menu-icon  | Replaces the default hamburger SVG in the mobile toggle button.                    |
+| right-side | Content rendered to the right of the nav links on desktop (e.g. a CTA button).    |
+
+### FwbNavbarCollapse Props
+
+| Name       | Type      | Default | Description                                                       |
+| ---------- | --------- | ------- | ----------------------------------------------------------------- |
+| isShowMenu | `Boolean` | `false` | Controls whether the mobile menu is expanded. Pass from `FwbNavbar`'s `isShowMenu` slot prop. |
+
+### FwbNavbarCollapse Slots
+
+| Name    | Description                           |
+| ------- | ------------------------------------- |
+| default | One or more `FwbNavbarLink` elements. |
+
+### FwbNavbarLink Props
+
+| Name      | Type      | Default  | Description                                              |
+| --------- | --------- | -------- | -------------------------------------------------------- |
+| component | `String`  | `'a'`    | Root element tag or component name (e.g. `'router-link'`). |
+| disabled  | `Boolean` | `false`  | Suppresses the `click` event when set.                   |
+| isActive  | `Boolean` | `false`  | Highlights the link as the current page.                 |
+| link      | `String`  | `'/'`    | The URL or route passed to the link element.             |
+| linkAttr  | `String`  | `'href'` | Attribute name used to pass `link` (e.g. `'to'` for router-link). |
+
+### FwbNavbarLink Events
+
+| Name  | Description                            |
+| ----- | -------------------------------------- |
+| click | Emitted when the link item is clicked. |
+
+### FwbNavbarLink Slots
+
+| Name    | Description        |
+| ------- | ------------------ |
+| default | The link label text. |
+
+### FwbNavbarLogo Props
+
+| Name      | Type     | Default             | Description                                                           |
+| --------- | -------- | ------------------- | --------------------------------------------------------------------- |
+| alt       | `String` | `'Logo'`            | Alt text for the logo image.                                          |
+| component | `String` | `'a'`               | Root element tag or component name.                                   |
+| imageUrl  | `String` | `'/assets/logo.svg'` | URL of the logo image.                                               |
+| link      | `String` | `'/'`               | The URL or route passed to the logo link.                             |
+| linkAttr  | `String` | `'href'`            | Attribute name used to pass `link` (e.g. `'to'` for router-link).    |
+
+### FwbNavbarLogo Slots
+
+| Name    | Description                                 |
+| ------- | ------------------------------------------- |
+| default | Brand name text displayed next to the logo. |

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -5,7 +5,7 @@ import FwbNavbarExampleActionButton from './navbar/examples/FwbNavbarExampleActi
 import FwbNavbarExampleCustomMobileIcon from './navbar/examples/FwbNavbarExampleCustomMobileIcon.vue'
 
 </script>
-# Vue Navbar – Flowbite
+# Navbar - Flowbite Vue
 The navbar component can be used to show a list of navigation links positioned on the top side of your page based on multiple layouts, sizes, and dropdowns
 
 ## Default navbar

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -11,7 +11,7 @@ import FwbPaginationExampleCustomLabels from './pagination/examples/FwbPaginatio
 import FwbPaginationExampleFirstLast from './pagination/examples/FwbPaginationExampleFirstLast.vue';
 </script>
 
-# Vue Pagination - Flowbite
+# Pagination - Flowbite Vue
 #### Use the Tailwind CSS pagination element to indicate a series of content across various pages based on multiple styles and sizes.
 The pagination component can be used to navigate across a series of content and data sets for various pages such as blog posts, products, and more. You can use multiple variants of this component with or without icons and even for paginating table data entries.
 

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -1,22 +1,31 @@
 <script setup>
-import FwbPaginationExample from './pagination/examples/FwbPaginationExample.vue';
-import FwbPaginationExampleIcons from './pagination/examples/FwbPaginationExampleIcons.vue';
-import FwbPaginationExampleNavigation from './pagination/examples/FwbPaginationExampleNavigation.vue';
-import FwbPaginationExampleNavigationIcons from './pagination/examples/FwbPaginationExampleNavigationIcons.vue';
-import FwbPaginationExampleSlots from './pagination/examples/FwbPaginationExampleSlots.vue';
-import FwbPaginationExampleSlotsAdvanced from './pagination/examples/FwbPaginationExampleSlotsAdvanced.vue';
-import FwbPaginationExampleTable from './pagination/examples/FwbPaginationExampleTable.vue';
-import FwbPaginationExampleCustomLength from './pagination/examples/FwbPaginationExampleCustomLength.vue';
-import FwbPaginationExampleCustomLabels from './pagination/examples/FwbPaginationExampleCustomLabels.vue';
-import FwbPaginationExampleFirstLast from './pagination/examples/FwbPaginationExampleFirstLast.vue';
+import FwbPaginationExample from './pagination/examples/FwbPaginationExample.vue'
+import FwbPaginationExampleIcons from './pagination/examples/FwbPaginationExampleIcons.vue'
+import FwbPaginationExampleNavigation from './pagination/examples/FwbPaginationExampleNavigation.vue'
+import FwbPaginationExampleNavigationIcons from './pagination/examples/FwbPaginationExampleNavigationIcons.vue'
+import FwbPaginationExampleSlots from './pagination/examples/FwbPaginationExampleSlots.vue'
+import FwbPaginationExampleSlotsAdvanced from './pagination/examples/FwbPaginationExampleSlotsAdvanced.vue'
+import FwbPaginationExampleTable from './pagination/examples/FwbPaginationExampleTable.vue'
+import FwbPaginationExampleCustomLength from './pagination/examples/FwbPaginationExampleCustomLength.vue'
+import FwbPaginationExampleCustomLabels from './pagination/examples/FwbPaginationExampleCustomLabels.vue'
+import FwbPaginationExampleFirstLast from './pagination/examples/FwbPaginationExampleFirstLast.vue'
 </script>
 
 # Pagination - Flowbite Vue
-#### Use the Tailwind CSS pagination element to indicate a series of content across various pages based on multiple styles and sizes.
-The pagination component can be used to navigate across a series of content and data sets for various pages such as blog posts, products, and more. You can use multiple variants of this component with or without icons and even for paginating table data entries.
 
-## Default pagination
-Use the following list of pagination items based on two sizes powered by Tailwind CSS utility classes to indicate a series of content for your website.
+#### Use the Tailwind CSS pagination element to indicate a series of content across various pages based on multiple styles and sizes
+
+---
+
+:::tip Pagination - Flowbite
+Original reference: [https://flowbite.com/docs/components/pagination/](https://flowbite.com/docs/components/pagination/)
+:::
+
+The pagination component can be used to navigate across a series of content and data sets for various pages such as blog posts, products, and more. Use `v-model` to bind the current page and supply either `total-pages` or `total-items` to drive the page count.
+
+## Default Pagination
+
+Use `FwbPagination` with `v-model` and `:total-items` (or `:total-pages`) to render a numbered page list. Add the `large` prop to increase the button height.
 
 <fwb-pagination-example />
 
@@ -41,8 +50,9 @@ const currentPage = ref(1)
 </script>
 ```
 
-## Pagination with icons
-The following pagination component example shows how you can use SVG icons instead of text to show the previous and next pages.
+## Pagination with Icons
+
+Add `show-icons` and `hide-labels` to render chevron SVGs in the previous/next buttons instead of text labels.
 
 <fwb-pagination-example-icons />
 
@@ -71,11 +81,12 @@ const currentPage = ref(1)
 </script>
 ```
 
-## Custom length pagination
-You can use your own pages count in the row by passing props: `slice-length`
-This prop means left side and right side pages row slicing. In the example it has value `4`. So row length will be `4 + 1 + 4 = 9` pages.
+## Custom Page Window
+
+Use `slice-length` to control how many page numbers are shown on each side of the current page. The total visible page count is `sliceLength + 1 + sliceLength`. The default value is `2`.
 
 <fwb-pagination-example-custom-length />
+
 ```vue
 <template>
   <fwb-pagination
@@ -93,9 +104,12 @@ const currentPage = ref(5)
 </script>
 ```
 
-## Previous and next
+## Previous and Next
+
+Set `layout="navigation"` to render only the previous and next navigation buttons without individual page numbers.
 
 <fwb-pagination-example-navigation />
+
 ```vue
 <template>
   <fwb-pagination
@@ -119,9 +133,12 @@ const currentPage = ref(1)
 </script>
 ```
 
-## Previous and next with icons
+## Previous and Next with Icons
+
+Combine `layout="navigation"` with `show-icons` to display chevron icons in the navigation buttons.
 
 <fwb-pagination-example-navigation-icons />
+
 ```vue
 <template>
   <fwb-pagination
@@ -147,9 +164,12 @@ const currentPage = ref(1)
 </script>
 ```
 
-## First and last
+## First and Last Buttons
+
+Add `enable-first-last` to render jump-to-first and jump-to-last buttons at the ends of the pagination strip. Combine with `show-icons` to display double-chevron SVGs.
 
 <fwb-pagination-example-first-last />
+
 ```vue
 <template>
   <fwb-pagination
@@ -180,16 +200,12 @@ const currentPage = ref(1)
 </script>
 ```
 
+## Table Data Pagination
 
-## Table data pagination
-You can use the following markup to show the number of data shown inside a table element and also the previous and next action buttons.
-To use that layout you have to pass required props:
-- `per-page`: it's items count displayed on each page.
-- `total-items`: it's the total items count.
-
-_And here you don't need to use `total-pages` prop._
+Set `layout="table"` to display a "Showing X to Y of Z" summary above the navigation buttons. Provide both `per-page` (items per page) and `total-items` (total record count) — `total-pages` is not needed with this layout.
 
 <fwb-pagination-example-table />
+
 ```vue
 <template>
   <fwb-pagination
@@ -216,10 +232,12 @@ const currentPageB = ref(1)
 </script>
 ```
 
+## Custom Labels
 
-## Pagination with custom labels
+Use `previous-label` and `next-label` (and `first-label` / `last-label` when `enable-first-last` is set) to replace the default button text.
 
 <fwb-pagination-example-custom-labels />
+
 ```vue
 <template>
   <fwb-pagination
@@ -238,8 +256,9 @@ const currentPage = ref(1)
 </script>
 ```
 
+## Custom Slots
 
-## Slots example
+Use the `prev-icon`, `next-icon`, and `page-button` slots to fully replace the default button rendering. The `page-button` slot exposes `{ page, setPage }` for wiring up click handlers.
 
 <fwb-pagination-example-slots />
 
@@ -269,7 +288,9 @@ const currentPage = ref(1)
 </script>
 ```
 
-## Advanced slots example
+## Advanced Slot Customization
+
+Replace every navigation button using the full set of scoped slots: `first-button`, `last-button`, `prev-button`, `next-button`, and `page-button`. Each slot exposes state and action helpers so you can render any custom element.
 
 <fwb-pagination-example-slots-advanced />
 
@@ -322,7 +343,7 @@ const currentPage = ref(1)
 
     <template #page-button="{ disabled, page, setPage }">
       <button
-        class="disabled:cursor-not-allowed ml-0 flex h-8 items-center justify-center border border-purple-300 px-3 leading-tight text-gray-500 first:rounded-l-lg last:rounded-r-lg  hover:text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
+        class="disabled:cursor-not-allowed ml-0 flex h-8 items-center justify-center border border-purple-300 px-3 leading-tight text-gray-500 first:rounded-l-lg last:rounded-r-lg hover:text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white"
         :class="{
           'bg-purple-200 hover:bg-purple-300': !disabled,
           'bg-purple-300': disabled
@@ -339,49 +360,52 @@ const currentPage = ref(1)
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-
-import { FwbPagination } from '../../../../src/index'
+import { FwbPagination } from 'flowbite-vue'
 
 const currentPage = ref<number>(1)
 </script>
-
 ```
 
-## API
+## Pagination component API
 
-### Props
-| Name            | Values                              | Default      |
-| --------------- | ----------------------------------- | ------------ |
-| modelValue      | `number`                            | `1`          |
-| totalPages      | `number`                            | `10`         |
-| perPage         | `number`                            | `10`         |
-| totalItems      | `number`                            | `10`         |
-| layout          | `pagination`, `table`, `navigation` | `pagination` |
-| showIcons       | `boolean`                           | `false`      |
-| sliceLength     | `number`                            | `2`          |
-| previousLabel   | `string`                            | `Previous`   |
-| nextLabel       | `string`                            | `Next`       |
-| enableFirstLast | `boolean`                           | `false`      |
-| hideLabels      | `boolean`                           | `false`      |
-| large           | `boolean`                           | `false`      |
+### FwbPagination Props
 
-### Events
-| Name                 | Description          |
-| -------------------- | -------------------- |
-| `update:model-value` | Current page changed |
-| `page-changed`       | Current page changed |
+| Name            | Type                                        | Default        | Description                                                                                 |
+| --------------- | ------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------- |
+| modelValue      | `Number`                                    | `1`            | The current page number (use with `v-model`).                                               |
+| totalPages      | `Number`                                    | `undefined`    | Total number of pages. Takes precedence over `totalItems` / `perPage` when set.             |
+| perPage         | `Number`                                    | `10`           | Number of items shown per page. Used with `totalItems` to compute total pages.              |
+| totalItems      | `Number`                                    | `10`           | Total number of items. Used with `perPage` to compute total pages.                          |
+| layout          | `'pagination' \| 'table' \| 'navigation'`  | `'pagination'` | Controls the pagination style shown.                                                        |
+| showIcons       | `Boolean`                                   | `false`        | Renders chevron SVG icons inside the previous/next (and first/last) buttons.                |
+| sliceLength     | `Number`                                    | `2`            | Number of page buttons shown on each side of the active page.                               |
+| previousLabel   | `String`                                    | `'Prev'`       | Label text for the previous button.                                                         |
+| nextLabel       | `String`                                    | `'Next'`       | Label text for the next button.                                                             |
+| firstLabel      | `String`                                    | `'First'`      | Label text for the first-page button (requires `enable-first-last`).                        |
+| lastLabel       | `String`                                    | `'Last'`       | Label text for the last-page button (requires `enable-first-last`).                         |
+| enableFirstLast | `Boolean`                                   | `false`        | Renders jump-to-first and jump-to-last buttons at the ends of the strip.                    |
+| hideLabels      | `Boolean`                                   | `false`        | Hides the text labels inside the previous/next buttons (useful when using icons only).      |
+| large           | `Boolean`                                   | `false`        | Increases the button height from `h-8` to `h-10`.                                          |
 
-### Slots
-| Name           | Description             |
-| -------------- | ----------------------- |
-| `start`        | content before buttons  |
-| `first-icon`   | first icon content      |
-| `first-button` | first button content    |
-| `prev-icon`    | previous icon content   |
-| `prev-button`  | previous button content |
-| `page-button`  | page button content     |
-| `next-button`  | next button content     |
-| `next-icon`    | next icon content       |
-| `last-button`  | last button content     |
-| `last-icon`    | last icon content       |
-| `end`          | content after buttons   |
+### FwbPagination Events
+
+| Name               | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| update:model-value | Emitted with the new page number when it changes.    |
+| page-changed       | Emitted with the new page number when it changes.    |
+
+### FwbPagination Slots
+
+| Name          | Scoped props                             | Description                                                          |
+| ------------- | ---------------------------------------- | -------------------------------------------------------------------- |
+| start         | —                                        | Content inserted before all buttons.                                 |
+| first-button  | `{ disabled, setPage }`                  | Replaces the jump-to-first button. Call `setPage()` to navigate.     |
+| first-icon    | —                                        | Replaces the default double-chevron inside the first button.         |
+| prev-button   | `{ disabled, decreasePage }`             | Replaces the previous button. Call `decreasePage()` to navigate.     |
+| prev-icon     | —                                        | Replaces the default chevron inside the previous button.             |
+| page-button   | `{ page, disabled, setPage }`            | Replaces each individual page button. Call `setPage(page)` to navigate. |
+| next-button   | `{ disabled, increasePage }`             | Replaces the next button. Call `increasePage()` to navigate.         |
+| next-icon     | —                                        | Replaces the default chevron inside the next button.                 |
+| last-button   | `{ page, disabled, setPage }`            | Replaces the jump-to-last button. `page` is the last page number.   |
+| last-icon     | —                                        | Replaces the default double-chevron inside the last button.          |
+| end           | —                                        | Content inserted after all buttons.                                  |

--- a/docs/components/paragraph.md
+++ b/docs/components/paragraph.md
@@ -3,7 +3,7 @@ import FwbPExample from './typography/p/FwbPExample.vue'
 import FwbPExampleCustom from './typography/p/FwbPExampleCustom.vue'
 </script>
 
-# Vue Paragraph - Flowbite
+# Paragraph - Flowbite Vue
 
 #### Use the paragraph component to create multiple blocks of text separated by blank lines and write content based on multiple layouts and styles
 

--- a/docs/components/paragraph.md
+++ b/docs/components/paragraph.md
@@ -7,71 +7,30 @@ import FwbPExampleCustom from './typography/p/FwbPExampleCustom.vue'
 
 #### Use the paragraph component to create multiple blocks of text separated by blank lines and write content based on multiple layouts and styles
 
-## Default paragraph
+---
 
-Use this example of a paragraph element to use inside article content or a landing page.
+:::tip Paragraph - Flowbite
+Original reference: [https://flowbite.com/docs/typography/paragraphs/](https://flowbite.com/docs/typography/paragraphs/)
+:::
 
-```vue
-<template>
-  <fwb-p>
-    Track work across the enterprise through an open, collaborative platform.
-    Link issues across Jira and ingest data from other software development
-    tools, so your IT support and operations teams have richer contextual
-    information to rapidly respond to requests, incidents, and changes.
-  </fwb-p>
-  <fwb-p>
-    Deliver great service experiences fast - without the complexityof
-    traditional ITSM solutions. Accelerate critical development work,
-    eliminate toil, and deploy changes with ease, with a complete
-    audit trail for every change.
-  </fwb-p>
-</template>
+The paragraph component can be used to create blocks of body text with Tailwind CSS utility classes, supporting custom font sizes, colors, line heights, and layout options.
 
-<script setup>
-import { FwbP } from 'flowbite-vue'
-</script>
-```
+## Default Paragraph
+
+Use `FwbP` to render a `<p>` element with consistent base typography — bottom margin, gray text, and normal line-height — styled for body content.
 
 <fwb-p-example />
 
-## Custom classes
-
-Use `class` attribute to apply the tailwind classes.
-
 ```vue
 <template>
-  <fwb-p class="font-light">
+  <fwb-p>
     Track work across the enterprise through an open, collaborative platform.
     Link issues across Jira and ingest data from other software development
     tools, so your IT support and operations teams have richer contextual
     information to rapidly respond to requests, incidents, and changes.
   </fwb-p>
-  <fwb-p class="font-bold">
-    Deliver great service experiences fast - without the complexityof
-    traditional ITSM solutions. Accelerate critical development work,
-    eliminate toil, and deploy changes with ease, with a complete
-    audit trail for every change.
-  </fwb-p>
-  <fwb-p  class="test-left">
-    Deliver great service experiences fast - without the complexityof
-    traditional ITSM solutions. Accelerate critical development work,
-    eliminate toil, and deploy changes with ease, with a complete
-    audit trail for every change.
-  </fwb-p>
-  <fwb-p class="test-center">
-    Deliver great service experiences fast - without the complexityof
-    traditional ITSM solutions. Accelerate critical development work,
-    eliminate toil, and deploy changes with ease, with a complete
-    audit trail for every change.
-  </fwb-p>
-  <fwb-p class="text-right">
-    Deliver great service experiences fast - without the complexityof
-    traditional ITSM solutions. Accelerate critical development work,
-    eliminate toil, and deploy changes with ease, with a complete
-    audit trail for every change.
-  </fwb-p>
-  <fwb-p class="text-green-600 dark:text-green-400 italic">
-    Deliver great service experiences fast - without the complexityof
+  <fwb-p>
+    Deliver great service experiences fast - without the complexity of
     traditional ITSM solutions. Accelerate critical development work,
     eliminate toil, and deploy changes with ease, with a complete
     audit trail for every change.
@@ -83,4 +42,37 @@ import { FwbP } from 'flowbite-vue'
 </script>
 ```
 
+## Custom Classes
+
+Use the `class` attribute to apply any Tailwind utility — font weight, alignment, color, style — directly to the paragraph element.
+
 <fwb-p-example-custom />
+
+```vue
+<template>
+  <fwb-p class="font-light">Light weight paragraph.</fwb-p>
+  <fwb-p class="font-bold">Bold paragraph.</fwb-p>
+  <fwb-p class="text-left">Left-aligned paragraph.</fwb-p>
+  <fwb-p class="text-center">Center-aligned paragraph.</fwb-p>
+  <fwb-p class="text-right">Right-aligned paragraph.</fwb-p>
+  <fwb-p class="italic text-green-600 dark:text-green-400">Italic green paragraph.</fwb-p>
+</template>
+
+<script setup>
+import { FwbP } from 'flowbite-vue'
+</script>
+```
+
+## Paragraph component API
+
+### FwbP Props
+
+| Name  | Type     | Default | Description                                                        |
+| ----- | -------- | ------- | ------------------------------------------------------------------ |
+| class | `String` | `''`    | Additional Tailwind classes merged onto the `<p>` element.         |
+
+### FwbP Slots
+
+| Name    | Description               |
+| ------- | ------------------------- |
+| default | The paragraph text content. |

--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -5,14 +5,26 @@ import FwbProgressExampleCustom from './progress/examples/FwbProgressExampleCust
 import FwbProgressExampleLabelInside from './progress/examples/FwbProgressExampleLabelInside.vue'
 import FwbProgressExampleLabelOutside from './progress/examples/FwbProgressExampleLabelOutside.vue'
 import FwbProgressExampleSize from './progress/examples/FwbProgressExampleSize.vue'
-
-
 </script>
+
 # Progress Bar - Flowbite Vue
 
-## Default
+#### Use the progress bar component to show the completion status of a task or process based on Tailwind CSS utility classes
+
+---
+
+:::tip Progress Bar - Flowbite
+Original reference: [https://flowbite.com/docs/components/progress/](https://flowbite.com/docs/components/progress/)
+:::
+
+The progress bar component can be used to show the completion percentage of a task or process, with support for custom colors, sizes, and both inside and outside label variants styled with Tailwind CSS utility classes.
+
+## Default Progress Bar
+
+Use `FwbProgress` with the `progress` prop (0–100) to render a basic horizontal progress bar.
 
 <fwb-progress-example />
+
 ```vue
 <template>
   <fwb-progress :progress="45" />
@@ -24,9 +36,11 @@ import { FwbProgress } from 'flowbite-vue'
 ```
 
 ## Sizes
-You can also use different sizes by using various sizing.
+
+Use the `size` prop to control the height of the progress bar track. Available sizes are `sm`, `md` (default), `lg`, and `xl`. Combine with `label` to show a description above the bar.
 
 <fwb-progress-example-size />
+
 ```vue
 <template>
   <div class="grid gap-2">
@@ -42,10 +56,12 @@ import { FwbProgress } from 'flowbite-vue'
 </script>
 ```
 
-## With label inside
-Here is an example of using a progress bar with the label inside the bar.
+## Label Inside
+
+Set `label-position="inside"` and `label-progress` to render the percentage value inside the progress bar. Use `size="lg"` or larger to ensure there is enough space for the label.
 
 <fwb-progress-example-label-inside />
+
 ```vue
 <template>
   <fwb-progress
@@ -61,10 +77,12 @@ import { FwbProgress } from 'flowbite-vue'
 </script>
 ```
 
-## With label outside
-And this is an example of using a progress bar outside the bar.
+## Label Outside
+
+Set `label-position="outside"` and `label-progress` to render the percentage value to the right of the label text above the bar. Use `label` to set the descriptive text on the left.
 
 <fwb-progress-example-label-outside />
+
 ```vue
 <template>
   <fwb-progress
@@ -81,20 +99,22 @@ import { FwbProgress } from 'flowbite-vue'
 ```
 
 ## Colors
-You can also apply color.
+
+Use the `color` prop to change the fill color of the progress bar. Available values are `default`, `dark`, `blue`, `red`, `green`, `yellow`, `indigo`, and `purple`.
 
 <fwb-progress-example-color />
+
 ```vue
 <template>
   <div class="grid gap-2">
-    <fwb-progress :progress="12.5" label="Default"  />
-    <fwb-progress :progress="25" color="dark" label="Dark"  />
-    <fwb-progress :progress="37.5" color="blue" label="Blue"  />
-    <fwb-progress :progress="50" color="red" label="Red"  />
-    <fwb-progress :progress="62.5" color="green" label="Green"  />
-    <fwb-progress :progress="75" color="yellow" label="Yellow"  />
-    <fwb-progress :progress="87.5" color="indigo" label="Indigo"  />
-    <fwb-progress :progress="100" color="purple" label="Purple"  />
+    <fwb-progress :progress="12.5" label="Default" />
+    <fwb-progress :progress="25" color="dark" label="Dark" />
+    <fwb-progress :progress="37.5" color="blue" label="Blue" />
+    <fwb-progress :progress="50" color="red" label="Red" />
+    <fwb-progress :progress="62.5" color="green" label="Green" />
+    <fwb-progress :progress="75" color="yellow" label="Yellow" />
+    <fwb-progress :progress="87.5" color="indigo" label="Indigo" />
+    <fwb-progress :progress="100" color="purple" label="Purple" />
   </div>
 </template>
 
@@ -103,18 +123,12 @@ import { FwbProgress } from 'flowbite-vue'
 </script>
 ```
 
-## Custom
-You can fully customize the appearance of the progress bar using TailwindCSS utility classes via the following props:
+## Custom Styling
 
-| Prop                  | Description                                                      |
-|-----------------------|------------------------------------------------------------------|
-| `inner-classes`       | Custom classes for the inner progress bar                        |
-| `outer-classes`       | Custom classes for the outer progress bar container              |
-| `outside-label-classes` | Custom classes for the label outside the progress bar        |
-
-These props allow you to override or extend the default styling for each part of the component, enabling advanced use cases such as gradients, custom colors, rounded corners, and more.
+Use `inner-classes`, `outer-classes`, and `outside-label-classes` to override any part of the progress bar's default styling with your own Tailwind utilities.
 
 <fwb-progress-example-custom />
+
 ```vue
 <template>
   <fwb-progress
@@ -130,3 +144,19 @@ These props allow you to override or extend the default styling for each part of
 import { FwbProgress } from 'flowbite-vue'
 </script>
 ```
+
+## Progress Bar component API
+
+### FwbProgress Props
+
+| Name               | Type                                                              | Default     | Description                                                                         |
+| ------------------ | ----------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------- |
+| color              | `'default' \| 'dark' \| 'blue' \| 'red' \| 'green' \| 'yellow' \| 'indigo' \| 'purple'` | `'default'` | Fill color of the inner progress bar.     |
+| innerClasses       | `String \| Object`                                                | `''`        | Overrides or extends classes on the inner progress bar element.                     |
+| label              | `String`                                                          | `''`        | Descriptive text rendered above the bar on the left side.                           |
+| labelPosition      | `'none' \| 'inside' \| 'outside'`                                | `'none'`    | Controls where the percentage value is rendered relative to the bar.                |
+| labelProgress      | `Boolean`                                                         | `false`     | When `true`, renders the `progress` percentage next to or inside the bar.           |
+| outerClasses       | `String \| Object`                                                | `''`        | Overrides or extends classes on the outer progress track element.                   |
+| outsideLabelClasses | `String \| Object`                                               | `''`        | Overrides or extends classes on the label/percentage text rendered outside the bar. |
+| progress           | `Number`                                                          | `0`         | The current completion value (0–100).                                               |
+| size               | `'sm' \| 'md' \| 'lg' \| 'xl'`                                   | `'md'`      | Controls the height of the progress bar track.                                      |

--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -8,7 +8,7 @@ import FwbProgressExampleSize from './progress/examples/FwbProgressExampleSize.v
 
 
 </script>
-# Vue Progress Bar - Flowbite
+# Progress Bar - Flowbite Vue
 
 ## Default
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -16,15 +16,15 @@ import FwbRadioExampleValidation from './radio/examples/FwbRadioExampleValidatio
 
 #### Get started with the radio component to let the user choose a single option from multiple options in the form of a circle based on multiple styles and colors
 
-The radio component can be used to allow the user to choose a single option from one or more available options coded with the utility classes from Tailwind CSS and available in multiple styles, variants, and colors and support dark mode.
-
 ---
 
-:::tip
+:::tip Radio - Flowbite
 Original reference: [https://flowbite.com/docs/forms/radio/](https://flowbite.com/docs/forms/radio/)
 :::
 
-## Default radio
+The radio component can be used to allow the user to choose a single option from one or more available options coded with the utility classes from Tailwind CSS and available in multiple styles, variants, and colors and support dark mode.
+
+## Default Radio
 
 Use `FwbRadio` with `v-model` and a `value` prop to let the user select a single option. Pass `name` directly on each radio when used standalone, or use `FwbRadioGroup` to share it automatically across child radios.
 
@@ -44,7 +44,7 @@ const picked = ref()
 
 ```
 
-## Disabled state
+## Disabled State
 
 Set the `disabled` prop to prevent the user from selecting the radio. Disabled styling is applied automatically to both the input and the label text.
 
@@ -63,7 +63,7 @@ const picked = ref('two')
 </script>
 ```
 
-## Radio group
+## Radio Group
 
 Use `FwbRadioGroup` to wrap related radio buttons. The `name` prop on the group is shared across all child radios automatically, so you don't need to repeat it on each one.
 
@@ -96,7 +96,7 @@ const picked = ref('banana')
 </script>
 ```
 
-## Inline radio
+## Inline Radio
 
 Place multiple `FwbRadio` components inside a flex wrapper to lay them out horizontally side by side.
 
@@ -120,7 +120,7 @@ const picked = ref('first')
 
 ```
 
-## Radio with a link
+## Radio with a Link
 
 Use the default slot instead of the `label` prop when the label contains rich content such as links.
 
@@ -142,7 +142,7 @@ const picked = ref()
 
 ```
 
-## Radio list group
+## Radio List Group
 
 Use `FwbListGroup` and `FwbListGroupItem` to display radio buttons inside a vertical grouped list.
 
@@ -178,7 +178,7 @@ const picked = ref('Vue JS')
 
 ```
 
-## Horizontal list group
+## Horizontal List Group
 
 Nest `FwbRadio` components inside a horizontal `<ul>` to create a full-width inline list selection.
 
@@ -352,7 +352,7 @@ const picked = ref('a')
 
 ```
 
-## FwbRadio component API
+## Radio component API
 
 ### FwbRadio Props
 
@@ -381,7 +381,7 @@ When a `FwbRadio` is inside a `FwbRadioGroup` with `validationStatus="error"`, `
 | ------- | --------------------------------------------------------------------------------- |
 | default | Rich label content rendered next to the radio (takes priority over `label` prop). |
 
-## FwbRadioGroup component API
+## RadioGroup component API
 
 ### FwbRadioGroup Props
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -12,7 +12,7 @@ import FwbRadioExampleStyling from './radio/examples/FwbRadioExampleStyling.vue'
 import FwbRadioExampleValidation from './radio/examples/FwbRadioExampleValidation.vue'
 </script>
 
-# Vue Radio - Flowbite
+# Radio - Flowbite Vue
 
 #### Get started with the radio component to let the user choose a single option from multiple options in the form of a circle based on multiple styles and colors
 

--- a/docs/components/range.md
+++ b/docs/components/range.md
@@ -15,11 +15,15 @@ import FwbRangeExampleValidation from './range/examples/FwbRangeExampleValidatio
 
 ---
 
-:::tip
+:::tip Range - Flowbite
 Original reference: [https://flowbite.com/docs/forms/range/](https://flowbite.com/docs/forms/range/)
 :::
 
+The range component can be used to let the user select a numeric value by dragging a slider handle. It supports custom min/max bounds, step increments, sizes, validation feedback, and helper text, all styled with Tailwind CSS utility classes.
+
 ## Default
+
+Use `FwbRange` with `v-model.number` to bind a numeric value to the slider.
 
 <fwb-range-example />
 ```vue
@@ -37,7 +41,9 @@ const value = ref(50)
 
 ```
 
-## Disabled state
+## Disabled State
+
+Set the `disabled` prop to prevent interaction with the slider.
 
 <fwb-range-example-disabled />
 ```vue
@@ -51,6 +57,8 @@ const value = ref(50)
 ```
 
 ## Min and Max
+
+Use the `min` and `max` props to constrain the range of values the slider can return.
 
 <fwb-range-example-min-max />
 ```vue
@@ -66,6 +74,8 @@ const value = ref(50)
 
 ## Steps
 
+Use the `steps` prop to set the increment between each selectable value on the slider track.
+
 <fwb-range-example-steps />
 ```vue
 <template>
@@ -78,6 +88,8 @@ const value = ref(50)
 ```
 
 ## Sizes
+
+Use the `size` prop to control the height of the slider track and thumb. Available sizes are `sm`, `md` (default), `lg`, and `xl`.
 
 <fwb-range-example-size />
 ```vue
@@ -109,7 +121,7 @@ Use `validationStatus` together with the `validationMessage` slot to show succes
 </template>
 ```
 
-## Helper text
+## Helper Text
 
 Use the `helper` slot to show a hint below the range input.
 

--- a/docs/components/range.md
+++ b/docs/components/range.md
@@ -9,7 +9,7 @@ import FwbRangeExampleStyling from './range/examples/FwbRangeExampleStyling.vue'
 import FwbRangeExampleValidation from './range/examples/FwbRangeExampleValidation.vue'
 </script>
 
-# Vue Range - Flowbite
+# Range - Flowbite Vue
 
 #### Get started with the range component to receive a number from the user anywhere from 1 to 100 by sliding form control horizontally based on multiple options
 

--- a/docs/components/rating.md
+++ b/docs/components/rating.md
@@ -4,7 +4,7 @@ import FwbRatingExampleWithText from './rating/examples/FwbRatingExampleWithText
 import FwbRatingExampleCount from './rating/examples/FwbRatingExampleCount.vue'
 import FwbRatingExampleStarSizes from './rating/examples/FwbRatingExampleStarSizes.vue'
 </script>
-# Vue Rating - Flowbite
+# Rating - Flowbite Vue
 
 ## Default rating
 Use this simple example of a star rating component for showing review results.

--- a/docs/components/rating.md
+++ b/docs/components/rating.md
@@ -4,10 +4,22 @@ import FwbRatingExampleWithText from './rating/examples/FwbRatingExampleWithText
 import FwbRatingExampleCount from './rating/examples/FwbRatingExampleCount.vue'
 import FwbRatingExampleStarSizes from './rating/examples/FwbRatingExampleStarSizes.vue'
 </script>
+
 # Rating - Flowbite Vue
 
-## Default rating
-Use this simple example of a star rating component for showing review results.
+#### Use the rating component to show star-based review scores and testimonials from your users based on Tailwind CSS utility classes
+
+---
+
+:::tip Rating - Flowbite
+Original reference: [https://flowbite.com/docs/components/rating/](https://flowbite.com/docs/components/rating/)
+:::
+
+The rating component can be used to show star-based review scores with support for partial ratings, review counts, and multiple star sizes.
+
+## Default Rating
+
+Use the `rating` prop to set how many stars are filled out of the `scale` (default 5). Fractional values render partial stars.
 
 <fwb-rating-example />
 ```vue
@@ -20,8 +32,9 @@ import { FwbRating } from 'flowbite-vue'
 </script>
 ```
 
-## Rating with text
-If you also want to show a text near the stars you can use this example as a reference.
+## Rating with Text
+
+Use the `besideText` slot to render additional content — such as a score label — next to the star row.
 
 <fwb-rating-example-with-text />
 ```vue
@@ -40,8 +53,9 @@ import { FwbRating } from 'flowbite-vue'
 </script>
 ```
 
-## Rating count
-Aggregate more results by using this example to show the amount of reviews and the average score.
+## Rating Count
+
+Combine the `besideText` slot with `reviewLink` and `reviewText` to display a linked review count alongside the stars.
 
 <fwb-rating-example-count />
 ```vue
@@ -65,8 +79,9 @@ import { FwbRating } from 'flowbite-vue'
 </script>
 ```
 
-## Star sizes
-Check out the different sizing options for the star review component from small, medium, and large.
+## Star Sizes
+
+Use the `size` prop to control the star dimensions. Available sizes are `sm`, `md` (default), and `lg`.
 
 <fwb-rating-example-star-sizes />
 ```vue
@@ -80,3 +95,21 @@ Check out the different sizing options for the star review component from small,
 import { FwbRating } from 'flowbite-vue'
 </script>
 ```
+
+## Rating component API
+
+### FwbRating Props
+
+| Name       | Type                    | Default | Description                                                                 |
+| ---------- | ----------------------- | ------- | --------------------------------------------------------------------------- |
+| rating     | `Number`                | `3`     | The score to display. Fractional values render partial stars.               |
+| reviewLink | `String`                | `''`    | URL applied to the review count text. Renders an `<a>` when set.           |
+| reviewText | `String`                | `''`    | Text displayed as the review count label next to the stars.                 |
+| scale      | `Number`                | `5`     | Total number of stars (the full-score denominator).                         |
+| size       | `'sm' \| 'md' \| 'lg'` | `'md'`  | Controls the size of each star icon.                                        |
+
+### FwbRating Slots
+
+| Name       | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| besideText | Content rendered next to the stars (e.g. a score label or review summary).  |

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -16,13 +16,15 @@ import FwbSelectExampleValidation from './select/examples/FwbSelectExampleValida
 
 ---
 
-:::tip
+:::tip Select - Flowbite
 Original reference: [https://flowbite.com/docs/forms/select/](https://flowbite.com/docs/forms/select/)
 :::
 
 The select input component can be used to gather information from users based on multiple options in the form of a dropdown list and by browsing this page you will find multiple options, styles, sizes, and variants built with the utility classes from Tailwind CSS also available in dark mode.
 
 ## Default
+
+Use `FwbSelect` with `v-model`, an `options` array of `{ value, name }` objects, and a `label` to render a styled native select input.
 
 <fwb-select-example />
 
@@ -80,6 +82,8 @@ const countries = [
 
 ## Sizes
 
+Use the `size` prop to control the padding and font size of the select. Available sizes are `sm`, `md` (default), `lg`, and `xl`.
+
 <fwb-select-example-size />
 ```vue
 <template>
@@ -125,6 +129,8 @@ const countries = [
 
 ## Disabled
 
+Set the `disabled` prop to prevent the user from interacting with the select. A custom `placeholder` can be provided to communicate the restriction.
+
 <fwb-select-example-disabled />
 ```vue
 <template>
@@ -152,6 +158,8 @@ const countries = [
 ```
 
 ## Underlined
+
+Add the `underline` prop to switch to a borderless style with only a bottom border, following the Flowbite underline variant.
 
 <fwb-select-example-underlined />
 ```vue
@@ -224,6 +232,8 @@ const countries = [
 ```
 
 ## Slot - Helper
+
+Use the `helper` slot to render supplementary text below the select — such as a privacy notice or contextual hint.
 
 <fwb-select-example-helper />
 ```vue

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -564,14 +564,14 @@ Use `FwbSidebarCta` to add a call-to-action banner inside the sidebar. Set a `la
 
 ## Logo Branding
 
-Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name. Use the `tag` prop to render it as a `router-link` when using Vue Router.
+Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name. Pass a URL to the `link` prop to make it a clickable anchor, or set `tag="router-link"` (and a route object to `link`) when using Vue Router.
 
 <FwbSidebarLogoExample />
 
 ```vue
 <template>
   <fwb-sidebar>
-    <fwb-sidebar-logo name="Flowbite" logo="https://flowbite.com/docs/images/logo.svg" tag="router-link" />
+    <fwb-sidebar-logo name="Flowbite" logo="https://flowbite.com/docs/images/logo.svg" link="https://flowbite.com" />
     <fwb-sidebar-item>
       <template #icon>
         <svg

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -711,7 +711,7 @@ Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name.
 
 | Name | Type                    | Default | Description                                               |
 | ---- | ----------------------- | ------- | --------------------------------------------------------- |
-| link | `String \| Object`      | `'/'`   | The URL or route object passed to the link element.       |
+| link | `String \| Record<string, unknown>` | `'/'` | The URL or route object passed to the link element. |
 | tag  | `String`                | `'a'`   | Root element tag or component name (e.g. `'router-link'`). |
 
 ### FwbSidebarItem Slots

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -5,7 +5,7 @@ import FwbSidebarGroupExample from './sidebar/examples/FwbSidebarGroupExample.vu
 import FwbSidebarCtaExample from './sidebar/examples/FwbSidebarCtaExample.vue'
 import FwbSidebarLogoExample from './sidebar/examples/FwbSidebarLogoExample.vue'
 </script>
-# Vue Sidebar - Flowbite
+# Sidebar - Flowbite Vue
 #### Use the sidebar component to show a list of menu items and multi-level menu items on either side of the page to navigate on your website
 The sidebar component can be used as a complementary element relative to the navbar shown on either the left or right side of the page used for the navigation on your web application, including menu items, multi-level menu items, call to actions elements, and more.
 

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -5,12 +5,22 @@ import FwbSidebarGroupExample from './sidebar/examples/FwbSidebarGroupExample.vu
 import FwbSidebarCtaExample from './sidebar/examples/FwbSidebarCtaExample.vue'
 import FwbSidebarLogoExample from './sidebar/examples/FwbSidebarLogoExample.vue'
 </script>
-# Sidebar - Flowbite Vue
-#### Use the sidebar component to show a list of menu items and multi-level menu items on either side of the page to navigate on your website
-The sidebar component can be used as a complementary element relative to the navbar shown on either the left or right side of the page used for the navigation on your web application, including menu items, multi-level menu items, call to actions elements, and more.
 
-## Default sidebar
-Use this example to show a responsive list of menu items inside the sidebar with icons and labels.
+# Sidebar - Flowbite Vue
+
+#### Use the sidebar component to show a list of menu items and multi-level menu items on either side of the page to navigate on your website
+
+---
+
+:::tip Sidebar - Flowbite
+Original reference: [https://flowbite.com/docs/components/sidebar/](https://flowbite.com/docs/components/sidebar/)
+:::
+
+The sidebar component can be used as a complementary element relative to the navbar shown on either the left or right side of the page used for the navigation on your web application, including menu items, multi-level menu items, call to action elements, and more.
+
+## Default Sidebar
+
+Use `FwbSidebar` as the outer shell and nest `FwbSidebarItem` components inside it. Each item supports an `icon` slot, a `suffix` slot for badges, and a `link` prop for navigation.
 
 <FwbSidebarExample />
 
@@ -144,8 +154,9 @@ import { FwbSidebar, FwbSidebarItem } from 'flowbite-vue'
 
 ```
 
-## Multi-level menu
-Use this sidebar example to create multi-level menu items by using the FwbSidebarDropdownItem component.
+## Multi-Level Menu
+
+Use `FwbSidebarDropdownItem` to create an expandable nested menu. The `trigger` slot sets the parent label and the default slot contains the child `FwbSidebarItem` entries.
 
 <FwbSidebarDropdownExample />
 
@@ -213,7 +224,9 @@ Use this sidebar example to create multi-level menu items by using the FwbSideba
 </script>
 ```
 
-## Content separator
+## Content Separator
+
+Wrap a set of `FwbSidebarItem` components in `FwbSidebarItemGroup` and add `border` to render a top border that visually separates groups of items.
 
 <FwbSidebarGroupExample />
 
@@ -409,7 +422,9 @@ Use this sidebar example to create multi-level menu items by using the FwbSideba
 </script>
 ```
 
-## CTA button
+## CTA Button
+
+Use `FwbSidebarCta` to add a call-to-action banner inside the sidebar. Set a `label` badge text and handle the `close` event to dismiss it.
 
 <FwbSidebarCtaExample />
 
@@ -547,7 +562,9 @@ Use this sidebar example to create multi-level menu items by using the FwbSideba
 </script>
 ```
 
-## Logo branding
+## Logo Branding
+
+Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name. Use the `tag` prop to render it as a `router-link` when using Vue Router.
 
 <FwbSidebarLogoExample />
 
@@ -682,81 +699,75 @@ Use this sidebar example to create multi-level menu items by using the FwbSideba
 ```
 
 
-## API
+## Sidebar component API
 
-### Sidebar component 
+### FwbSidebar Slots
 
-#### Slots
-| Name    | Description     |
-|---------|-----------------|
-| default | Sidebar content |
+| Name    | Description                                              |
+| ------- | -------------------------------------------------------- |
+| default | Sidebar content — one or more `FwbSidebarItem` elements. |
 
+### FwbSidebarItem Props
 
-### SidebarCta component
+| Name | Type                    | Default | Description                                               |
+| ---- | ----------------------- | ------- | --------------------------------------------------------- |
+| link | `String \| Object`      | `'/'`   | The URL or route object passed to the link element.       |
+| tag  | `String`                | `'a'`   | Root element tag or component name (e.g. `'router-link'`). |
 
-#### Slots
-| Name    | Description     |
-|---------|-----------------|
-| default | Sidebar content |
+### FwbSidebarItem Slots
 
-#### Props
-| Name  | type     |
-|-------|----------|
-| label | `string` |
+| Name    | Description                                           |
+| ------- | ----------------------------------------------------- |
+| default | The item label text.                                  |
+| icon    | Icon rendered to the left of the item label.          |
+| suffix  | Content rendered to the right of the label (e.g. a badge). |
 
-#### Events
-| Name  | Description          |
-|-------|----------------------|
-| close | close button clicked |
+### FwbSidebarDropdownItem Slots
 
-### SidebarDropdownItem component
+| Name       | Description                                                      |
+| ---------- | ---------------------------------------------------------------- |
+| default    | Child `FwbSidebarItem` elements shown when the dropdown expands. |
+| icon       | Icon rendered to the left of the trigger label.                  |
+| trigger    | The parent item label text that toggles the dropdown.            |
+| arrow-icon | Replaces the default chevron arrow inside the trigger.           |
 
-#### Slots
-| Name       | Description              |
-|------------|--------------------------|
-| default    | Dropdown content         |
-| icon       | Dropdown item icon       |
-| trigger    | Dropdown text            |
-| arrow-icon | Dropdown item arrow icon |
+### FwbSidebarItemGroup Props
 
+| Name   | Type      | Default | Description                                               |
+| ------ | --------- | ------- | --------------------------------------------------------- |
+| border | `Boolean` | `false` | Adds a top border to visually separate this group.        |
 
-### SidebarItem
+### FwbSidebarItemGroup Slots
 
-#### Slots
-| Name    | Description     |
-|---------|-----------------|
-| default | Sidebar content |
-| icon    | Item icon       |
-| suffix  | suffix content  |
+| Name    | Description                                    |
+| ------- | ---------------------------------------------- |
+| default | One or more `FwbSidebarItem` elements to group. |
 
-#### Props
-| Name | type     | default     |
-|------|----------|-------------|
-| link | `string` | /           |
-| tag  | `string` | router-link |
+### FwbSidebarCta Props
 
+| Name  | Type     | Default     | Description                                          |
+| ----- | -------- | ----------- | ---------------------------------------------------- |
+| label | `String` | `undefined` | Badge text displayed in the top-right of the banner. |
 
-### SidebarItemGroup
+### FwbSidebarCta Events
 
-#### Slots
-| Name    | Description   |
-|---------|---------------|
-| default | Group content |
+| Name  | Description                               |
+| ----- | ----------------------------------------- |
+| close | Emitted when the dismiss button is clicked. |
 
+### FwbSidebarCta Slots
 
-#### Props
-| Name   | type      | default |
-|--------|-----------|---------|
-| border | `boolean` | `false` |
+| Name    | Description                           |
+| ------- | ------------------------------------- |
+| default | The CTA banner content.               |
 
+### FwbSidebarLogo Props
 
-### SidebarLogo
-
-#### Props
-| Name | type     | default       |
-|------|----------|---------------|
-| name | `string` |               |
-| link | `string` | `/`           |
-| logo | `string` |               |
-| tag  | `string` | `router-link` |
+| Name | Type     | Default     | Description                                                        |
+| ---- | -------- | ----------- | ------------------------------------------------------------------ |
+| alt  | `String` | `undefined` | Alt text for the logo image.                                       |
+| link | `String` | `'/'`       | The URL or route passed to the logo link.                          |
+| logo | `String` | `undefined` | URL of the logo image.                                             |
+| name | `String` | `undefined` | Brand name text displayed next to the logo image.                  |
+| tag  | `String` | `'a'`       | Root element tag or component name (e.g. `'router-link'`).         |
 

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -766,8 +766,8 @@ Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name.
 | Name | Type     | Default     | Description                                                        |
 | ---- | -------- | ----------- | ------------------------------------------------------------------ |
 | alt  | `String` | `undefined` | Alt text for the logo image.                                       |
-| link | `String \| Object` | `'/'`  | The URL or route object passed to the logo link.                   |
-| logo | `String` | `undefined` | URL of the logo image.                                             |
-| name | `String` | `undefined` | Brand name text displayed next to the logo image.                  |
+| link | `String \| Record<string, unknown>` | `'/'` | The URL or route object (e.g. `{ name: 'home', params: {} }`) passed to the logo link. |
+| logo | `String` | `''`        | URL of the logo image.                                             |
+| name | `String` | `''`        | Brand name text displayed next to the logo image.                  |
 | tag  | `String` | `'a'`       | Root element tag or component name (e.g. `'router-link'`).         |
 

--- a/docs/components/sidebar.md
+++ b/docs/components/sidebar.md
@@ -705,7 +705,7 @@ Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name.
 
 | Name    | Description                                              |
 | ------- | -------------------------------------------------------- |
-| default | Sidebar content — one or more `FwbSidebarItem` elements. |
+| default | Sidebar content — accepts `FwbSidebarLogo`, `FwbSidebarItem`, `FwbSidebarDropdownItem`, `FwbSidebarItemGroup`, and `FwbSidebarCta` elements. |
 
 ### FwbSidebarItem Props
 
@@ -766,7 +766,7 @@ Add `FwbSidebarLogo` at the top of the sidebar to display a brand logo and name.
 | Name | Type     | Default     | Description                                                        |
 | ---- | -------- | ----------- | ------------------------------------------------------------------ |
 | alt  | `String` | `undefined` | Alt text for the logo image.                                       |
-| link | `String` | `'/'`       | The URL or route passed to the logo link.                          |
+| link | `String \| Object` | `'/'`  | The URL or route object passed to the logo link.                   |
 | logo | `String` | `undefined` | URL of the logo image.                                             |
 | name | `String` | `undefined` | Brand name text displayed next to the logo image.                  |
 | tag  | `String` | `'a'`       | Root element tag or component name (e.g. `'router-link'`).         |

--- a/docs/components/sidebar/examples/FwbSidebarLogoExample.vue
+++ b/docs/components/sidebar/examples/FwbSidebarLogoExample.vue
@@ -4,7 +4,7 @@
       <fwb-sidebar-logo
         name="Flowbite"
         logo="https://flowbite.com/docs/images/logo.svg"
-        tag="router-link"
+        link="https://flowbite.com"
       />
       <fwb-sidebar-item>
         <template #icon>

--- a/docs/components/spinner.md
+++ b/docs/components/spinner.md
@@ -4,7 +4,7 @@ import FwbSpinnerExampleColor from './spinner/examples/FwbSpinnerExampleColor.vu
 import FwbSpinnerExampleSize from './spinner/examples/FwbSpinnerExampleSize.vue'
 </script>
 
-# Vue Spinner - Flowbite
+# Spinner - Flowbite Vue
 
 #### Use the spinner component as a loader indicator in your projects when fetching data based on an animated SVG using the utility classes from Tailwind CSS
 

--- a/docs/components/spinner.md
+++ b/docs/components/spinner.md
@@ -10,13 +10,15 @@ import FwbSpinnerExampleSize from './spinner/examples/FwbSpinnerExampleSize.vue'
 
 ---
 
-:::tip
+:::tip Spinner - Flowbite
 Original reference: [https://flowbite.com/docs/components/spinner/](https://flowbite.com/docs/components/spinner/)
 :::
 
 The spinner component can be used as a loading indicator which comes in multiple colors, sizes, and styles separately or inside elements such as buttons to improve the user experience whenever data is being fetched from your server.
 
-## Basic example
+## Default
+
+Use `FwbSpinner` to display a circular loading indicator.
 
 <fwb-spinner-example />
 ```vue
@@ -29,7 +31,9 @@ import { FwbSpinner } from 'flowbite-vue'
 </script>
 ```
 
-## Prop - size
+## Sizes
+
+Use the `size` prop to control the spinner dimensions using a Tailwind spacing unit (e.g. `'4'` = 1rem, `'8'` = 2rem).
 
 <fwb-spinner-example-size />
 ```vue
@@ -46,7 +50,9 @@ import { FwbSpinner } from 'flowbite-vue'
 </script>
 ```
 
-## Prop - color
+## Colors
+
+Use the `color` prop to choose from named colors or pass any hex string (e.g. `'#3fb984'`) for a fully custom fill color.
 
 <fwb-spinner-example-color />
 ```vue
@@ -67,10 +73,11 @@ import { FwbSpinner } from 'flowbite-vue'
 </script>
 ```
 
-## API
+## Spinner component API
 
-### Props
-| Name  | Values                                                                                  | Default |
-|-------|-----------------------------------------------------------------------------------------|---------|
-| color | `blue`, `gray`, `green`, `pink`, `purple`, `red`, `white`, `yellow`, any hex code       | `blue`  |
-| size  | `0`, `0.5`, `1`, `1.5`, `10`, `11`, `12`, `2`, `2.5`, `3`, `4`, `5`, `6`, `7`, `8`, `9` | `4`     |
+### FwbSpinner Props
+
+| Name  | Type                                                                              | Default  | Description                                                                        |
+| ----- | --------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| color | `'blue' \| 'gray' \| 'green' \| 'pink' \| 'purple' \| 'red' \| 'white' \| 'yellow' \| String` | `'blue'` | Fill color of the spinner. Accepts a named color or any hex string (e.g. `'#3fb984'`). |
+| size  | `'0' \| '0.5' \| '1' \| '1.5' \| '2' \| '2.5' \| '3' \| '4' \| '5' \| '6' \| '7' \| '8' \| '9' \| '10' \| '11' \| '12'` | `'4'` | Spinner size mapped to a Tailwind spacing unit. |

--- a/docs/components/spinner.md
+++ b/docs/components/spinner.md
@@ -79,5 +79,5 @@ import { FwbSpinner } from 'flowbite-vue'
 
 | Name  | Type                                                                              | Default  | Description                                                                        |
 | ----- | --------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
-| color | `'blue' \| 'gray' \| 'green' \| 'pink' \| 'purple' \| 'red' \| 'white' \| 'yellow' \| String` | `'blue'` | Fill color of the spinner. Accepts a named color or any hex string (e.g. `'#3fb984'`). |
+| color | `'blue' \| 'gray' \| 'green' \| 'pink' \| 'purple' \| 'red' \| 'white' \| 'yellow' \| \`#${string}\`` | `'blue'` | Fill color of the spinner. Accepts a named color or any hex string (e.g. `'#3fb984'`). |
 | size  | `'0' \| '0.5' \| '1' \| '1.5' \| '2' \| '2.5' \| '3' \| '4' \| '5' \| '6' \| '7' \| '8' \| '9' \| '10' \| '11' \| '12'` | `'4'` | Spinner size mapped to a Tailwind spacing unit. |

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -4,7 +4,7 @@ import FwbTableExampleHoverable from './table/examples/FwbTableExampleHoverable.
 import FwbTableExampleStriped from './table/examples/FwbTableExampleStriped.vue'
 import FwbTableExampleStripedColumns from './table/examples/FwbTableExampleStripedColumns.vue'
 </script>
-# Vue Table - Flowbite
+# Table - Flowbite Vue
 
 #### Button groups are a Tailwind CSS powered set of buttons sticked together in a horizontal line
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -4,17 +4,22 @@ import FwbTableExampleHoverable from './table/examples/FwbTableExampleHoverable.
 import FwbTableExampleStriped from './table/examples/FwbTableExampleStriped.vue'
 import FwbTableExampleStripedColumns from './table/examples/FwbTableExampleStripedColumns.vue'
 </script>
+
 # Table - Flowbite Vue
 
-#### Button groups are a Tailwind CSS powered set of buttons sticked together in a horizontal line
+#### Use the table component to display structured data in rows and columns with support for striped rows, striped columns, and hoverable row highlights
 
 ---
 
-:::tip
+:::tip Table - Flowbite
 Original reference: [https://flowbite.com/docs/components/tables/](https://flowbite.com/docs/components/tables/)
 :::
 
-## Basic example
+The table component can be used to display structured data in rows and columns, with Tailwind CSS styling for striped rows, striped columns, and hoverable row highlights — all compatible with dark mode.
+
+## Default
+
+Use `FwbTable` with `FwbTableHead`, `FwbTableBody`, `FwbTableRow`, `FwbTableHeadCell`, and `FwbTableCell` to compose a structured data table.
 
 <fwb-table-example />
 ```vue
@@ -80,7 +85,9 @@ import {
 </script>
 ```
 
-## Striped example
+## Striped Rows
+
+Add the `striped` prop to apply alternating background colors to table rows, making the data easier to read.
 
 <fwb-table-example-striped />
 ```vue
@@ -147,7 +154,9 @@ import {
 
 ```
 
-## Striped columns example
+## Striped Columns
+
+Add the `striped-columns` prop to apply alternating background colors to columns instead of rows.
 
 <fwb-table-example-striped-columns />
 ```vue
@@ -211,7 +220,9 @@ import {
 </script>
 ```
 
-## Hoverable example
+## Hoverable
+
+Add the `hoverable` prop to highlight the row under the cursor, useful for interactive tables.
 
 <fwb-table-example-hoverable />
 ```vue
@@ -276,3 +287,49 @@ import {
 } from 'flowbite-vue'
 </script>
 ```
+
+## Table component API
+
+### FwbTable Props
+
+| Name           | Type      | Default | Description                                               |
+| -------------- | --------- | ------- | --------------------------------------------------------- |
+| hoverable      | `Boolean` | `false` | Highlights the row under the cursor on hover.             |
+| striped        | `Boolean` | `false` | Applies alternating background colors to rows.            |
+| stripedColumns | `Boolean` | `false` | Applies alternating background colors to columns.         |
+
+### FwbTable Slots
+
+| Name    | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
+| default | Table content — `FwbTableHead` and `FwbTableBody` elements.       |
+
+### FwbTableHead Slots
+
+| Name    | Description                              |
+| ------- | ---------------------------------------- |
+| default | One or more `FwbTableHeadCell` elements. |
+
+### FwbTableHeadCell Slots
+
+| Name    | Description          |
+| ------- | -------------------- |
+| default | Header cell content. |
+
+### FwbTableBody Slots
+
+| Name    | Description                         |
+| ------- | ----------------------------------- |
+| default | One or more `FwbTableRow` elements. |
+
+### FwbTableRow Slots
+
+| Name    | Description                          |
+| ------- | ------------------------------------ |
+| default | One or more `FwbTableCell` elements. |
+
+### FwbTableCell Slots
+
+| Name    | Description        |
+| ------- | ------------------ |
+| default | Data cell content. |

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -6,7 +6,7 @@ import FwbTabsExamplePills from './tabs/examples/FwbTabsExamplePills.vue'
 import FwbTabsExampleUnderline from './tabs/examples/FwbTabsExampleUnderline.vue'
 </script>
 
-# Vue Tabs - Flowbite
+# Tabs - Flowbite Vue
 
 #### Use these responsive tabs components to create a secondary navigational hierarchy for your website or toggle content inside a container
 

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -144,7 +144,7 @@ const activeTab = ref('first')
 
 ## Tab Pane Interaction
 
-Listen to the `click:pane` event on `FwbTabs` to intercept tab button clicks before the active tab changes.
+Listen to the `click:pane` event on `FwbTabs` to be notified when a tab button is clicked. The event carries no payload and fires after the active tab has already changed.
 
 <fwb-tabs-example-interaction />
 ```vue
@@ -190,7 +190,7 @@ const handlePaneClick = () => { console.log('Click!') }
 | Name               | Description                                                          |
 | ------------------ | -------------------------------------------------------------------- |
 | update:modelValue  | Emitted with the new tab name when the active tab changes.           |
-| click:pane         | Emitted with the tab name when a tab button is clicked.              |
+| click:pane         | Emitted when a tab button is clicked (no payload); fires after the active tab has changed. |
 
 ### FwbTabs Slots
 

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -12,13 +12,15 @@ import FwbTabsExampleUnderline from './tabs/examples/FwbTabsExampleUnderline.vue
 
 ---
 
-:::tip
+:::tip Tabs - Flowbite
 Original reference: [https://flowbite.com/docs/components/tabs/](https://flowbite.com/docs/components/tabs/)
 :::
 
 The tabs component can be used either as an extra navigational hierarchy complementing the main navbar or you can also use it to change content inside a container just below the tabs using the data attributes from Flowbite.
 
-## Prop - variant (default)
+## Default
+
+Use `FwbTabs` with `v-model` bound to a tab name and nest `FwbTab` components inside. Each `FwbTab` requires a unique `name` and a `title` for its button label.
 
 <fwb-tabs-example />
 ```vue
@@ -47,9 +49,11 @@ const activeTab = ref('first')
 </script>
 ```
 
-## Prop - variant (underline)
+## Underline
 
-<fwb-tabsExample-underline />
+Set `variant="underline"` to render tab buttons with an underline indicator instead of a bordered box.
+
+<fwb-tabs-example-underline />
 ```vue
 <template>
   <fwb-tabs v-model="activeTab" variant="underline" class="p-5">
@@ -76,13 +80,15 @@ const activeTab = ref('first')
 </script>
 ```
 
-## Prop - variant (pills)
+## Pills
+
+Set `variant="pills"` to render each tab button as a pill-shaped badge.
 
 <fwb-tabs-example-pills />
 ```vue
 <template>
   <fwb-tabs v-model="activeTab" variant="pills" class="p-5">
-    <fwb-tab name="first" title="First" >
+    <fwb-tab name="first" title="First">
       Lorem ipsum dolor...
     </fwb-tab>
     <fwb-tab name="second" title="Second">
@@ -95,7 +101,6 @@ const activeTab = ref('first')
       Lorem ipsum dolor...
     </fwb-tab>
   </fwb-tabs>
- </div>
 </template>
 
 <script setup>
@@ -106,9 +111,9 @@ const activeTab = ref('first')
 </script>
 ```
 
-## Prop - directive
+## Directive
 
-Use this props if you want to control which directive to use for rendering every tab content
+Set `directive="show"` to keep all tab content in the DOM and toggle visibility with `v-show`, instead of mounting/unmounting with `v-if` (the default).
 
 <fwb-tabs-example-directive />
 ```vue
@@ -137,9 +142,9 @@ const activeTab = ref('first')
 </script>
 ```
 
-## Tab pane interaction
+## Tab Pane Interaction
 
-You can add `@click:pane` to Tabs component to intercept click on tab pane.
+Listen to the `click:pane` event on `FwbTabs` to intercept tab button clicks before the active tab changes.
 
 <fwb-tabs-example-interaction />
 ```vue
@@ -170,11 +175,39 @@ const handlePaneClick = () => { console.log('Click!') }
 </script>
 ```
 
-## API
+## Tabs component API
 
-### Props
-| Name       | Values                         | Default   |
-|------------|--------------------------------|-----------|
-| directive  | `if`, `show`                   | `if`      |
-| modelValue | `string`                       | `''`      |
-| variant    | `default`, `underline`, `pill` | `default` |
+### FwbTabs Props
+
+| Name       | Type                                    | Default     | Description                                                                               |
+| ---------- | --------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| directive  | `'if' \| 'show'`                        | `'if'`      | Controls how hidden tab content is rendered: `'if'` unmounts it, `'show'` hides it.      |
+| modelValue | `String`                                | `''`        | Name of the currently active tab (use with `v-model`).                                   |
+| variant    | `'default' \| 'underline' \| 'pills'`   | `'default'` | Visual style of the tab buttons.                                                          |
+
+### FwbTabs Events
+
+| Name               | Description                                                          |
+| ------------------ | -------------------------------------------------------------------- |
+| update:model-value | Emitted with the new tab name when the active tab changes.           |
+| click:pane         | Emitted with the tab name when a tab button is clicked.              |
+
+### FwbTabs Slots
+
+| Name    | Description                          |
+| ------- | ------------------------------------ |
+| default | One or more `FwbTab` components.     |
+
+### FwbTab Props
+
+| Name     | Type      | Default | Description                                            |
+| -------- | --------- | ------- | ------------------------------------------------------ |
+| disabled | `Boolean` | `false` | Prevents the tab from being selected when clicked.     |
+| name     | `String`  | —       | **Required.** Unique identifier for this tab.          |
+| title    | `String`  | `''`    | Label text displayed in the tab button.                |
+
+### FwbTab Slots
+
+| Name    | Description              |
+| ------- | ------------------------ |
+| default | The tab panel content.   |

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -189,7 +189,7 @@ const handlePaneClick = () => { console.log('Click!') }
 
 | Name               | Description                                                          |
 | ------------------ | -------------------------------------------------------------------- |
-| update:model-value | Emitted with the new tab name when the active tab changes.           |
+| update:modelValue  | Emitted with the new tab name when the active tab changes.           |
 | click:pane         | Emitted with the tab name when a tab button is clicked.              |
 
 ### FwbTabs Slots

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -20,9 +20,9 @@ Original reference: [https://flowbite.com/docs/forms/textarea/](https://flowbite
 
 The textarea component is a multi-line text field that can be used to receive longer chunks of text from the user in the form of a comment box, description field, and more.
 
-## Textarea example
+## Default
 
-Get started with the default example of a textarea component below.
+Use `FwbTextarea` with `v-model` to bind a multi-line text value. Add `label` for an accessible label above the field and `placeholder` for hint text inside.
 
 <fwb-textarea-example />
 
@@ -68,6 +68,8 @@ const message = ref('')
 ```
 
 ## Disabled / Readonly
+
+Use the `disabled` prop to prevent the user from editing the textarea entirely, or pass `readonly` as a native attribute to allow reading but not editing.
 
 <fwb-textarea-example-disabled />
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -8,7 +8,7 @@ import FwbTextareaExampleStyling from './textarea/examples/FwbTextareaExampleSty
 import FwbTextareaExampleValidation from './textarea/examples/FwbTextareaExampleValidation.vue'
 </script>
 
-# Vue Textarea - Flowbite
+# Textarea - Flowbite Vue
 
 #### Use the textarea component as a multi-line text field input and use it inside form elements available in multiple sizes, styles, and variants
 

--- a/docs/components/timeline.md
+++ b/docs/components/timeline.md
@@ -3,11 +3,25 @@ import FwbTimelineExample from './timeline/examples/FwbTimelineExample.vue'
 import FwbTimelineExampleWithIcons from './timeline/examples/FwbTimelineExampleWithIcons.vue'
 import FwbTimelineExampleHorizontal from './timeline/examples/FwbTimelineExampleHorizontal.vue'
 </script>
+
 # Timeline - Flowbite Vue
 
-## Default timeline usage
+#### Use the timeline component to display a list of items and events in a chronological order based on Tailwind CSS utility classes
+
+---
+
+:::tip Timeline - Flowbite
+Original reference: [https://flowbite.com/docs/components/timeline/](https://flowbite.com/docs/components/timeline/)
+:::
+
+The timeline component can be used to display a list of events in chronological order with support for icons, dates, and a horizontal layout — built with `FwbTimeline`, `FwbTimelineItem`, `FwbTimelinePoint`, `FwbTimelineContent`, `FwbTimelineTime`, and `FwbTimelineTitle`.
+
+## Default
+
+Use `FwbTimeline` with nested `FwbTimelineItem` components. Each item contains a `FwbTimelinePoint` followed by `FwbTimelineContent` with optional `FwbTimelineTime`, `FwbTimelineTitle`, and `FwbTimelineBody`.
 
 <fwb-timeline-example />
+
 ```vue
 <template>
   <fwb-timeline>
@@ -72,10 +86,12 @@ import {
 </script>
 ```
 
-## Timeline with icons
-You can add icons by passing svg icons as slot to `<fwb-timeline-point>` component
+## Timeline with Icons
+
+Pass an SVG icon as the default slot of `<fwb-timeline-point>` to replace the default dot with a custom icon.
 
 <fwb-timeline-example-with-icons />
+
 ```vue
 <template>
   <fwb-timeline class="vp-raw">
@@ -181,11 +197,13 @@ import {
 } from 'flowbite-vue'
 </script>
 ```
-## Timeline with icons
-`horizontal` prop makes timeline horizontal
-<br>
+
+## Horizontal Timeline
+
+Add the `horizontal` prop to `FwbTimeline` to arrange items side by side instead of stacked vertically.
 
 <fwb-timeline-example-horizontal />
+
 ```vue
 <template>
   <fwb-timeline horizontal>
@@ -286,3 +304,53 @@ import {
 } from 'flowbite-vue'
 </script>
 ```
+
+## Timeline component API
+
+### FwbTimeline Props
+
+| Name       | Type      | Default | Description                                 |
+| ---------- | --------- | ------- | ------------------------------------------- |
+| horizontal | `Boolean` | `false` | Lays out the timeline items horizontally.   |
+
+### FwbTimeline Slots
+
+| Name    | Description                              |
+| ------- | ---------------------------------------- |
+| default | One or more `FwbTimelineItem` components. |
+
+### FwbTimelineItem Slots
+
+| Name    | Description                                           |
+| ------- | ----------------------------------------------------- |
+| default | `FwbTimelinePoint` and `FwbTimelineContent` elements. |
+
+### FwbTimelinePoint Slots
+
+| Name    | Description                                       |
+| ------- | ------------------------------------------------- |
+| default | Optional icon to replace the default dot marker.  |
+
+### FwbTimelineContent Slots
+
+| Name    | Description                                                            |
+| ------- | ---------------------------------------------------------------------- |
+| default | `FwbTimelineTime`, `FwbTimelineTitle`, and `FwbTimelineBody` elements. |
+
+### FwbTimelineTime Slots
+
+| Name    | Description                  |
+| ------- | ---------------------------- |
+| default | The date or time label text. |
+
+### FwbTimelineTitle Slots
+
+| Name    | Description           |
+| ------- | --------------------- |
+| default | The event title text. |
+
+### FwbTimelineBody Slots
+
+| Name    | Description                 |
+| ------- | --------------------------- |
+| default | The event description text. |

--- a/docs/components/timeline.md
+++ b/docs/components/timeline.md
@@ -3,7 +3,7 @@ import FwbTimelineExample from './timeline/examples/FwbTimelineExample.vue'
 import FwbTimelineExampleWithIcons from './timeline/examples/FwbTimelineExampleWithIcons.vue'
 import FwbTimelineExampleHorizontal from './timeline/examples/FwbTimelineExampleHorizontal.vue'
 </script>
-# Vue Timeline - Flowbite
+# Timeline - Flowbite Vue
 
 ## Default timeline usage
 

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -6,21 +6,25 @@ import FwbToastExampleDivide from './toast/examples/FwbToastExampleDivide.vue'
 import FwbToastExampleMessage from './toast/examples/FwbToastExampleMessage.vue'
 import FwbToastExampleInteractive from './toast/examples/FwbToastExampleInteractive.vue'
 </script>
+
 # Toast - Flowbite Vue
 
 #### Push notifications to your users using the toast component and choose from multiple sizes, colors, styles, and positions
 
 ---
 
-:::tip
+:::tip Toast - Flowbite
 Original reference: [https://flowbite.com/docs/components/toast/](https://flowbite.com/docs/components/toast/)
 :::
 
-The toast component can be used to enhance your website’s interactivity by pushing notifications to your visitors. You can choose from multiple styles, colors, sizes, and positions and even dismiss the component.
+The toast component can be used to enhance your website's interactivity by pushing notifications to your visitors. You can choose from multiple styles, colors, sizes, and positions and even dismiss the component.
 
-## Prop - type
+## Default
+
+Use `FwbToast` to display a notification badge. Set the `type` prop to `'success'`, `'warning'`, or `'danger'` to show a colored icon; omit it (or use `'empty'`) to render without an icon badge.
 
 <fwb-toast-example />
+
 ```vue
 <template>
   <fwb-toast>
@@ -42,9 +46,12 @@ import { FwbToast } from 'flowbite-vue'
 </script>
 ```
 
-## Prop - closable
+## Closable
+
+Add the `closable` prop to render a close button that dismisses the toast when clicked and emits a `close` event.
 
 <fwb-toast-example-closable />
+
 ```vue
 <template>
   <fwb-toast closable>
@@ -66,9 +73,12 @@ import { FwbToast } from 'flowbite-vue'
 </script>
 ```
 
-## Prop - divide
+## Divide
+
+Add the `divide` prop to render a vertical divider between the icon badge and the toast content.
 
 <fwb-toast-example-divide />
+
 ```vue
 <template>
   <fwb-toast divide>
@@ -92,7 +102,10 @@ import { FwbToast } from 'flowbite-vue'
 
 ## Message
 
+Set `alignment="start"` to left-align the content, then use the `icon` slot and interactive elements inside the default slot to build a rich message-style notification.
+
 <fwb-toast-example-message />
+
 ```vue
 <template>
   <fwb-toast alignment="start" closable>
@@ -117,7 +130,10 @@ import { FwbButton, FwbToast } from 'flowbite-vue'
 
 ## Interactive
 
+Wrap `FwbToast` in `FlowbiteThemable` to apply a custom theme color to the icon badge background.
+
 <fwb-toast-example-interactive />
+
 ```vue
 <template>
   <flowbite-themable theme="blue">
@@ -146,14 +162,14 @@ import { FwbButton, FwbToast } from 'flowbite-vue'
 <script setup>
 import { FlowbiteThemable, FwbButton, FwbToast } from 'flowbite-vue'
 </script>
-
 ```
 
-## Slot - icon
+## Slot - Icon
 
-You can use icon slot for rendering your own icons. Also you can change icon background color by using [FlowbiteThemable](/components/flowbiteThemable/flowbiteThemable.md)
+Use the `icon` slot to render a custom SVG inside the colored badge. Pair with [FlowbiteThemable](/components/flowbiteThemable/flowbiteThemable.md) to control the badge background color.
 
 <fwb-toast-example-icon />
+
 ```vue
 <template>
   <fwb-toast closable>
@@ -173,7 +189,7 @@ You can use icon slot for rendering your own icons. Also you can change icon bac
     </template>
     You have new friend request.
   </fwb-toast>
-  <fwb-toast closabletype="success">
+  <fwb-toast closable type="success">
     <template #icon>
       <svg class="bi bi-earbuds" fill="currentColor" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
         <path d="M6.825 4.138c.596 2.141-.36 3.593-2.389 4.117a4.432 4.432 0 0 1-2.018.054c-.048-.01.9 2.778 1.522 4.61l.41 1.205a.52.52 0 0 1-.346.659l-.593.19a.548.548 0 0 1-.69-.34L.184 6.99c-.696-2.137.662-4.309 2.564-4.8 2.029-.523 3.402 0 4.076 1.948zm-.868 2.221c.43-.112.561-.993.292-1.969-.269-.975-.836-1.675-1.266-1.563-.43.112-.561.994-.292 1.969.269.975.836 1.675 1.266 1.563zm3.218-2.221c-.596 2.141.36 3.593 2.389 4.117a4.434 4.434 0 0 0 2.018.054c.048-.01-.9 2.778-1.522 4.61l-.41 1.205a.52.52 0 0 0 .346.659l.593.19c.289.092.6-.06.69-.34l2.536-7.643c.696-2.137-.662-4.309-2.564-4.8-2.029-.523-3.402 0-4.076 1.948zm.868 2.221c-.43-.112-.561-.993-.292-1.969.269-.975.836-1.675 1.266-1.563.43.112.561.994.292 1.969-.269.975-.836 1.675-1.266 1.563z" fill-rule="evenodd" />
@@ -187,3 +203,27 @@ You can use icon slot for rendering your own icons. Also you can change icon bac
 import { FwbToast } from 'flowbite-vue'
 </script>
 ```
+
+## Toast component API
+
+### FwbToast Props
+
+| Name      | Type                                              | Default    | Description                                                                          |
+| --------- | ------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------ |
+| alignment | `'start' \| 'center' \| 'end'`                   | `'center'` | Horizontal alignment of the content inside the toast.                                |
+| closable  | `Boolean`                                         | `false`    | Renders a close button that dismisses the toast and emits `close`.                   |
+| divide    | `Boolean`                                         | `false`    | Renders a vertical divider between the icon badge and the content.                   |
+| type      | `'success' \| 'warning' \| 'danger' \| 'empty'`  | `'empty'`  | Sets the icon badge color. `'empty'` hides the badge unless the `icon` slot is used. |
+
+### FwbToast Events
+
+| Name  | Description                                |
+| ----- | ------------------------------------------ |
+| close | Emitted when the close button is clicked.  |
+
+### FwbToast Slots
+
+| Name    | Description                                                                       |
+| ------- | --------------------------------------------------------------------------------- |
+| default | The toast message content.                                                        |
+| icon    | Custom icon rendered inside the colored badge (overrides the built-in type icon). |

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -6,7 +6,7 @@ import FwbToastExampleDivide from './toast/examples/FwbToastExampleDivide.vue'
 import FwbToastExampleMessage from './toast/examples/FwbToastExampleMessage.vue'
 import FwbToastExampleInteractive from './toast/examples/FwbToastExampleInteractive.vue'
 </script>
-# Vue Toast - Flowbite
+# Toast - Flowbite Vue
 
 #### Push notifications to your users using the toast component and choose from multiple sizes, colors, styles, and positions
 

--- a/docs/components/toastProvider/toastProvider.md
+++ b/docs/components/toastProvider/toastProvider.md
@@ -2,7 +2,7 @@
 import FwbToastProviderExample from './examples/FwbToastProviderExample.vue'
 </script>
 
-# Vue Toast Provider - Flowbite
+# Toast Provider - Flowbite Vue
 
 :::warning
 WIP, Do not use it in production

--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -10,7 +10,7 @@ import FwbToggleExampleStyling from './toggle/examples/FwbToggleExampleStyling.v
 import FwbToggleExampleValidation from './toggle/examples/FwbToggleExampleValidation.vue'
 </script>
 
-# Vue Toggle - Flowbite
+# Toggle - Flowbite Vue
 
 #### Use the toggle component to switch between a binary state of true or false using a single click available in multiple sizes, variants, and colors
 

--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -16,15 +16,18 @@ import FwbToggleExampleValidation from './toggle/examples/FwbToggleExampleValida
 
 ---
 
-:::tip
+:::tip Toggle - Flowbite
 Original reference: [https://flowbite.com/docs/forms/toggle/](https://flowbite.com/docs/forms/toggle/)
 :::
 
 The toggle component can be used to receive a simple "yes" or "no" type of answer from the user by choosing a single option from two options available in multiple sizes, styles, and colors coded with the utility classes from Tailwind CSS and with dark mode support.
 
-## Default toggle
+## Default
+
+Use `FwbToggle` with `v-model` to bind a boolean value and `label` to display accessible text beside the switch.
 
 <fwb-toggle-example />
+
 ```vue
 <template>
   <fwb-toggle v-model="toggle" label="Toggle me" />
@@ -36,12 +39,14 @@ import { FwbToggle } from 'flowbite-vue'
 
 const toggle = ref(false)
 </script>
-
 ```
 
-## Checked toggle
+## Checked
+
+Initialize `v-model` with `true` to render the toggle in its checked (on) state by default.
 
 <fwb-toggle-example-checked />
+
 ```vue
 <template>
   <fwb-toggle v-model="toggle" label="Toggle me" />
@@ -55,9 +60,12 @@ const toggle = ref(true)
 </script>
 ```
 
-## Disabled toggle
+## Disabled
+
+Add the `disabled` prop to prevent the user from interacting with the toggle.
 
 <fwb-toggle-example-disabled />
+
 ```vue
 <template>
   <fwb-toggle v-model="toggle" disabled label="Can't Toggle me" />
@@ -69,12 +77,14 @@ import { FwbToggle } from 'flowbite-vue'
 
 const toggle = ref(false)
 </script>
-
 ```
 
 ## Colors
 
+Use the `color` prop to set the accent color of the track when the toggle is checked.
+
 <fwb-toggle-example-colors />
+
 ```vue
 <template>
   <fwb-toggle label="Red" color="red" />
@@ -88,7 +98,10 @@ const toggle = ref(false)
 
 ## Size
 
+Use the `size` prop to control the size of the toggle track and thumb.
+
 <fwb-toggle-example-size />
+
 ```vue
 <template>
   <fwb-toggle label="Small" size="sm" />
@@ -98,9 +111,12 @@ const toggle = ref(false)
 </template>
 ```
 
-## Label position
+## Label Position
+
+Add the `reverse` prop to place the label text to the left of the toggle instead of the right.
 
 <fwb-toggle-example-order />
+
 ```vue
 <template>
   <fwb-toggle label="Toggle me" />
@@ -113,6 +129,7 @@ const toggle = ref(false)
 Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the toggle.
 
 <fwb-toggle-example-validation />
+
 ```vue
 <template>
   <fwb-toggle v-model="toggle1" label="Notifications (success)" validation-status="success">
@@ -128,11 +145,12 @@ Use `validationStatus` together with the `validationMessage` slot to show succes
 </template>
 ```
 
-## Helper text
+## Helper Text
 
 Use the `helper` slot to show a hint below the toggle.
 
 <fwb-toggle-example-helper />
+
 ```vue
 <template>
   <fwb-toggle v-model="toggle" label="Dark mode">
@@ -148,6 +166,7 @@ Use the `helper` slot to show a hint below the toggle.
 Use dedicated props to pass classes to individual elements.
 
 <fwb-toggle-example-styling />
+
 ```vue
 <template>
   <fwb-toggle

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -5,11 +5,25 @@ import FwbTooltipExampleStyle from './tooltip/examples/FwbTooltipExampleStyle.vu
 import FwbTooltipExampleGroup from './tooltip/examples/FwbTooltipExampleGroup.vue'
 import FwbTooltipExampleTrigger from './tooltip/examples/FwbTooltipExampleTrigger.vue'
 </script>
+
 # Tooltip - Flowbite Vue
 
-## Demo
+#### Use the tooltip component to show additional information when hovering over an element based on Tailwind CSS utility classes
+
+---
+
+:::tip Tooltip - Flowbite
+Original reference: [https://flowbite.com/docs/components/tooltips/](https://flowbite.com/docs/components/tooltips/)
+:::
+
+The tooltip component can be used to show additional information when hovering over an element, with support for multiple placement positions, light and dark styles, and custom trigger events.
+
+## Default
+
+Use `FwbTooltip` with a `trigger` slot (the element that opens the tooltip) and a `content` slot (the tooltip text). By default the tooltip appears on hover and is positioned above the trigger.
 
 <fwb-tooltip-example />
+
 ```vue
 <template>
   <fwb-tooltip>
@@ -29,11 +43,12 @@ import { FwbButton, FwbTooltip } from 'flowbite-vue'
 </script>
 ```
 
-## Tooltip styles
+## Styles
 
-You can use choose between dark and light version styles for the tooltip component by changing the utility classes from Tailwind CSS and by applying the `tooltip-light` or `tooltip-dark` attribute.
+Use the `theme` prop to switch between `'dark'` (default) and `'light'` tooltip backgrounds.
 
 <fwb-tooltip-example-style />
+
 ```vue
 <template>
   <fwb-tooltip theme="light">
@@ -65,10 +80,10 @@ import { FwbButton, FwbTooltip } from 'flowbite-vue'
 
 ## Placement
 
-The positioning of the tooltip element relative to the triggering element (eg. button, link) can be set using placement attribute with `top`, `top-start` , `top-end`, `bottom`, `bottom-start`, `bottom-end`, `right`, `right-start`, `right-end`, `left`, `left-start`, `left-end`, `auto`, `auto-start`,  `auto-end`.
-The default value is: `top`
+Use the `placement` prop to control where the tooltip appears relative to its trigger. Accepted values include `'top'`, `'bottom'`, `'left'`, `'right'`, and their `-start` / `-end` variants, as well as `'auto'`.
 
 <fwb-tooltip-example-position />
+
 ```vue
 <template>
   <fwb-tooltip placement="top">
@@ -120,9 +135,10 @@ import { FwbButton, FwbTooltip } from 'flowbite-vue'
 
 ## Inside of Button Group
 
-You can use the tooltip component inside of the button group component.
+`FwbTooltip` can be nested inside `FwbButtonGroup` — the trigger slot wraps any button in the group.
 
 <fwb-tooltip-example-group />
+
 ```vue
 <template>
   <fwb-button-group>
@@ -143,16 +159,16 @@ You can use the tooltip component inside of the button group component.
 </template>
 
 <script setup>
-import { FwbButton, FwbButtonGroup, FwbTooltip } from '../../../../src/index'
+import { FwbButton, FwbButtonGroup, FwbTooltip } from 'flowbite-vue'
 </script>
 ```
 
+## Trigger Type
 
-## triggerType
-
-You can choose the triggering event by using the `hover` or `click` attributes to choose whether you want to show the tooltip when hovering or clicking on the element. By default this option is set to `click`.
+Set `trigger="click"` to open the tooltip on click instead of the default hover behaviour.
 
 <fwb-tooltip-example-trigger />
+
 ```vue
 <template>
   <fwb-tooltip>
@@ -177,7 +193,24 @@ You can choose the triggering event by using the `hover` or `click` attributes t
   </fwb-tooltip>
 </template>
 
-<script lang="ts" setup>
+<script setup>
 import { FwbButton, FwbTooltip } from 'flowbite-vue'
 </script>
 ```
+
+## Tooltip component API
+
+### FwbTooltip Props
+
+| Name      | Type                                                                                                                                                                        | Default  | Description                                                                  |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| placement | `'auto' \| 'auto-start' \| 'auto-end' \| 'top' \| 'top-start' \| 'top-end' \| 'bottom' \| 'bottom-start' \| 'bottom-end' \| 'right' \| 'right-start' \| 'right-end' \| 'left' \| 'left-start' \| 'left-end'` | `'top'` | Where the tooltip appears relative to its trigger element. |
+| theme     | `'dark' \| 'light'`                                                                                                                                                         | `'dark'` | Visual style of the tooltip bubble.                                          |
+| trigger   | `'hover' \| 'click'`                                                                                                                                                        | `'hover'` | Event that opens the tooltip.                                                |
+
+### FwbTooltip Slots
+
+| Name    | Description                                      |
+| ------- | ------------------------------------------------ |
+| trigger | The element that opens and anchors the tooltip.  |
+| content | The text or markup shown inside the tooltip.     |

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -5,7 +5,7 @@ import FwbTooltipExampleStyle from './tooltip/examples/FwbTooltipExampleStyle.vu
 import FwbTooltipExampleGroup from './tooltip/examples/FwbTooltipExampleGroup.vue'
 import FwbTooltipExampleTrigger from './tooltip/examples/FwbTooltipExampleTrigger.vue'
 </script>
-# Vue Tooltip - Flowbite
+# Tooltip - Flowbite Vue
 
 ## Demo
 

--- a/src/components/FwbSidebar/FwbSidebarItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarItem.vue
@@ -19,7 +19,7 @@
 import { resolveComponent } from 'vue'
 const props = withDefaults(
   defineProps<{
-    link?: string | { name: string }
+    link?: string | Record<string, unknown>
     tag?: string
   }>(),
   {

--- a/src/components/FwbSidebar/FwbSidebarItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarItem.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="component"
+    :is="tag"
     :[linkAttr]="linkValue"
     class="group flex items-center rounded-lg p-2 text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
   >
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, resolveComponent } from 'vue'
+import { computed } from 'vue'
 const props = withDefaults(
   defineProps<{
     link?: string | Record<string, unknown>
@@ -28,8 +28,6 @@ const props = withDefaults(
   },
 )
 
-const resolved = computed(() => props.tag === 'a' ? 'a' : resolveComponent(props.tag))
-const component = computed(() => typeof resolved.value === 'string' ? 'a' : resolved.value)
-const linkAttr = computed(() => component.value === 'a' ? 'href' : 'to')
-const linkValue = computed(() => component.value === 'a' && typeof props.link !== 'string' ? '/' : props.link)
+const linkAttr = computed(() => props.tag === 'a' ? 'href' : 'to')
+const linkValue = computed(() => props.tag === 'a' && typeof props.link !== 'string' ? '/' : props.link)
 </script>

--- a/src/components/FwbSidebar/FwbSidebarItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarItem.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { resolveComponent } from 'vue'
+import { computed, resolveComponent } from 'vue'
 const props = withDefaults(
   defineProps<{
     link?: string | Record<string, unknown>
@@ -28,8 +28,8 @@ const props = withDefaults(
   },
 )
 
-const resolved = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
-const component = typeof resolved === 'string' ? 'a' : resolved
-const linkAttr = component === 'a' ? 'href' : 'to'
-const linkValue = component === 'a' && typeof props.link !== 'string' ? '/' : props.link
+const resolved = computed(() => props.tag === 'a' ? 'a' : resolveComponent(props.tag))
+const component = computed(() => typeof resolved.value === 'string' ? 'a' : resolved.value)
+const linkAttr = computed(() => component.value === 'a' ? 'href' : 'to')
+const linkValue = computed(() => component.value === 'a' && typeof props.link !== 'string' ? '/' : props.link)
 </script>

--- a/src/components/FwbSidebar/FwbSidebarItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarItem.vue
@@ -24,10 +24,11 @@ const props = withDefaults(
   }>(),
   {
     link: '/',
-    tag: 'router-link',
+    tag: 'a',
   },
 )
 
-const component = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
-const linkAttr = props.tag === 'a' ? 'href' : 'to'
+const resolved = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
+const component = typeof resolved === 'string' ? 'a' : resolved
+const linkAttr = component === 'a' ? 'href' : 'to'
 </script>

--- a/src/components/FwbSidebar/FwbSidebarItem.vue
+++ b/src/components/FwbSidebar/FwbSidebarItem.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="component"
-    :[linkAttr]="link"
+    :[linkAttr]="linkValue"
     class="group flex items-center rounded-lg p-2 text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
   >
     <slot name="icon" />
@@ -31,4 +31,5 @@ const props = withDefaults(
 const resolved = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
 const component = typeof resolved === 'string' ? 'a' : resolved
 const linkAttr = component === 'a' ? 'href' : 'to'
+const linkValue = component === 'a' && typeof props.link !== 'string' ? '/' : props.link
 </script>

--- a/src/components/FwbSidebar/FwbSidebarLogo.vue
+++ b/src/components/FwbSidebar/FwbSidebarLogo.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="component"
+    :is="tag"
     :[linkAttr]="linkValue"
     class="mb-5 flex items-center pl-2.5"
   >
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, resolveComponent } from 'vue'
+import { computed } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -33,8 +33,6 @@ const props = withDefaults(
   },
 )
 
-const resolved = computed(() => props.tag === 'a' ? 'a' : resolveComponent(props.tag))
-const component = computed(() => typeof resolved.value === 'string' ? 'a' : resolved.value)
-const linkAttr = computed(() => component.value === 'a' ? 'href' : 'to')
-const linkValue = computed(() => component.value === 'a' && typeof props.link !== 'string' ? '/' : props.link)
+const linkAttr = computed(() => props.tag === 'a' ? 'href' : 'to')
+const linkValue = computed(() => props.tag === 'a' && typeof props.link !== 'string' ? '/' : props.link)
 </script>

--- a/src/components/FwbSidebar/FwbSidebarLogo.vue
+++ b/src/components/FwbSidebar/FwbSidebarLogo.vue
@@ -19,7 +19,7 @@ import { resolveComponent } from 'vue'
 const props = withDefaults(
   defineProps<{
     name?: string
-    link?: string | { name: string }
+    link?: string | Record<string, unknown>
     logo?: string
     alt?: string
     tag?: string

--- a/src/components/FwbSidebar/FwbSidebarLogo.vue
+++ b/src/components/FwbSidebar/FwbSidebarLogo.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { resolveComponent } from 'vue'
+import { computed, resolveComponent } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -33,8 +33,8 @@ const props = withDefaults(
   },
 )
 
-const resolved = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
-const component = typeof resolved === 'string' ? 'a' : resolved
-const linkAttr = component === 'a' ? 'href' : 'to'
-const linkValue = component === 'a' && typeof props.link !== 'string' ? '/' : props.link
+const resolved = computed(() => props.tag === 'a' ? 'a' : resolveComponent(props.tag))
+const component = computed(() => typeof resolved.value === 'string' ? 'a' : resolved.value)
+const linkAttr = computed(() => component.value === 'a' ? 'href' : 'to')
+const linkValue = computed(() => component.value === 'a' && typeof props.link !== 'string' ? '/' : props.link)
 </script>

--- a/src/components/FwbSidebar/FwbSidebarLogo.vue
+++ b/src/components/FwbSidebar/FwbSidebarLogo.vue
@@ -19,7 +19,7 @@ import { resolveComponent } from 'vue'
 const props = withDefaults(
   defineProps<{
     name?: string
-    link?: string
+    link?: string | { name: string }
     logo?: string
     alt?: string
     tag?: string
@@ -29,7 +29,7 @@ const props = withDefaults(
     link: '/',
     logo: '',
     tag: 'a',
-    alt: '',
+    alt: undefined,
   },
 )
 

--- a/src/components/FwbSidebar/FwbSidebarLogo.vue
+++ b/src/components/FwbSidebar/FwbSidebarLogo.vue
@@ -28,11 +28,12 @@ const props = withDefaults(
     name: '',
     link: '/',
     logo: '',
-    tag: 'router-link',
+    tag: 'a',
     alt: '',
   },
 )
 
-const component = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
-const linkAttr = props.tag === 'a' ? 'href' : 'to'
+const resolved = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
+const component = typeof resolved === 'string' ? 'a' : resolved
+const linkAttr = component === 'a' ? 'href' : 'to'
 </script>

--- a/src/components/FwbSidebar/FwbSidebarLogo.vue
+++ b/src/components/FwbSidebar/FwbSidebarLogo.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="component"
-    :[linkAttr]="link"
+    :[linkAttr]="linkValue"
     class="mb-5 flex items-center pl-2.5"
   >
     <img
@@ -36,4 +36,5 @@ const props = withDefaults(
 const resolved = props.tag === 'a' ? 'a' : resolveComponent(props.tag)
 const component = typeof resolved === 'string' ? 'a' : resolved
 const linkAttr = component === 'a' ? 'href' : 'to'
+const linkValue = component === 'a' && typeof props.link !== 'string' ? '/' : props.link
 </script>

--- a/src/components/FwbSidebar/tests/FwbSidebarItem.spec.ts
+++ b/src/components/FwbSidebar/tests/FwbSidebarItem.spec.ts
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbSidebarItem from '../FwbSidebarItem.vue'
+
+describe('FwbSidebarItem', () => {
+  describe('default rendering', () => {
+    it('renders an <a> element by default', () => {
+      const wrapper = mount(FwbSidebarItem)
+      expect(wrapper.element.tagName).toBe('A')
+    })
+
+    it('sets href="/" by default', () => {
+      const wrapper = mount(FwbSidebarItem)
+      expect(wrapper.attributes('href')).toBe('/')
+    })
+  })
+
+  describe('link prop', () => {
+    it('passes a string link as href when tag is "a"', () => {
+      const wrapper = mount(FwbSidebarItem, { props: { link: '/dashboard' } })
+      expect(wrapper.attributes('href')).toBe('/dashboard')
+    })
+
+    it('falls back to href="/" when link is a route object and tag is "a"', () => {
+      const wrapper = mount(FwbSidebarItem, { props: { link: { name: 'home' } } })
+      expect(wrapper.attributes('href')).toBe('/')
+    })
+  })
+
+  describe('tag prop', () => {
+    it('uses the "to" attribute instead of "href" when tag is not "a"', () => {
+      const wrapper = mount(FwbSidebarItem, {
+        props: { tag: 'router-link', link: '/home' },
+        global: { stubs: { 'router-link': true } },
+      })
+      expect(wrapper.attributes('href')).toBeUndefined()
+      expect(wrapper.attributes('to')).toBe('/home')
+    })
+
+    it('passes a route object as "to" when tag is not "a"', () => {
+      const wrapper = mount(FwbSidebarItem, {
+        props: { tag: 'router-link', link: { name: 'home', params: { id: '1' } } },
+        global: { stubs: { 'router-link': true } },
+      })
+      expect(wrapper.attributes('href')).toBeUndefined()
+      expect(wrapper.attributes('to')).toBeDefined()
+    })
+  })
+})

--- a/src/components/FwbSidebar/tests/FwbSidebarLogo.spec.ts
+++ b/src/components/FwbSidebar/tests/FwbSidebarLogo.spec.ts
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbSidebarLogo from '../FwbSidebarLogo.vue'
+
+describe('FwbSidebarLogo', () => {
+  describe('default rendering', () => {
+    it('renders an <a> element by default', () => {
+      const wrapper = mount(FwbSidebarLogo)
+      expect(wrapper.element.tagName).toBe('A')
+    })
+
+    it('sets href="/" by default', () => {
+      const wrapper = mount(FwbSidebarLogo)
+      expect(wrapper.attributes('href')).toBe('/')
+    })
+  })
+
+  describe('alt prop', () => {
+    it('falls back to name as img alt text when alt is omitted', () => {
+      const wrapper = mount(FwbSidebarLogo, { props: { name: 'Flowbite', logo: '/logo.svg' } })
+      expect(wrapper.find('img').attributes('alt')).toBe('Flowbite')
+    })
+
+    it('uses the alt prop when explicitly provided', () => {
+      const wrapper = mount(FwbSidebarLogo, { props: { name: 'Flowbite', logo: '/logo.svg', alt: 'Company logo' } })
+      expect(wrapper.find('img').attributes('alt')).toBe('Company logo')
+    })
+  })
+
+  describe('link prop', () => {
+    it('passes a string link as href when tag is "a"', () => {
+      const wrapper = mount(FwbSidebarLogo, { props: { link: 'https://flowbite.com' } })
+      expect(wrapper.attributes('href')).toBe('https://flowbite.com')
+    })
+
+    it('falls back to href="/" when link is a route object and tag is "a"', () => {
+      const wrapper = mount(FwbSidebarLogo, { props: { link: { name: 'home' } } })
+      expect(wrapper.attributes('href')).toBe('/')
+    })
+  })
+
+  describe('tag prop', () => {
+    it('uses the "to" attribute instead of "href" when tag is not "a"', () => {
+      const wrapper = mount(FwbSidebarLogo, {
+        props: { tag: 'router-link', link: '/home' },
+        global: { stubs: { 'router-link': true } },
+      })
+      expect(wrapper.attributes('href')).toBeUndefined()
+      expect(wrapper.attributes('to')).toBe('/home')
+    })
+
+    it('passes a route object as "to" when tag is not "a"', () => {
+      const wrapper = mount(FwbSidebarLogo, {
+        props: { tag: 'router-link', link: { name: 'home' } },
+        global: { stubs: { 'router-link': true } },
+      })
+      expect(wrapper.attributes('href')).toBeUndefined()
+      expect(wrapper.attributes('to')).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Complete pass over every component documentation page in the repo. Each page was reviewed against a standard checklist and fixed where needed. Also fixes a silent runtime error in `FwbSidebarItem` / `FwbSidebarLogo` when Vue Router is not installed, and adds a markdownlint config to enforce consistent fence formatting.

## What changed

### Sidebar bug fix

**`FwbSidebarItem.vue`, `FwbSidebarLogo.vue`**
- Changed default `tag` prop from `'router-link'` to `'a'` — components now work out of the box without Vue Router
- Replaced the `resolveComponent()` guard with two simple computed values keyed directly on `props.tag`: `linkAttr` switches between `'href'` (when `tag === 'a'`) and `'to'` (everything else); `linkValue` falls back to `'/'` when `tag === 'a'` and `link` is a route object. Vue's `<component :is>` handles string tag names and component references natively at render time
- Widened `link` prop type from `string | { name: string }` to `string | Record<string, unknown>` on both components, accepting all Vue Router route location shapes (`{ name, params }`, `{ path, query }`, etc.)
- Changed `alt` default to `undefined` on `FwbSidebarLogo` so the `alt ?? name` fallback in the template actually fires when `alt` is omitted
- Updated sidebar logo example and docs snippet to use `link="https://flowbite.com"` instead of the stale `tag="router-link"`

### Docs checklist — applied to all 39 pages

- `:::tip` label updated to `ComponentName - Flowbite` format
- H1 follows `ComponentName - Flowbite Vue` format (done in prior commit)
- Section headings renamed to Title Case; dropped verbose prefixes (`Default toggle` → `Default`, `Prop - type` → `Default`, `## Demo` → `## Default`, etc.)
- Meaningful description added to every section (replaced boilerplate "use the following example")
- Blank lines enforced between live component instances and code fences (MD031)
- Blank lines enforced around headings (MD022)
- Code examples import from `'flowbite-vue'`, not relative paths
- API sections added or standardised: `## [Name] component API` header, `### Fwb[Name] Props` with Name/Type/Default/Description columns, Events and Slots tables where applicable

### Page-specific notable fixes

- **avatar** — removed duplicate `<script setup>` block
- **dropdown** — fixed stale prop references in section descriptions; corrected `content-class` → `content-wrapper-class`
- **footer** — restructured heavily duplicated content; added API for all sub-components; added `sr-text` to icon-only footer icon example
- **jumbotron** — removed 400-line duplicate content block; rewrote all section descriptions
- **navbar** — added full API for `FwbNavbar` and all sub-components
- **sidebar** — noted `tag` prop and router-link usage in API; added API for all sub-components; broadened default slot description to list all valid children
- **tabs** — corrected `click:pane` event: no payload, fires after the active tab has already changed (not before)
- **timeline** — renamed duplicate `## Timeline with Icons` heading to `## Horizontal Timeline`; removed stray `<br>` tag
- **toast** — fixed bug where `closable` and `type` attrs were merged into one word (`closabletype`) in the icon slot example
- **tooltip** — fixed relative import path (`../../../../src/index` → `'flowbite-vue'`) in the Button Group example

### Infra

- **`.markdownlint.json`** — added config enabling MD022/MD031/MD040 while disabling rules that conflict with VitePress conventions (MD013 line length, MD033 inline HTML, MD041 first heading)

## Test plan

- [x] `npm run lint` — 0 errors, 21 warnings (pre-existing `no-explicit-any`, unchanged)
- [x] `npm run build:types` — clean
- [x] `npm run test` — 275/275 passed