### PR TITLE
feat(badge): add pill, border, and dismissible variants

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -4,6 +4,9 @@ import FwbBadgeExampleSize from './badge/examples/FwbBadgeExampleSize.vue'
 import FwbBadgeExampleLink from './badge/examples/FwbBadgeExampleLink.vue'
 import FwbBadgeExampleIcon from './badge/examples/FwbBadgeExampleIcon.vue'
 import FwbBadgeExampleIconOnly from './badge/examples/FwbBadgeExampleIconOnly.vue'
+import FwbBadgeExamplePill from './badge/examples/FwbBadgeExamplePill.vue'
+import FwbBadgeExampleBorder from './badge/examples/FwbBadgeExampleBorder.vue'
+import FwbBadgeExampleDismissible from './badge/examples/FwbBadgeExampleDismissible.vue'
 </script>
 
 # Badge - Flowbite Vue
@@ -61,6 +64,71 @@ Use the `size` prop to control badge dimensions. `xs` is the default (smaller) s
 
 <script setup>
 import { FwbBadge } from 'flowbite-vue'
+</script>
+```
+
+## Pill Badges
+
+Set the `pill` prop to use fully rounded corners instead of the default slight rounding.
+
+<fwb-badge-example-pill />
+
+```vue
+<template>
+  <fwb-badge pill>Default</fwb-badge>
+  <fwb-badge pill type="dark">Dark</fwb-badge>
+  <fwb-badge pill type="red">Red</fwb-badge>
+  <fwb-badge pill type="green">Green</fwb-badge>
+  <fwb-badge pill type="yellow">Yellow</fwb-badge>
+  <fwb-badge pill type="indigo">Indigo</fwb-badge>
+  <fwb-badge pill type="purple">Purple</fwb-badge>
+  <fwb-badge pill type="pink">Pink</fwb-badge>
+</template>
+
+<script setup>
+import { FwbBadge } from 'flowbite-vue'
+</script>
+```
+
+## Border Badges
+
+Set the `border` prop to add a coloured outline to the badge. The dark mode background changes to neutral gray to keep the border visible.
+
+<fwb-badge-example-border />
+
+```vue
+<template>
+  <fwb-badge border>Default</fwb-badge>
+  <fwb-badge border type="dark">Dark</fwb-badge>
+  <fwb-badge border type="red">Red</fwb-badge>
+  <fwb-badge border type="green">Green</fwb-badge>
+  <fwb-badge border type="yellow">Yellow</fwb-badge>
+  <fwb-badge border type="indigo">Indigo</fwb-badge>
+  <fwb-badge border type="purple">Purple</fwb-badge>
+  <fwb-badge border type="pink">Pink</fwb-badge>
+</template>
+
+<script setup>
+import { FwbBadge } from 'flowbite-vue'
+</script>
+```
+
+## Dismissible Badges
+
+Set the `dismissible` prop to show a remove button inside the badge. Handle the `@dismiss` event to hide or remove the badge.
+
+<fwb-badge-example-dismissible />
+
+```vue
+<template>
+  <fwb-badge v-if="shown" dismissible @dismiss="shown = false">Default</fwb-badge>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbBadge } from 'flowbite-vue'
+
+const shown = ref(true)
 </script>
 ```
 
@@ -156,11 +224,20 @@ import { FwbBadge } from 'flowbite-vue'
 
 ### FwbBadge Props
 
-| Name | Type                                                                        | Default     | Description                                                    |
-| ---- | --------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------- |
-| type | `'default' \| 'dark' \| 'red' \| 'green' \| 'yellow' \| 'indigo' \| 'purple' \| 'pink'` | `'default'` | Sets the badge colour scheme. |
-| size | `'xs' \| 'sm'`                                                              | `'xs'`      | Controls badge padding and font size.                          |
-| href | `String`                                                                    | `null`      | When set, renders an `<a>` element instead of `<span>`.        |
+| Name        | Type                                                                        | Default     | Description                                                    |
+| ----------- | --------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------- |
+| type        | `'default' \| 'dark' \| 'red' \| 'green' \| 'yellow' \| 'indigo' \| 'purple' \| 'pink'` | `'default'` | Sets the badge colour scheme. |
+| size        | `'xs' \| 'sm'`                                                              | `'xs'`      | Controls badge padding and font size.                          |
+| href        | `String`                                                                    | `null`      | When set, renders an `<a>` element instead of `<span>`.        |
+| pill        | `Boolean`                                                                   | `false`     | Uses fully rounded corners (`rounded-full`).                   |
+| border      | `Boolean`                                                                   | `false`     | Adds a coloured border outline around the badge.               |
+| dismissible | `Boolean`                                                                   | `false`     | Shows a remove button inside the badge.                        |
+
+### FwbBadge Events
+
+| Name    | Payload | Description                                             |
+| ------- | ------- | ------------------------------------------------------- |
+| dismiss | -       | Emitted when the dismiss button is clicked.             |
 
 ### FwbBadge Slots
 

--- a/docs/components/badge/examples/FwbBadgeExampleBorder.vue
+++ b/docs/components/badge/examples/FwbBadgeExampleBorder.vue
@@ -1,13 +1,50 @@
 <template>
-  <div class="vp-raw flex flex-wrap gap-2">
-    <fwb-badge border>Default</fwb-badge>
-    <fwb-badge border type="dark">Dark</fwb-badge>
-    <fwb-badge border type="red">Red</fwb-badge>
-    <fwb-badge border type="green">Green</fwb-badge>
-    <fwb-badge border type="yellow">Yellow</fwb-badge>
-    <fwb-badge border type="indigo">Indigo</fwb-badge>
-    <fwb-badge border type="purple">Purple</fwb-badge>
-    <fwb-badge border type="pink">Pink</fwb-badge>
+  <div class="flex flex-wrap gap-2 vp-raw">
+    <fwb-badge border>
+      Default
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="dark"
+    >
+      Dark
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="red"
+    >
+      Red
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="green"
+    >
+      Green
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="yellow"
+    >
+      Yellow
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="indigo"
+    >
+      Indigo
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="purple"
+    >
+      Purple
+    </fwb-badge>
+    <fwb-badge
+      border
+      type="pink"
+    >
+      Pink
+    </fwb-badge>
   </div>
 </template>
 

--- a/docs/components/badge/examples/FwbBadgeExampleBorder.vue
+++ b/docs/components/badge/examples/FwbBadgeExampleBorder.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-2">
+    <fwb-badge border>Default</fwb-badge>
+    <fwb-badge border type="dark">Dark</fwb-badge>
+    <fwb-badge border type="red">Red</fwb-badge>
+    <fwb-badge border type="green">Green</fwb-badge>
+    <fwb-badge border type="yellow">Yellow</fwb-badge>
+    <fwb-badge border type="indigo">Indigo</fwb-badge>
+    <fwb-badge border type="purple">Purple</fwb-badge>
+    <fwb-badge border type="pink">Pink</fwb-badge>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbBadge } from '../../../../src/index'
+</script>

--- a/docs/components/badge/examples/FwbBadgeExampleDismissible.vue
+++ b/docs/components/badge/examples/FwbBadgeExampleDismissible.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-2">
+    <fwb-badge
+      v-if="shown.default"
+      dismissible
+      @dismiss="shown.default = false"
+    >
+      Default
+    </fwb-badge>
+    <fwb-badge
+      v-if="shown.dark"
+      dismissible
+      type="dark"
+      @dismiss="shown.dark = false"
+    >
+      Dark
+    </fwb-badge>
+    <fwb-badge
+      v-if="shown.green"
+      dismissible
+      type="green"
+      @dismiss="shown.green = false"
+    >
+      Green
+    </fwb-badge>
+    <fwb-badge
+      v-if="shown.red"
+      dismissible
+      type="red"
+      @dismiss="shown.red = false"
+    >
+      Red
+    </fwb-badge>
+    <button
+      class="text-xs underline text-gray-500"
+      @click="reset"
+    >
+      Reset
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { reactive } from 'vue'
+
+import { FwbBadge } from '../../../../src/index'
+
+const shown = reactive({ default: true, dark: true, green: true, red: true })
+const reset = () => Object.keys(shown).forEach(k => (shown[k as keyof typeof shown] = true))
+</script>

--- a/docs/components/badge/examples/FwbBadgeExamplePill.vue
+++ b/docs/components/badge/examples/FwbBadgeExamplePill.vue
@@ -1,13 +1,50 @@
 <template>
   <div class="vp-raw flex flex-wrap gap-2">
-    <fwb-badge pill>Default</fwb-badge>
-    <fwb-badge pill type="dark">Dark</fwb-badge>
-    <fwb-badge pill type="red">Red</fwb-badge>
-    <fwb-badge pill type="green">Green</fwb-badge>
-    <fwb-badge pill type="yellow">Yellow</fwb-badge>
-    <fwb-badge pill type="indigo">Indigo</fwb-badge>
-    <fwb-badge pill type="purple">Purple</fwb-badge>
-    <fwb-badge pill type="pink">Pink</fwb-badge>
+    <fwb-badge pill>
+      Default
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="dark"
+    >
+      Dark
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="red"
+    >
+      Red
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="green"
+    >
+      Green
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="yellow"
+    >
+      Yellow
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="indigo"
+    >
+      Indigo
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="purple"
+    >
+      Purple
+    </fwb-badge>
+    <fwb-badge
+      pill
+      type="pink"
+    >
+      Pink
+    </fwb-badge>
   </div>
 </template>
 

--- a/docs/components/badge/examples/FwbBadgeExamplePill.vue
+++ b/docs/components/badge/examples/FwbBadgeExamplePill.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-2">
+    <fwb-badge pill>Default</fwb-badge>
+    <fwb-badge pill type="dark">Dark</fwb-badge>
+    <fwb-badge pill type="red">Red</fwb-badge>
+    <fwb-badge pill type="green">Green</fwb-badge>
+    <fwb-badge pill type="yellow">Yellow</fwb-badge>
+    <fwb-badge pill type="indigo">Indigo</fwb-badge>
+    <fwb-badge pill type="purple">Purple</fwb-badge>
+    <fwb-badge pill type="pink">Pink</fwb-badge>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbBadge } from '../../../../src/index'
+</script>

--- a/src/components/FwbBadge/FwbBadge.vue
+++ b/src/components/FwbBadge/FwbBadge.vue
@@ -6,6 +6,30 @@
   >
     <slot name="icon" />
     <slot name="default" />
+    <button
+      v-if="dismissible"
+      type="button"
+      :class="dismissButtonClass"
+      aria-label="Remove badge"
+      @click="$emit('dismiss')"
+    >
+      <svg
+        aria-hidden="true"
+        class="h-2 w-2"
+        fill="none"
+        viewBox="0 0 14 14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+      </svg>
+      <span class="sr-only">Remove badge</span>
+    </button>
   </component>
 </template>
 
@@ -20,16 +44,25 @@ interface IBadgeProps {
   type?: BadgeType
   size?: BadgeSize
   href?: string | null
+  pill?: boolean
+  border?: boolean
+  dismissible?: boolean
 }
+
 const props = withDefaults(defineProps<IBadgeProps>(), {
   type: 'default',
   size: 'xs',
   href: null,
+  pill: false,
+  border: false,
+  dismissible: false,
 })
+
+defineEmits<{ dismiss: [] }>()
 
 const slots = useSlots()
 const isContentEmpty = computed(() => !slots.default)
 const wrapperType = computed(() => (props.href ? 'a' : 'span'))
 
-const { badgeClasses } = useBadgeClasses(props, { isContentEmpty })
+const { badgeClasses, dismissButtonClass } = useBadgeClasses(props, { isContentEmpty })
 </script>

--- a/src/components/FwbBadge/FwbBadge.vue
+++ b/src/components/FwbBadge/FwbBadge.vue
@@ -11,7 +11,7 @@
       type="button"
       :class="dismissButtonClass"
       aria-label="Remove badge"
-      @click="$emit('dismiss')"
+      @click.stop="$emit('dismiss')"
     >
       <svg
         aria-hidden="true"

--- a/src/components/FwbBadge/composables/useBadgeClasses.ts
+++ b/src/components/FwbBadge/composables/useBadgeClasses.ts
@@ -1,22 +1,14 @@
-import { twMerge } from 'tailwind-merge'
 import { computed, type Ref, useAttrs } from 'vue'
 
 import type { BadgeSize, BadgeType } from '../types'
 
+import { useMergeClasses } from '@/composables/useMergeClasses'
+
 const defaultBadgeClasses = 'mr-2 px-2.5 py-0.5 rounded flex items-center justify-center'
-const badgeLinkClasses = 'bg-blue-100 hover:bg-blue-200 text-blue-800 dark:text-blue-800 dark:hover:bg-blue-300'
+const pillBadgeClasses = 'rounded-full'
 const onlyIconClasses = 'p-1 rounded-full mr-2'
 
-const badgeTextClasses: Record<BadgeType, string> = {
-  default: 'text-blue-800 dark:text-blue-300',
-  dark: 'text-gray-800 dark:text-gray-300',
-  red: 'text-red-800 dark:text-red-300',
-  green: 'text-green-800 dark:text-green-300',
-  yellow: 'text-yellow-800 dark:text-yellow-300',
-  indigo: 'text-indigo-800 dark:text-indigo-300',
-  purple: 'text-purple-800 dark:text-purple-300',
-  pink: 'text-pink-800 dark:text-pink-300',
-}
+const badgeLinkClasses = 'bg-blue-100 hover:bg-blue-200 text-blue-800 dark:text-blue-800 dark:hover:bg-blue-300'
 
 const badgeTypeClasses: Record<BadgeType, string> = {
   default: 'bg-blue-100 dark:bg-blue-900',
@@ -29,15 +21,62 @@ const badgeTypeClasses: Record<BadgeType, string> = {
   pink: 'bg-pink-100 dark:bg-pink-900',
 }
 
+const badgeTextClasses: Record<BadgeType, string> = {
+  default: 'text-blue-800 dark:text-blue-300',
+  dark: 'text-gray-800 dark:text-gray-300',
+  red: 'text-red-800 dark:text-red-300',
+  green: 'text-green-800 dark:text-green-300',
+  yellow: 'text-yellow-800 dark:text-yellow-300',
+  indigo: 'text-indigo-800 dark:text-indigo-300',
+  purple: 'text-purple-800 dark:text-purple-300',
+  pink: 'text-pink-800 dark:text-pink-300',
+}
+
 const badgeSizeClasses: Record<BadgeSize, string> = {
   xs: 'text-xs font-semibold',
   sm: 'text-sm font-medium',
+}
+
+const badgeBorderTypeClasses: Record<BadgeType, string> = {
+  default: 'bg-blue-100 dark:bg-gray-700 border border-blue-400 dark:border-blue-400',
+  dark: 'bg-gray-100 dark:bg-gray-700 border border-gray-500 dark:border-gray-400',
+  red: 'bg-red-100 dark:bg-gray-700 border border-red-400 dark:border-red-400',
+  green: 'bg-green-100 dark:bg-gray-700 border border-green-400 dark:border-green-400',
+  yellow: 'bg-yellow-100 dark:bg-gray-700 border border-yellow-400 dark:border-yellow-400',
+  indigo: 'bg-indigo-100 dark:bg-gray-700 border border-indigo-400 dark:border-indigo-400',
+  purple: 'bg-purple-100 dark:bg-gray-700 border border-purple-400 dark:border-purple-400',
+  pink: 'bg-pink-100 dark:bg-gray-700 border border-pink-400 dark:border-pink-400',
+}
+
+const badgeBorderTextClasses: Record<BadgeType, string> = {
+  default: 'text-blue-800 dark:text-blue-400',
+  dark: 'text-gray-800 dark:text-gray-400',
+  red: 'text-red-800 dark:text-red-400',
+  green: 'text-green-800 dark:text-green-400',
+  yellow: 'text-yellow-800 dark:text-yellow-400',
+  indigo: 'text-indigo-800 dark:text-indigo-400',
+  purple: 'text-purple-800 dark:text-purple-400',
+  pink: 'text-pink-800 dark:text-pink-400',
+}
+
+const badgeDismissButtonClasses: Record<BadgeType, string> = {
+  default: 'text-blue-400 hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300',
+  dark: 'text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-gray-300',
+  red: 'text-red-400 hover:bg-red-200 hover:text-red-900 dark:hover:bg-red-800 dark:hover:text-red-300',
+  green: 'text-green-400 hover:bg-green-200 hover:text-green-900 dark:hover:bg-green-800 dark:hover:text-green-300',
+  yellow: 'text-yellow-400 hover:bg-yellow-200 hover:text-yellow-900 dark:hover:bg-yellow-800 dark:hover:text-yellow-300',
+  indigo: 'text-indigo-400 hover:bg-indigo-200 hover:text-indigo-900 dark:hover:bg-indigo-800 dark:hover:text-indigo-300',
+  purple: 'text-purple-400 hover:bg-purple-200 hover:text-purple-900 dark:hover:bg-purple-800 dark:hover:text-purple-300',
+  pink: 'text-pink-400 hover:bg-pink-200 hover:text-pink-900 dark:hover:bg-pink-800 dark:hover:text-pink-300',
 }
 
 export type UseBadgeClassesProps = {
   type: BadgeType
   size: BadgeSize
   href: string | null
+  pill: boolean
+  border: boolean
+  dismissible: boolean
 }
 export type UseBadgeClassesOptions = {
   isContentEmpty: Ref<boolean>
@@ -48,19 +87,50 @@ export function useBadgeClasses (
   options: UseBadgeClassesOptions,
 ): {
     badgeClasses: Ref<string>
+    dismissButtonClass: Ref<string>
   } {
   const attrs = useAttrs()
+
   const badgeClasses = computed<string>(() => {
-    return twMerge(
+    if (options.isContentEmpty.value) {
+      return useMergeClasses([
+        onlyIconClasses,
+        props.href
+          ? badgeLinkClasses
+          : props.border ? badgeBorderTypeClasses[props.type] : badgeTypeClasses[props.type],
+        props.href ? '' : (props.border ? badgeBorderTextClasses[props.type] : badgeTextClasses[props.type]),
+        attrs.class as string,
+      ])
+    }
+
+    if (props.href) {
+      return useMergeClasses([
+        defaultBadgeClasses,
+        props.pill ? pillBadgeClasses : '',
+        props.dismissible ? 'pr-1' : '',
+        badgeSizeClasses[props.size],
+        badgeLinkClasses,
+        attrs.class as string,
+      ])
+    }
+
+    return useMergeClasses([
+      defaultBadgeClasses,
+      props.pill ? pillBadgeClasses : '',
+      props.dismissible ? 'pr-1' : '',
       badgeSizeClasses[props.size],
-      props.href ? '' : badgeTypeClasses[props.type],
-      props.href ? '' : badgeTextClasses[props.type],
-      props.href ? badgeLinkClasses : '',
-      options.isContentEmpty.value ? onlyIconClasses : defaultBadgeClasses,
+      props.border ? badgeBorderTypeClasses[props.type] : badgeTypeClasses[props.type],
+      props.border ? badgeBorderTextClasses[props.type] : badgeTextClasses[props.type],
       attrs.class as string,
-    )
+    ])
   })
-  return {
-    badgeClasses,
-  }
+
+  const dismissButtonClass = computed<string>(() =>
+    useMergeClasses([
+      'inline-flex items-center p-1 ms-2 rounded-sm bg-transparent',
+      badgeDismissButtonClasses[props.type],
+    ]),
+  )
+
+  return { badgeClasses, dismissButtonClass }
 }

--- a/src/components/FwbBadge/composables/useBadgeClasses.ts
+++ b/src/components/FwbBadge/composables/useBadgeClasses.ts
@@ -95,10 +95,8 @@ export function useBadgeClasses (
     if (options.isContentEmpty.value) {
       return useMergeClasses([
         onlyIconClasses,
-        props.href
-          ? badgeLinkClasses
-          : props.border ? badgeBorderTypeClasses[props.type] : badgeTypeClasses[props.type],
-        props.href ? '' : (props.border ? badgeBorderTextClasses[props.type] : badgeTextClasses[props.type]),
+        props.border ? badgeBorderTypeClasses[props.type] : (props.href ? badgeLinkClasses : badgeTypeClasses[props.type]),
+        props.border ? badgeBorderTextClasses[props.type] : (props.href ? '' : badgeTextClasses[props.type]),
         attrs.class as string,
       ])
     }
@@ -109,7 +107,8 @@ export function useBadgeClasses (
         props.pill ? pillBadgeClasses : '',
         props.dismissible ? 'pr-1' : '',
         badgeSizeClasses[props.size],
-        badgeLinkClasses,
+        props.border ? badgeBorderTypeClasses[props.type] : badgeLinkClasses,
+        props.border ? badgeBorderTextClasses[props.type] : '',
         attrs.class as string,
       ])
     }

--- a/src/components/FwbBadge/tests/FwbBadge.spec.ts
+++ b/src/components/FwbBadge/tests/FwbBadge.spec.ts
@@ -1,0 +1,78 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbBadge from '../FwbBadge.vue'
+
+describe('FwbBadge', () => {
+  describe('default rendering', () => {
+    it('renders a <span> by default', () => {
+      const wrapper = mount(FwbBadge, { slots: { default: 'Default' } })
+      expect(wrapper.element.tagName).toBe('SPAN')
+    })
+
+    it('renders an <a> when href is set', () => {
+      const wrapper = mount(FwbBadge, { props: { href: '/link' }, slots: { default: 'Link' } })
+      expect(wrapper.element.tagName).toBe('A')
+      expect(wrapper.attributes('href')).toBe('/link')
+    })
+  })
+
+  describe('pill prop', () => {
+    it('applies rounded-full when pill is true', () => {
+      const wrapper = mount(FwbBadge, { props: { pill: true }, slots: { default: 'Pill' } })
+      expect(wrapper.classes()).toContain('rounded-full')
+    })
+
+    it('does not apply rounded-full by default', () => {
+      const wrapper = mount(FwbBadge, { slots: { default: 'Default' } })
+      expect(wrapper.classes()).not.toContain('rounded-full')
+    })
+  })
+
+  describe('border prop', () => {
+    it('applies a border class when border is true', () => {
+      const wrapper = mount(FwbBadge, { props: { border: true }, slots: { default: 'Bordered' } })
+      expect(wrapper.classes()).toContain('border')
+    })
+
+    it('does not apply border by default', () => {
+      const wrapper = mount(FwbBadge, { slots: { default: 'Default' } })
+      expect(wrapper.classes()).not.toContain('border')
+    })
+  })
+
+  describe('dismissible prop', () => {
+    it('renders a dismiss button when dismissible is true', () => {
+      const wrapper = mount(FwbBadge, { props: { dismissible: true }, slots: { default: 'Tag' } })
+      expect(wrapper.find('button').exists()).toBe(true)
+    })
+
+    it('does not render a dismiss button by default', () => {
+      const wrapper = mount(FwbBadge, { slots: { default: 'Tag' } })
+      expect(wrapper.find('button').exists()).toBe(false)
+    })
+
+    it('emits dismiss when the button is clicked', async () => {
+      const wrapper = mount(FwbBadge, { props: { dismissible: true }, slots: { default: 'Tag' } })
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.emitted('dismiss')).toHaveLength(1)
+    })
+  })
+
+  describe('icon-only mode', () => {
+    it('applies rounded-full for icon-only badges', () => {
+      const wrapper = mount(FwbBadge, { slots: { icon: '<svg />' } })
+      expect(wrapper.classes()).toContain('rounded-full')
+    })
+
+    it('applies type color classes for icon-only badges', () => {
+      const wrapper = mount(FwbBadge, { slots: { icon: '<svg />' } })
+      expect(wrapper.classes()).toContain('bg-blue-100')
+    })
+
+    it('applies type color classes for icon-only badges with a non-default type', () => {
+      const wrapper = mount(FwbBadge, { props: { type: 'green' }, slots: { icon: '<svg />' } })
+      expect(wrapper.classes()).toContain('bg-green-100')
+    })
+  })
+})

--- a/src/components/FwbBadge/tests/FwbBadge.spec.ts
+++ b/src/components/FwbBadge/tests/FwbBadge.spec.ts
@@ -59,6 +59,22 @@ describe('FwbBadge', () => {
     })
   })
 
+  describe('prop combinations', () => {
+    it('applies border classes when both href and border are set', () => {
+      const wrapper = mount(FwbBadge, { props: { href: '/link', border: true, type: 'green' }, slots: { default: 'Bordered Link' } })
+      expect(wrapper.element.tagName).toBe('A')
+      expect(wrapper.classes()).toContain('border')
+      expect(wrapper.classes()).toContain('bg-green-100')
+    })
+
+    it('emits dismiss when href and dismissible are both set', async () => {
+      const wrapper = mount(FwbBadge, { props: { href: '/link', dismissible: true }, slots: { default: 'Tag' } })
+      expect(wrapper.find('button').exists()).toBe(true)
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.emitted('dismiss')).toHaveLength(1)
+    })
+  })
+
   describe('icon-only mode', () => {
     it('applies rounded-full for icon-only badges', () => {
       const wrapper = mount(FwbBadge, { slots: { icon: '<svg />' } })


### PR DESCRIPTION
## Summary

Extends `FwbBadge` with three new variants:

- **`pill`** — applies `rounded-full` for fully rounded corners
- **`border`** — adds a coloured outline with per-type border and text classes; dark mode uses neutral gray background to keep the border visible
- **`dismissible`** — renders a remove button inside the badge with per-type hover colours; emits `@dismiss` when clicked

## Fixes

- Icon-only badges (no default slot, icon slot only) were missing their colour and text classes after the composable refactor — now resolved by running the same type/border resolution inside the icon-only branch
- Dismissible badges had excess right padding from `px-2.5`; a `pr-1` override via `twMerge` reduces it to match the button size

## Tests

Adds `FwbBadge.spec.ts` covering default rendering, `pill`, `border`, `dismissible`, and icon-only mode including a regression test for the colour bug.

## Docs

Adds Pill Badges, Border Badges, and Dismissible Badges sections with live examples and updated Props/Events/Slots API tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pill badge variant for rounded appearance
  * Added border badge variant for outlined styling
  * Added dismissible badge variant with a close button and `dismiss` event support

* **Documentation**
  * Expanded badge documentation with new usage examples for pill, border, and dismissible badges
  * Updated the badge API reference with new props and the `dismiss` event

* **Tests**
  * Added comprehensive test coverage for badge variants, styling combinations, and dismiss interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->