### PR TITLE
chore: unify import convention across components

### DIFF
--- a/src/components/FwbAccordion/FwbAccordion.vue
+++ b/src/components/FwbAccordion/FwbAccordion.vue
@@ -11,9 +11,10 @@
 import { nanoid } from 'nanoid'
 import { computed } from 'vue'
 
-import type { AccordionProps } from '@/components/FwbAccordion/types'
+import { useAccordionState } from './composables/useAccordionState'
 
-import { useAccordionState } from '@/components/FwbAccordion/composables/useAccordionState'
+import type { AccordionProps } from './types'
+
 import { useMergeClasses } from '@/composables/useMergeClasses'
 
 const accordionId = nanoid()

--- a/src/components/FwbAccordion/FwbAccordionHeader.vue
+++ b/src/components/FwbAccordion/FwbAccordionHeader.vue
@@ -22,10 +22,10 @@
 <script lang="ts" setup>
 import { computed, onMounted, ref } from 'vue'
 
-import type { AccordionHeaderProps, AccordionPanel } from './types'
+import { useAccordionHeaderClasses } from './composables/useAccordionHeaderClasses'
+import { useAccordionState } from './composables/useAccordionState'
 
-import { useAccordionHeaderClasses } from '@/components/FwbAccordion/composables/useAccordionHeaderClasses'
-import { useAccordionState } from '@/components/FwbAccordion/composables/useAccordionState'
+import type { AccordionHeaderProps, AccordionPanel } from './types'
 
 const props = withDefaults(
   defineProps<AccordionHeaderProps>(), {

--- a/src/components/FwbAccordion/FwbAccordionPanel.vue
+++ b/src/components/FwbAccordion/FwbAccordionPanel.vue
@@ -13,10 +13,9 @@ import { nanoid } from 'nanoid'
 import { computed, onMounted, type Ref, ref, watch } from 'vue'
 
 import { useAccordionPanelClasses } from './composables/useAccordionPanelClasses'
+import { useAccordionState } from './composables/useAccordionState'
 
-import type { AccordionPanelProps, AccordionState } from '@/components/FwbAccordion/types'
-
-import { useAccordionState } from '@/components/FwbAccordion/composables/useAccordionState'
+import type { AccordionPanelProps, AccordionState } from './types'
 
 const props = withDefaults(
   defineProps<AccordionPanelProps>(), {

--- a/src/components/FwbAccordion/composables/useAccordionState.ts
+++ b/src/components/FwbAccordion/composables/useAccordionState.ts
@@ -6,7 +6,7 @@ import type {
   GetAccordionPanelState,
   GetAccordionState,
   UseAccordionState,
-} from '@/components/FwbAccordion/types'
+} from '../types'
 
 const accordionStates = reactive<AccordionStates>({})
 

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -166,12 +166,11 @@ import {
   watch,
 } from 'vue'
 
-import FwbInput from '../FwbInput/FwbInput.vue'
-
 import { useAutocompleteClasses } from './composables/useAutocompleteClasses'
 
 import type { AutocompleteEmits, AutocompleteProps } from './types'
 
+import FwbInput from '@/components/FwbInput/FwbInput.vue'
 import { useFormFieldIds } from '@/composables/useFormFieldIds'
 
 defineOptions({ inheritAttrs: false })

--- a/src/components/FwbAvatar/FwbAvatar.vue
+++ b/src/components/FwbAvatar/FwbAvatar.vue
@@ -48,9 +48,9 @@
 <script lang="ts" setup>
 import { computed, type PropType, ref, toRefs, useSlots } from 'vue'
 
-import type { AvatarSize, AvatarStatus, AvatarStatusPosition } from './types'
+import { useAvatarClasses } from './composables/useAvatarClasses'
 
-import { useAvatarClasses } from '@/components/FwbAvatar/composables/useAvatarClasses'
+import type { AvatarSize, AvatarStatus, AvatarStatusPosition } from './types'
 
 const imageError = ref(false)
 

--- a/src/components/FwbAvatar/composables/useAvatarClasses.ts
+++ b/src/components/FwbAvatar/composables/useAvatarClasses.ts
@@ -6,7 +6,7 @@ import type {
   AvatarStatus,
   AvatarStatusPosition,
   AvatarType,
-} from '@/components/FwbAvatar/types'
+} from '../types'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
 

--- a/src/components/FwbCarousel/FwbCarousel.vue
+++ b/src/components/FwbCarousel/FwbCarousel.vue
@@ -86,7 +86,7 @@
 <script lang="ts" setup>
 import { onMounted, type PropType, ref } from 'vue'
 
-import type { PictureItem } from '@/components/FwbCarousel/types'
+import type { PictureItem } from './types'
 
 const props = defineProps({
   pictures: {

--- a/src/components/FwbTabs/composables/useTabClasses.ts
+++ b/src/components/FwbTabs/composables/useTabClasses.ts
@@ -1,9 +1,8 @@
 import { computed, type Ref, unref } from 'vue'
 
-import { useFlowbiteThemable } from '../../utils/FlowbiteThemable/composables/useFlowbiteThemable'
-
 import type { TabsVariant } from './../types'
 
+import { useFlowbiteThemable } from '@/components/utils/FlowbiteThemable/composables/useFlowbiteThemable'
 import { useMergeClasses } from '@/composables/useMergeClasses'
 
 export type TabClassMap = {

--- a/src/components/utils/FwbSlotListener/FwbSlotListener.vue
+++ b/src/components/utils/FwbSlotListener/FwbSlotListener.vue
@@ -2,7 +2,7 @@
 import { pick } from 'lodash-es'
 import { defineComponent, type PropType, type VNode } from 'vue'
 
-import type { SlotListenerTrigger, TriggerEventHandlers } from '@/components/utils/FwbSlotListener/types'
+import type { SlotListenerTrigger, TriggerEventHandlers } from './types'
 
 import { getFirstSlotVNode } from '@/utils/getFirstSlotNode'
 


### PR DESCRIPTION
## Summary

Standardizes the import convention across the library: relative imports (`./`, `../`) for anything within a component's own directory tree, and the `@/` alias for anything crossing component boundaries or referencing shared/top-level code (`src/index.ts`, `src/composables.ts`, `src/utils`, etc.).

Surveyed all imports in `src/` and found the convention already held in the vast majority of the codebase, with a handful of exceptions:

- **`FwbTabs/composables/useTabClasses.ts`** — multi-level relative import of `useFlowbiteThemable` → `@/` alias (it crosses into `components/utils/`)
- **`FwbAutocomplete.vue`** — relative import of `FwbInput.vue` → `@/` alias (crosses into a sibling component)
- **`FwbAvatar`, `FwbCarousel`, `FwbSlotListener`, and all of `FwbAccordion`'s files** — were importing their own types/composables via the full `@/components/...` path instead of a relative one; switched to relative since these stay within the component's own directory

No behavior change — pure import path cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal module imports across accordion, avatar, carousel, tabs, autocomplete, and slot listener components.
  * Improved consistency between local component imports and shared utility imports.
  * No visible behavior, component APIs, or interaction flows were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->