### PR TITLE
fix: restore Flowbite plugin for Tailwind v4; fix FwbSelect double arrow

### DIFF
--- a/src/components/FwbSelect/composables/useSelectClasses.ts
+++ b/src/components/FwbSelect/composables/useSelectClasses.ts
@@ -7,7 +7,7 @@ const defaultWrapperClasses = ''
 const defaultLabelClasses = 'block mb-2 font-medium text-gray-900 dark:text-white text-sm'
 const defaultHelperClasses = 'mt-2 text-gray-500 dark:text-gray-400 text-sm'
 
-const defaultSelectClasses = 'w-full appearance-none bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white shadow-xs focus:outline-hidden focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-500 dark:focus:border-blue-500'
+const defaultSelectClasses = 'w-full bg-none bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white shadow-xs focus:outline-hidden focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-500 dark:focus:border-blue-500'
 const borderSelectClasses = 'border border-gray-300 dark:border-gray-600 rounded-lg'
 const underlineSelectClasses = 'bg-transparent dark:bg-transparent border-b-2 border-gray-200 dark:border-gray-700 focus:outline-hidden focus:ring-0 focus:border-gray-200 peer'
 const disabledSelectClasses = 'cursor-not-allowed bg-gray-100'

--- a/src/style.css
+++ b/src/style.css
@@ -1,1 +1,2 @@
 @import 'tailwindcss';
+@plugin "flowbite/plugin";


### PR DESCRIPTION
## Summary

- Adds `@plugin "flowbite/plugin"` to `src/style.css`, restoring base CSS that was lost when `tailwind.config.js` was dropped in the Tailwind v4 migration (`8813901`). Affected elements: `[type='checkbox']`, `[type='radio']`, `input[type="range"]` (thumb), `[type='file']`, `select`.
- Fixes `FwbSelect` double arrow: the plugin injects a `background-image` SVG arrow on `select:not([size])`; since the component already renders its own absolutely-positioned chevron, the plugin arrow is suppressed with `bg-none`. The now-redundant `appearance-none` is removed (the plugin covers it via `@layer base`).

## Visual QA

All form components verified in the browser after the plugin was added:
- `FwbCheckbox` — styled correctly
- `FwbRadio` — styled correctly
- `FwbRange` — track and thumb render correctly
- `FwbFileInput` — styled correctly
- `FwbSelect` — single chevron (component's own SVG), no plugin arrow

## Test plan

- [x] `npm run lint` — 0 errors, 21 warnings (unchanged)
- [x] `npm run build:types` — clean
- [x] `npm run test` — 289/289 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined select component styling for improved consistency and appearance.
* **Chores**
  * Integrated Flowbite Tailwind plugin to enhance available component functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->