### PR TITLE
feat(forms): add validationMessage string prop to all form components

### DIFF
--- a/docs/components/autocomplete.md
+++ b/docs/components/autocomplete.md
@@ -152,7 +152,7 @@ const countries = [
 
 ## Validation
 
-Set `validationStatus` to `'success'` or `'error'` to apply the corresponding colour scheme. Use the `validationMessage` slot to render feedback text below the input.
+Set `validationStatus` to `'success'` or `'error'` to apply the corresponding colour scheme. Use the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string) to render feedback text below the input. The slot takes priority when both are given.
 
 <fwb-autocomplete-example-validation />
 
@@ -177,12 +177,9 @@ Set `validationStatus` to `'success'` or `'error'` to apply the corresponding co
     :search-fields="['name']"
     display="name"
     label="Select a country"
+    validation-message="Oh, snap! Please select a country."
     validation-status="error"
-  >
-    <template #validationMessage>
-      <span class="font-medium">Oh, snap!</span> Please select a country.
-    </template>
-  </fwb-autocomplete>
+  />
 </template>
 
 <script setup>
@@ -478,6 +475,7 @@ const countries = [
 | remote           | `boolean`                           | `false`              | Disables local filtering; relies on `@search` to populate `options`.   |
 | debounce         | `number`                            | `300`                | Delay in ms before emitting `search` when `remote` is `true`.          |
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'`      | `'md'`               | Controls padding and font size of the input.                           |
+| validationMessage | `string`                           | `undefined`          | Validation feedback text; fallback for the `validationMessage` slot.   |
 | validationStatus | `'success' \| 'error'`              | `undefined`          | Applies success or error colour styles.                                |
 | class            | `String \| Object`                  | `''`                 | Added to the input wrapper element.                                    |
 | inputClass       | `String \| Object`                  | `''`                 | Added to the `<input>` element (use for text and placeholder colours). |
@@ -489,7 +487,7 @@ const countries = [
 | zIndex           | `number`                            | `100`                | Z-index of the dropdown overlay.                                       |
 
 :::tip Accessibility
-`aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and merged with any `aria-describedby` value you pass as an attribute.
+`aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and merged with any `aria-describedby` value you pass as an attribute.
 :::
 
 ### FwbAutocomplete Events
@@ -506,5 +504,5 @@ const countries = [
 | ----------------- | ----------------------------------------- | ------------------------------------------------------------- |
 | option            | `{ option: T, index: number }`            | Custom template for rendering each dropdown option.           |
 | suffix            | `{ loading: boolean, clear: () => void }` | Replaces the default search/clear/loading icons in the input. |
-| validationMessage | —                                         | Validation feedback rendered below the input.                 |
+| validationMessage | —                                         | Validation feedback rendered below the input. Takes priority over the `validationMessage` prop. |
 | helper            | —                                         | Helper text rendered below the input.                         |

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleValidation.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleValidation.vue
@@ -21,12 +21,9 @@
       display="name"
       label="Select a country"
       placeholder="Search countries..."
+      validation-message="Oh, snap! Please select a country."
       validation-status="error"
-    >
-      <template #validationMessage>
-        <span class="font-medium">Oh, snap!</span> Please select a country.
-      </template>
-    </fwb-autocomplete>
+    />
   </div>
 </template>
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -114,7 +114,7 @@ const fruits = ['Apple', 'Banana', 'Orange', 'Strawberry']
 
 ## Validation
 
-Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the checkbox.
+Use `validationStatus` together with the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string) to show success or error feedback below the checkbox. The slot takes priority when both are given.
 
 <fwb-checkbox-example-validation />
 
@@ -125,11 +125,12 @@ Use `validationStatus` together with the `validationMessage` slot to show succes
       <span class="font-medium">Great!</span> You have accepted the terms.
     </template>
   </fwb-checkbox>
-  <fwb-checkbox v-model="check2" label="Terms not accepted (error)" validation-status="error">
-    <template #validationMessage>
-      <span class="font-medium">Required!</span> You must accept the terms to continue.
-    </template>
-  </fwb-checkbox>
+  <fwb-checkbox
+    v-model="check2"
+    label="Terms not accepted (error)"
+    validation-message="Required! You must accept the terms to continue."
+    validation-status="error"
+  />
 </template>
 ```
 
@@ -182,11 +183,12 @@ Use dedicated props to pass classes to individual elements inside the checkbox.
 | label            | `String`               | `''`        | Label text rendered next to the checkbox. Ignored when the default slot is used. |
 | labelClass       | `String \| Object`     | `''`        | Added to the label text element.                                                 |
 | modelValue       | `Boolean \| Array`     | `false`     | The current value (use with `v-model`). Pass an array for group checkboxes.      |
+| validationMessage | `String`              | `undefined` | Validation feedback text; fallback for the `validationMessage` slot.             |
 | validationStatus | `'success' \| 'error'` | `undefined` | Applies success or error colour styles to the label text.                        |
 | wrapperClass     | `String \| Object`     | `''`        | Added to the outer root `<div>`.                                                 |
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop or default slot is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
+`aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop or default slot is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
 :::
 
 ### FwbCheckbox Slots
@@ -195,4 +197,4 @@ Use dedicated props to pass classes to individual elements inside the checkbox.
 | ----------------- | ------------------------------------------------------------------------------------ |
 | default           | Rich label content rendered next to the checkbox (takes priority over `label` prop). |
 | helper            | Helper text rendered below the checkbox.                                             |
-| validationMessage | Validation feedback rendered below the checkbox (styled by `validationStatus`).      |
+| validationMessage | Validation feedback rendered below the checkbox (styled by `validationStatus`). Takes priority over the `validationMessage` prop. |

--- a/docs/components/checkbox/examples/FwbCheckboxExampleValidation.vue
+++ b/docs/components/checkbox/examples/FwbCheckboxExampleValidation.vue
@@ -12,12 +12,9 @@
     <fwb-checkbox
       v-model="check2"
       label="Terms not accepted (error)"
+      validation-message="Required! You must accept the terms to continue."
       validation-status="error"
-    >
-      <template #validationMessage>
-        <span class="font-medium">Required!</span> You must accept the terms to continue.
-      </template>
-    </fwb-checkbox>
+    />
   </div>
 </template>
 

--- a/docs/components/fileInput.md
+++ b/docs/components/fileInput.md
@@ -132,7 +132,7 @@ const file = ref(null)
 
 ## Validation
 
-Set `validation-status` to `'success'` or `'error'` and use the `validationMessage` slot to display contextual feedback.
+Set `validation-status` to `'success'` or `'error'` and use the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string) to display contextual feedback. The slot takes priority when both are given.
 
 <fwb-file-input-example-validation />
 
@@ -142,12 +142,9 @@ Set `validation-status` to `'success'` or `'error'` and use the `validationMessa
     <fwb-file-input
       v-model="file"
       validation-status="error"
+      validation-message="Please select a valid file."
       label="Upload file"
-    >
-      <template #validationMessage>
-        Please select a valid file.
-      </template>
-    </fwb-file-input>
+    />
     <fwb-file-input
       v-model="file"
       validation-status="success"
@@ -274,15 +271,16 @@ const file = ref(null)
 | labelClass       | `String \| Object`                    | `''`        | Added to the label element (`<label>` in default mode, `<span>` in dropzone mode).              |
 | multiple         | `Boolean`                             | `false`     | Allows selecting multiple files.                                                                |
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'`        | `'md'`      | Controls the padding and font size of the file selector button.                                 |
+| validationMessage | `String`                             | `undefined` | Validation feedback text; fallback for the `validationMessage` slot.                            |
 | validationStatus | `'success' \| 'error'`                | `undefined` | Sets the validation state of the input.                                                         |
 | wrapperClass     | `String \| Object`                    | `''`        | Added to the outermost wrapper `<div>`.                                                         |
 
 :::warning Dropzone mode limitations
-`class` and `size` have no effect in dropzone mode. `validationStatus` changes the label color only — input styling and validation messages are not rendered. `helper` and `validationMessage` slots are not rendered in dropzone mode.
+`class` and `size` have no effect in dropzone mode. `validationStatus` changes the label color only — input styling and validation messages are not rendered. `helper` slot, `validationMessage` slot, and `validationMessage` prop are not rendered in dropzone mode.
 :::
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. These apply to the default (non-dropzone) rendering only.
+`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. These apply to the default (non-dropzone) rendering only.
 :::
 
 ### FwbFileInput Slots
@@ -290,5 +288,5 @@ const file = ref(null)
 | Name                | Description                                                                         |
 | ------------------- | ----------------------------------------------------------------------------------- |
 | helper              | Helper text shown below the input. Linked via `aria-describedby`.                   |
-| validationMessage   | Validation feedback shown below the input. Linked via `aria-describedby`.           |
+| validationMessage   | Validation feedback shown below the input. Linked via `aria-describedby`. Takes priority over the `validationMessage` prop. |
 | dropzonePlaceholder | Custom content for the dropzone upload prompt (replaces default "Click to upload"). |

--- a/docs/components/fileInput/examples/FwbFileInputExampleValidation.vue
+++ b/docs/components/fileInput/examples/FwbFileInputExampleValidation.vue
@@ -3,12 +3,9 @@
     <fwb-file-input
       v-model="file"
       validation-status="error"
+      validation-message="Please select a valid file."
       label="Upload file"
-    >
-      <template #validationMessage>
-        Please select a valid file.
-      </template>
-    </fwb-file-input>
+    />
     <fwb-file-input
       v-model="file"
       validation-status="success"

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -178,7 +178,7 @@ const value = ref('A pre-filled value')
 ## Validation
 
 - Set validation status via `validationStatus` prop, which accepts `'success'` or `'error'`.
-- Add validation message via `validationMessage` slot.
+- Add a validation message via the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string). The slot takes priority when both are given.
 
 <fwb-input-example-validation />
 ```vue
@@ -200,12 +200,9 @@ const value = ref('A pre-filled value')
     label="Your name"
     placeholder="Error input"
     required
+    validation-message="Oh, snap! Some error message."
     validation-status="error"
-  >
-    <template #validationMessage>
-      <span class="font-medium">Oh, snap!</span> Some error message.
-    </template>
-  </fwb-input>
+  />
 </template>
 
 <script lang="ts" setup>
@@ -399,11 +396,12 @@ const name = ref('')
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`      | Controls input padding and font size.                                                           |
 | suffixClass      | `String \| Object`             | `''`        | Added to the suffix slot container. Overrides addon default colors when used with text content. |
 | type             | `InputType`                    | `'text'`    | Native HTML input type (e.g. `email`, `password`, `number`).                                    |
+| validationMessage | `String`                      | `undefined` | Validation feedback text; fallback for the `validationMessage` slot.                            |
 | validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error color scheme.                                                          |
 | wrapperClass     | `String \| Object`             | `''`        | Added to the outermost wrapper element.                                                         |
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
+`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
 :::
 
 ### FwbInput Slots
@@ -413,4 +411,4 @@ const name = ref('')
 | prefix            | Content rendered on the left side of the input (icon, text, or addon span).  |
 | suffix            | Content rendered on the right side of the input (button or icon).            |
 | helper            | Helper text rendered below the input.                                        |
-| validationMessage | Validation feedback rendered below the input (styled by `validationStatus`). |
+| validationMessage | Validation feedback rendered below the input (styled by `validationStatus`). Takes priority over the `validationMessage` prop. |

--- a/docs/components/input/examples/FwbInputExampleValidation.vue
+++ b/docs/components/input/examples/FwbInputExampleValidation.vue
@@ -17,12 +17,9 @@
       label="Your name"
       placeholder="Error input"
       required
+      validation-message="Oh, snap! Some error message."
       validation-status="error"
-    >
-      <template #validationMessage>
-        <span class="font-medium">Oh, snap!</span> Some error message.
-      </template>
-    </fwb-input>
+    />
   </div>
 </template>
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -254,7 +254,7 @@ const picked = ref('one')
 
 ## Validation
 
-Use `validationStatus` on `FwbRadioGroup` together with the `validationMessage` slot to show success or error feedback below the group.
+Use `validationStatus` on `FwbRadioGroup` together with the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string) to show success or error feedback below the group. The slot takes priority when both are given.
 
 <fwb-radio-example-validation />
 ```vue
@@ -268,12 +268,14 @@ Use `validationStatus` on `FwbRadioGroup` together with the `validationMessage` 
       </template>
     </fwb-radio-group>
 
-    <fwb-radio-group name="fruit-error" label="Pick a fruit (error)" validation-status="error">
+    <fwb-radio-group
+      name="fruit-error"
+      label="Pick a fruit (error)"
+      validation-message="Required! Please select a fruit to continue."
+      validation-status="error"
+    >
       <fwb-radio v-model="picked2" label="Apple" value="apple" />
       <fwb-radio v-model="picked2" label="Banana" value="banana" />
-      <template #validationMessage>
-        <span class="font-medium">Required!</span> Please select a fruit to continue.
-      </template>
     </fwb-radio-group>
   </div>
 </template>
@@ -386,7 +388,7 @@ When a `FwbRadio` is inside a `FwbRadioGroup` with `validationStatus="error"`, `
 ### FwbRadioGroup Props
 
 :::tip Accessibility
-`FwbRadioGroup` renders as a `<fieldset>` with a `<legend>`. `aria-invalid="true"` is set on every child `FwbRadio` when `validationStatus="error"`. `aria-describedby` on the fieldset is wired to the IDs of any rendered `validationMessage` and `helper` slots.
+`FwbRadioGroup` renders as a `<fieldset>` with a `<legend>`. `aria-invalid="true"` is set on every child `FwbRadio` when `validationStatus="error"`. `aria-describedby` on the fieldset is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots.
 :::
 
 | Name             | Type                   | Default     | Description                                                                     |
@@ -394,6 +396,7 @@ When a `FwbRadio` is inside a `FwbRadioGroup` with `validationStatus="error"`, `
 | label            | `String`               | `''`        | Legend text for the group. Ignored when the `legend` slot is used.              |
 | legendClass      | `String \| Object`     | `''`        | Added to the `<legend>` element.                                                |
 | name             | `String`               | —           | **Required.** Shared `name` attribute provided to all child `FwbRadio` inputs.  |
+| validationMessage | `String`              | `undefined` | Validation feedback text; fallback for the `validationMessage` slot.            |
 | validationStatus | `'success' \| 'error'` | `undefined` | Applies success or error colour styles and sets `aria-invalid` on child radios. |
 | wrapperClass     | `String \| Object`     | `''`        | Added to the outer `<fieldset>` element.                                        |
 
@@ -404,4 +407,4 @@ When a `FwbRadio` is inside a `FwbRadioGroup` with `validationStatus="error"`, `
 | default           | Container for `FwbRadio` instances.                                          |
 | legend            | Rich legend content (takes priority over `label` prop).                      |
 | helper            | Helper text rendered below the group.                                        |
-| validationMessage | Validation feedback rendered below the group (styled by `validationStatus`). |
+| validationMessage | Validation feedback rendered below the group (styled by `validationStatus`). Takes priority over the `validationMessage` prop. |

--- a/docs/components/radio/examples/FwbRadioExampleValidation.vue
+++ b/docs/components/radio/examples/FwbRadioExampleValidation.vue
@@ -23,6 +23,7 @@
     <fwb-radio-group
       name="fruit-error"
       label="Pick a fruit (error)"
+      validation-message="Required! Please select a fruit to continue."
       validation-status="error"
     >
       <fwb-radio
@@ -35,9 +36,6 @@
         label="Banana"
         value="banana"
       />
-      <template #validationMessage>
-        <span class="font-medium">Required!</span> Please select a fruit to continue.
-      </template>
     </fwb-radio-group>
   </div>
 </template>

--- a/docs/components/range.md
+++ b/docs/components/range.md
@@ -103,7 +103,7 @@ Use the `size` prop to control the height of the slider track and thumb. Availab
 
 ## Validation
 
-Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the range.
+Use `validationStatus` together with the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string) to show success or error feedback below the range. The slot takes priority when both are given.
 
 <fwb-range-example-validation />
 ```vue
@@ -113,11 +113,12 @@ Use `validationStatus` together with the `validationMessage` slot to show succes
       <span class="font-medium">Looks good!</span> Volume is set correctly.
     </template>
   </fwb-range>
-  <fwb-range v-model.number="value" label="Volume (error)" validation-status="error">
-    <template #validationMessage>
-      <span class="font-medium">Too loud!</span> Please lower the volume.
-    </template>
-  </fwb-range>
+  <fwb-range
+    v-model.number="value"
+    label="Volume (error)"
+    validation-message="Too loud! Please lower the volume."
+    validation-status="error"
+  />
 </template>
 ```
 
@@ -172,6 +173,7 @@ Use dedicated props to pass classes to individual elements.
 | modelValue       | `Number`                       | `50`        | The current value (use with `v-model`).                                            |
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`      | Controls track height and thumb size.                                              |
 | steps            | `Number`                       | `1`         | Step increment between values.                                                     |
+| validationMessage | `String`                      | `undefined` | Validation feedback text; fallback for the `validationMessage` slot.               |
 | validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error colour styles to the label.                               |
 | wrapperClass     | `String \| Object`             | `''`        | Added to the outer root `<div>`.                                                   |
 
@@ -181,7 +183,7 @@ The thumb colour defaults to blue-500 and can be overridden by setting the `--fw
 :::
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
+`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
 :::
 
 ### FwbRange Slots
@@ -189,4 +191,4 @@ The thumb colour defaults to blue-500 and can be overridden by setting the `--fw
 | Name              | Description                                                                  |
 | ----------------- | ---------------------------------------------------------------------------- |
 | helper            | Helper text rendered below the range input.                                  |
-| validationMessage | Validation feedback rendered below the input (styled by `validationStatus`). |
+| validationMessage | Validation feedback rendered below the input (styled by `validationStatus`). Takes priority over the `validationMessage` prop. |

--- a/docs/components/range/examples/FwbRangeExampleValidation.vue
+++ b/docs/components/range/examples/FwbRangeExampleValidation.vue
@@ -12,12 +12,9 @@
     <fwb-range
       v-model.number="value"
       label="Volume (error)"
+      validation-message="Too loud! Please lower the volume."
       validation-status="error"
-    >
-      <template #validationMessage>
-        <span class="font-medium">Too loud!</span> Please lower the volume.
-      </template>
-    </fwb-range>
+    />
   </div>
 </template>
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -189,7 +189,7 @@ const countries = [
 ## Validation
 
 - Set validation status via `validationStatus` prop, which accepts `'success'` or `'error'`.
-- Add validation message via `validationMessage` slot.
+- Add a validation message via the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string). The slot takes priority when both are given.
 
 <fwb-select-example-validation />
 ```vue
@@ -209,12 +209,9 @@ const countries = [
     v-model="selected"
     :options="countries"
     label="Select a country"
+    validation-message="Oh, snap! Please select a country."
     validation-status="error"
-  >
-    <template #validationMessage>
-      <span class="font-medium">Oh, snap!</span> Please select a country.
-    </template>
-  </fwb-select>
+  />
 </template>
 
 <script setup>
@@ -363,11 +360,12 @@ const countries = [
 | required         | `Boolean`                      | `false`               | Sets the `required` attribute.                   |
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`                | Controls padding and font size.                  |
 | underline        | `Boolean`                      | `false`               | Uses the underline style variant.                |
+| validationMessage | `String`                      | `undefined`           | Validation feedback text; fallback for the `validationMessage` slot. |
 | validationStatus | `'success' \| 'error'`         | `undefined`           | Applies success or error colour styles.          |
 | wrapperClass     | `String \| Object`             | `''`                  | Added to the outer root `<div>`.                 |
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native select when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
+`aria-invalid="true"` is set automatically on the native select when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
 :::
 
 ### FwbSelect Slots
@@ -376,4 +374,4 @@ const countries = [
 | ----------------- | ----------------------------------------------------------------------------- |
 | chevron           | Replaces the default chevron icon inside the select.                          |
 | helper            | Helper text rendered below the select.                                        |
-| validationMessage | Validation feedback rendered below the select (styled by `validationStatus`). |
+| validationMessage | Validation feedback rendered below the select (styled by `validationStatus`). Takes priority over the `validationMessage` prop. |

--- a/docs/components/select/examples/FwbSelectExampleValidation.vue
+++ b/docs/components/select/examples/FwbSelectExampleValidation.vue
@@ -15,12 +15,9 @@
       v-model="selected"
       :options="countries"
       label="Select a country"
+      validation-message="Oh, snap! Please select a country."
       validation-status="error"
-    >
-      <template #validationMessage>
-        <span class="font-medium">Oh, snap!</span> Please select a country.
-      </template>
-    </fwb-select>
+    />
   </div>
 </template>
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -101,7 +101,7 @@ const message = ref('Some content')
 
 ## Validation
 
-Set `validation-status` to `'success'` or `'error'` and use the `validationMessage` or `helper` slots to display contextual feedback.
+Set `validation-status` to `'success'` or `'error'` and use the `validationMessage` slot (rich content), the `validationMessage` prop (plain string), or the `helper` slot to display contextual feedback. The slot takes priority over the prop when both are given.
 
 <fwb-textarea-example-validation />
 
@@ -111,13 +111,10 @@ Set `validation-status` to `'success'` or `'error'` and use the `validationMessa
     <fwb-textarea
       v-model="message"
       validation-status="error"
+      validation-message="This field is required."
       label="Your message"
       placeholder="Write your message..."
-    >
-      <template #validationMessage>
-        This field is required.
-      </template>
-    </fwb-textarea>
+    />
     <fwb-textarea
       v-model="message"
       validation-status="success"
@@ -263,11 +260,12 @@ const message = ref('')
 | rows             | `Number`                              | `4`         | Number of visible text rows.                          |
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'`        | `'md'`      | Controls padding and font size.                       |
 | textareaClass    | `String \| Object`                    | `''`        | Added to the `<textarea>` element.                    |
+| validationMessage | `String`                             | `undefined` | Validation feedback text; fallback for the `validationMessage` slot. |
 | validationStatus | `'success' \| 'error'`                | `undefined` | Sets the validation state of the textarea.            |
 | wrapperClass     | `String \| Object`                    | `''`        | Added to the outermost wrapper `<div>`.               |
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native textarea when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
+`aria-invalid="true"` is set automatically on the native textarea when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
 :::
 
 ### FwbTextarea Slots
@@ -275,5 +273,5 @@ const message = ref('')
 | Name              | Description                                                                            |
 | ----------------- | -------------------------------------------------------------------------------------- |
 | footer            | Content rendered inside the textarea wrapper below the text area (e.g. submit button). |
-| validationMessage | Validation feedback shown below the wrapper. Linked via `aria-describedby`.            |
+| validationMessage | Validation feedback shown below the wrapper. Linked via `aria-describedby`. Takes priority over the `validationMessage` prop. |
 | helper            | Helper text shown below the wrapper. Linked via `aria-describedby`.                    |

--- a/docs/components/textarea/examples/FwbTextareaExampleValidation.vue
+++ b/docs/components/textarea/examples/FwbTextareaExampleValidation.vue
@@ -3,13 +3,10 @@
     <fwb-textarea
       v-model="message"
       validation-status="error"
+      validation-message="This field is required."
       label="Your message"
       placeholder="Write your message..."
-    >
-      <template #validationMessage>
-        This field is required.
-      </template>
-    </fwb-textarea>
+    />
     <fwb-textarea
       v-model="message"
       validation-status="success"

--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -126,7 +126,7 @@ Add the `reverse` prop to place the label text to the left of the toggle instead
 
 ## Validation
 
-Use `validationStatus` together with the `validationMessage` slot to show success or error feedback below the toggle.
+Use `validationStatus` together with the `validationMessage` slot (rich content) or the `validationMessage` prop (plain string) to show success or error feedback below the toggle. The slot takes priority when both are given.
 
 <fwb-toggle-example-validation />
 
@@ -137,11 +137,12 @@ Use `validationStatus` together with the `validationMessage` slot to show succes
       <span class="font-medium">Great!</span> Notifications are enabled.
     </template>
   </fwb-toggle>
-  <fwb-toggle v-model="toggle2" label="Location (error)" validation-status="error">
-    <template #validationMessage>
-      <span class="font-medium">Required!</span> Location access must be enabled.
-    </template>
-  </fwb-toggle>
+  <fwb-toggle
+    v-model="toggle2"
+    label="Location (error)"
+    validation-message="Required! Location access must be enabled."
+    validation-status="error"
+  />
 </template>
 ```
 
@@ -197,11 +198,12 @@ Use dedicated props to pass classes to individual elements.
 | modelValue       | `Boolean`                      | `false`     | The current value (use with `v-model`).                                          |
 | reverse          | `Boolean`                      | `false`     | Places the label text to the left of the toggle.                                 |
 | size             | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`      | Controls the size of the toggle track and thumb.                                 |
+| validationMessage | `String`                      | `undefined` | Validation feedback text; fallback for the `validationMessage` slot.             |
 | validationStatus | `'success' \| 'error'`         | `undefined` | Applies success or error colour styles to the label text.                        |
 | wrapperClass     | `String \| Object`             | `''`        | Added to the outer root `<div>`.                                                 |
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
+`aria-invalid="true"` is set automatically on the native checkbox when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. When no `label` prop is provided, pass `aria-label` as an attribute to maintain an accessible name — it is forwarded directly to the `<input>`.
 :::
 
 ### FwbToggle Slots
@@ -209,4 +211,4 @@ Use dedicated props to pass classes to individual elements.
 | Name              | Description                                                                   |
 | ----------------- | ----------------------------------------------------------------------------- |
 | helper            | Helper text rendered below the toggle.                                        |
-| validationMessage | Validation feedback rendered below the toggle (styled by `validationStatus`). |
+| validationMessage | Validation feedback rendered below the toggle (styled by `validationStatus`). Takes priority over the `validationMessage` prop. |

--- a/docs/components/toggle/examples/FwbToggleExampleValidation.vue
+++ b/docs/components/toggle/examples/FwbToggleExampleValidation.vue
@@ -12,12 +12,9 @@
     <fwb-toggle
       v-model="toggle2"
       label="Location (error)"
+      validation-message="Required! Location access must be enabled."
       validation-status="error"
-    >
-      <template #validationMessage>
-        <span class="font-medium">Required!</span> Location access must be enabled.
-      </template>
-    </fwb-toggle>
+    />
   </div>
 </template>
 

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -136,12 +136,14 @@
     </div>
 
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
       data-testid="fwb-autocomplete-validation-message"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -193,6 +195,7 @@ const props = withDefaults(
     labelClass: '',
     dropdownClass: '',
     loading: false,
+    validationMessage: undefined,
     validationStatus: undefined,
     inputComponent: FwbInput,
     inputProps: () => ({}),
@@ -220,7 +223,7 @@ const {
 
 const _id = useId()
 const autocompleteId = computed(() => _id)
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(autocompleteId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(autocompleteId, computed(() => props.validationMessage))
 
 const filteredOptions = computed(() => {
   if (props.remote || inputValue.value.length < props.minChars) {

--- a/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
+++ b/src/components/FwbAutocomplete/tests/Autocomplete.spec.ts
@@ -582,4 +582,29 @@ describe('FwbAutocomplete', () => {
       ids.filter(id => id !== 'external-id').forEach(id => expect(wrapper.find(`#${id}`).exists()).toBe(true))
     })
   })
+
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'], validationStatus: 'error', validationMessage: 'Please select a country' },
+      })
+      expect(wrapper.find('[data-testid="fwb-autocomplete-validation-message"]').text()).toBe('Please select a country')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'], validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('[data-testid="fwb-autocomplete-validation-message"]').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbAutocomplete, {
+        props: { options: mockOptions, searchFields: ['name'], validationStatus: 'error', validationMessage: 'Please select a country' },
+      })
+      const msgP = wrapper.find('[data-testid="fwb-autocomplete-validation-message"]')
+      expect(wrapper.find('input').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
 })

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -25,6 +25,7 @@ export interface AutocompleteProps<T = Record<string, any>> {
   remote?: boolean
   searchFields?: string[]
   size?: AutocompleteSize
+  validationMessage?: string
   validationStatus?: ValidationStatus
   valueField?: string
   wrapperClass?: string | Record<string, boolean>

--- a/src/components/FwbCheckbox/FwbCheckbox.vue
+++ b/src/components/FwbCheckbox/FwbCheckbox.vue
@@ -18,11 +18,13 @@
       </span>
     </label>
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -51,6 +53,7 @@ const props = withDefaults(defineProps<CheckboxProps>(), {
   disabled: false,
   label: '',
   labelClass: '',
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
@@ -58,7 +61,7 @@ const props = withDefaults(defineProps<CheckboxProps>(), {
 const model = defineModel<boolean | (string | number | boolean | object)[]>({ default: false })
 
 const { elementId: checkboxId, elementAttributes: checkboxAttributes } = useElementAttributes()
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(checkboxId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(checkboxId, computed(() => props.validationMessage))
 
 const inputAttributes = computed(() => ({
   ...checkboxAttributes.value,

--- a/src/components/FwbCheckbox/tests/FwbCheckbox.spec.ts
+++ b/src/components/FwbCheckbox/tests/FwbCheckbox.spec.ts
@@ -129,6 +129,31 @@ describe('FwbCheckbox', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbCheckbox, {
+        props: { validationStatus: 'error', validationMessage: 'Required' },
+      })
+      expect(wrapper.find('p').text()).toBe('Required')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbCheckbox, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbCheckbox, {
+        props: { validationStatus: 'error', validationMessage: 'Required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('validation label text colors', () => {
     it('applies error color to label text when validationStatus is "error"', () => {
       const wrapper = mount(FwbCheckbox, { props: { label: 'Accept', validationStatus: 'error' } })

--- a/src/components/FwbCheckbox/types.ts
+++ b/src/components/FwbCheckbox/types.ts
@@ -5,6 +5,7 @@ export interface CheckboxProps {
   disabled?: boolean
   label?: string
   labelClass?: string | Record<string, boolean>
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }

--- a/src/components/FwbFileInput/FwbFileInput.vue
+++ b/src/components/FwbFileInput/FwbFileInput.vue
@@ -20,11 +20,13 @@
       @change="handleChange"
     >
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -115,6 +117,7 @@ interface FileInputProps {
   labelClass?: string | Record<string, boolean>
   multiple?: boolean
   size?: FormElementSize
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }
@@ -128,6 +131,7 @@ const props = withDefaults(defineProps<FileInputProps>(), {
   labelClass: '',
   multiple: false,
   size: 'md',
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
@@ -192,7 +196,7 @@ const dragOverHandler = (event: Event) => {
 }
 
 const { elementId: inputId, elementAttributes: inputAttributes } = useElementAttributes()
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(inputId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(inputId, computed(() => props.validationMessage))
 
 const {
   dropzoneLabelClass,

--- a/src/components/FwbFileInput/tests/FileInput.spec.ts
+++ b/src/components/FwbFileInput/tests/FileInput.spec.ts
@@ -110,6 +110,31 @@ describe('FwbFileInput', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbFileInput, {
+        props: { validationStatus: 'error', validationMessage: 'File is required' },
+      })
+      expect(wrapper.find('p').text()).toBe('File is required')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbFileInput, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbFileInput, {
+        props: { validationStatus: 'error', validationMessage: 'File is required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="file"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('size classes', () => {
     it('sm and xl apply different padding to the input', () => {
       const sm = mount(FwbFileInput, { props: { size: 'sm' } })

--- a/src/components/FwbInput/FwbInput.vue
+++ b/src/components/FwbInput/FwbInput.vue
@@ -31,11 +31,13 @@
       </div>
     </div>
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -73,6 +75,7 @@ const props = withDefaults(defineProps<InputProps>(), {
   size: 'md',
   suffixClass: '',
   type: 'text',
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
@@ -82,7 +85,7 @@ const model = defineModel<string | number>({ default: '' })
 const { inputId, inputAttributes } = useInputAttributes()
 const slots = useSlots()
 
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(inputId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(inputId, computed(() => props.validationMessage))
 
 const isTextSlot = (name: string) => {
   const vnodes = slots[name]?.()

--- a/src/components/FwbInput/tests/Input.spec.ts
+++ b/src/components/FwbInput/tests/Input.spec.ts
@@ -131,6 +131,31 @@ describe('FwbInput', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbInput, {
+        props: { validationStatus: 'error', validationMessage: 'Field is required' },
+      })
+      expect(wrapper.find('p').text()).toBe('Field is required')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbInput, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbInput, {
+        props: { validationStatus: 'error', validationMessage: 'Field is required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('size classes', () => {
     it('sm and xl apply different padding to the input', () => {
       const sm = mount(FwbInput, { props: { size: 'sm' } })

--- a/src/components/FwbInput/types.ts
+++ b/src/components/FwbInput/types.ts
@@ -14,6 +14,7 @@ export interface InputProps {
   size?: FormElementSize
   suffixClass?: string | Record<string, boolean>
   type?: InputType
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }

--- a/src/components/FwbRadio/FwbRadioGroup.vue
+++ b/src/components/FwbRadio/FwbRadioGroup.vue
@@ -14,11 +14,13 @@
     </legend>
     <slot />
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -31,7 +33,7 @@
 </template>
 
 <script lang="ts" setup>
-import { provide, toRef, toRefs } from 'vue'
+import { computed, provide, toRef, toRefs } from 'vue'
 
 import { useRadioGroupClasses } from './composables/useRadioGroupClasses'
 import { radioGroupNameKey, type RadioGroupProps, radioGroupValidationStatusKey } from './types'
@@ -44,12 +46,13 @@ defineOptions({ inheritAttrs: false })
 const props = withDefaults(defineProps<RadioGroupProps>(), {
   label: '',
   legendClass: '',
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
 
 const { elementId: fieldsetId, elementAttributes: fieldsetAttributes } = useElementAttributes()
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(fieldsetId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(fieldsetId, computed(() => props.validationMessage))
 
 provide(radioGroupNameKey, toRef(props, 'name'))
 provide(radioGroupValidationStatusKey, toRef(props, 'validationStatus'))

--- a/src/components/FwbRadio/tests/FwbRadioGroup.spec.ts
+++ b/src/components/FwbRadio/tests/FwbRadioGroup.spec.ts
@@ -131,6 +131,31 @@ describe('FwbRadioGroup', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error', validationMessage: 'Required' },
+      })
+      expect(wrapper.find('p').text()).toBe('Required')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbRadioGroup, {
+        props: { name: 'fruit', validationStatus: 'error', validationMessage: 'Required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.element.getAttribute('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('validation styling', () => {
     it('applies error color to legend when validationStatus is "error"', () => {
       const wrapper = mount(FwbRadioGroup, {

--- a/src/components/FwbRadio/types.ts
+++ b/src/components/FwbRadio/types.ts
@@ -15,6 +15,7 @@ export interface RadioGroupProps {
   label?: string
   legendClass?: string | Record<string, boolean>
   name: string
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }

--- a/src/components/FwbRange/FwbRange.vue
+++ b/src/components/FwbRange/FwbRange.vue
@@ -18,11 +18,13 @@
       type="range"
     >
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -35,7 +37,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 
 import { useRangeClasses } from './composables/useRangeClasses'
 
@@ -55,6 +57,7 @@ const props = withDefaults(defineProps<RangeProps>(), {
   min: 0,
   size: 'md',
   steps: 1,
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
@@ -62,7 +65,7 @@ const props = withDefaults(defineProps<RangeProps>(), {
 const model = defineModel<number>({ default: 50 })
 
 const { elementId: rangeId, elementAttributes: rangeAttributes } = useElementAttributes()
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(rangeId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(rangeId, computed(() => props.validationMessage))
 
 const {
   helperMessageClass,

--- a/src/components/FwbRange/tests/FwbRange.spec.ts
+++ b/src/components/FwbRange/tests/FwbRange.spec.ts
@@ -116,6 +116,31 @@ describe('FwbRange', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbRange, {
+        props: { validationStatus: 'error', validationMessage: 'Value is out of range' },
+      })
+      expect(wrapper.find('p').text()).toBe('Value is out of range')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbRange, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbRange, {
+        props: { validationStatus: 'error', validationMessage: 'Value is out of range' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="range"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('styling props', () => {
     it('applies class prop classes to the input element', () => {
       const wrapper = mount(FwbRange, { props: { class: 'bg-amber-200' } })

--- a/src/components/FwbRange/types.ts
+++ b/src/components/FwbRange/types.ts
@@ -9,6 +9,7 @@ export interface RangeProps {
   min?: number
   size?: FormElementSize
   steps?: number
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }

--- a/src/components/FwbSelect/FwbSelect.vue
+++ b/src/components/FwbSelect/FwbSelect.vue
@@ -56,11 +56,13 @@
       </div>
     </div>
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -73,7 +75,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 
 import { useSelectAttributes } from './composables/useSelectAttributes'
 import { useSelectClasses } from './composables/useSelectClasses'
@@ -98,13 +100,14 @@ const props = withDefaults(defineProps<SelectProps>(), {
   required: false,
   size: 'md',
   underline: false,
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
 
 const model = defineModel<string>({ default: '' })
 const { selectId, selectAttributes } = useSelectAttributes()
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(selectId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(selectId, computed(() => props.validationMessage))
 
 const {
   chevronClass,

--- a/src/components/FwbSelect/tests/Select.spec.ts
+++ b/src/components/FwbSelect/tests/Select.spec.ts
@@ -156,6 +156,31 @@ describe('FwbSelect', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbSelect, {
+        props: { validationStatus: 'error', validationMessage: 'Please select a country' },
+      })
+      expect(wrapper.find('p').text()).toBe('Please select a country')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbSelect, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbSelect, {
+        props: { validationStatus: 'error', validationMessage: 'Please select a country' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('select').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('size classes', () => {
     it('sm and xl apply different padding to the select', () => {
       const sm = mount(FwbSelect, { props: { size: 'sm' } })

--- a/src/components/FwbSelect/types.ts
+++ b/src/components/FwbSelect/types.ts
@@ -21,6 +21,7 @@ export interface SelectProps {
   required?: boolean
   size?: FormElementSize
   underline?: boolean
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }

--- a/src/components/FwbTextarea/FwbTextarea.vue
+++ b/src/components/FwbTextarea/FwbTextarea.vue
@@ -25,11 +25,13 @@
       </div>
     </div>
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -42,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import { toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 
 import { useTextareaClasses } from './composables/useTextareaClasses'
 
@@ -62,6 +64,7 @@ interface TextareaProps {
   rows?: number
   size?: FormElementSize
   textareaClass?: string | Record<string, boolean>
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }
@@ -81,6 +84,7 @@ const props = withDefaults(defineProps<TextareaProps>(), {
   rows: 4,
   size: 'md',
   textareaClass: '',
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
@@ -89,7 +93,7 @@ const model = defineModel<string>({ default: '' })
 
 const { elementId: textareaId, elementAttributes: textareaAttributes } = useElementAttributes()
 
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(textareaId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(textareaId, computed(() => props.validationMessage))
 
 const {
   footerClass,

--- a/src/components/FwbTextarea/tests/Textarea.spec.ts
+++ b/src/components/FwbTextarea/tests/Textarea.spec.ts
@@ -131,6 +131,31 @@ describe('FwbTextarea', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbTextarea, {
+        props: { validationStatus: 'error', validationMessage: 'This field is required' },
+      })
+      expect(wrapper.find('p').text()).toBe('This field is required')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbTextarea, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbTextarea, {
+        props: { validationStatus: 'error', validationMessage: 'This field is required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('textarea').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('size classes', () => {
     it('sm and xl apply different padding to the textarea', () => {
       const sm = mount(FwbTextarea, { props: { size: 'sm' } })

--- a/src/components/FwbToggle/FwbToggle.vue
+++ b/src/components/FwbToggle/FwbToggle.vue
@@ -17,11 +17,13 @@
       >{{ label }}</span>
     </label>
     <p
-      v-if="$slots.validationMessage"
+      v-if="$slots.validationMessage || validationMessage"
       :id="validationMessageId"
       :class="validationMessageClass"
     >
-      <slot name="validationMessage" />
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
     </p>
     <p
       v-if="$slots.helper"
@@ -34,7 +36,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { computed, toRefs } from 'vue'
 
 import { useToggleClasses } from './composables/useToggleClasses'
 
@@ -53,6 +55,7 @@ const props = withDefaults(defineProps<ToggleProps>(), {
   labelClass: '',
   reverse: false,
   size: 'md',
+  validationMessage: undefined,
   validationStatus: undefined,
   wrapperClass: '',
 })
@@ -60,7 +63,7 @@ const props = withDefaults(defineProps<ToggleProps>(), {
 const model = defineModel<boolean>({ default: false })
 
 const { elementId: toggleId, elementAttributes: toggleAttributes } = useElementAttributes()
-const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(toggleId)
+const { ariaDescribedby, helperId, validationMessageId } = useFormFieldIds(toggleId, computed(() => props.validationMessage))
 
 const {
   helperMessageClass,

--- a/src/components/FwbToggle/tests/FwbToggle.spec.ts
+++ b/src/components/FwbToggle/tests/FwbToggle.spec.ts
@@ -127,6 +127,31 @@ describe('FwbToggle', () => {
     })
   })
 
+  describe('validationMessage prop', () => {
+    it('renders the prop text when no validationMessage slot is provided', () => {
+      const wrapper = mount(FwbToggle, {
+        props: { validationStatus: 'error', validationMessage: 'Required' },
+      })
+      expect(wrapper.find('p').text()).toBe('Required')
+    })
+
+    it('is overridden by the validationMessage slot when both are provided', () => {
+      const wrapper = mount(FwbToggle, {
+        props: { validationStatus: 'error', validationMessage: 'Prop message' },
+        slots: { validationMessage: 'Slot message' },
+      })
+      expect(wrapper.find('p').text()).toBe('Slot message')
+    })
+
+    it('points aria-describedby to the validation paragraph when only the prop is set', () => {
+      const wrapper = mount(FwbToggle, {
+        props: { validationStatus: 'error', validationMessage: 'Required' },
+      })
+      const msgP = wrapper.find('p')
+      expect(wrapper.find('input[type="checkbox"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
+
   describe('validation label text colors', () => {
     it('applies error color to label text when validationStatus is "error"', () => {
       const wrapper = mount(FwbToggle, { props: { label: 'Notifications', validationStatus: 'error' } })

--- a/src/components/FwbToggle/types.ts
+++ b/src/components/FwbToggle/types.ts
@@ -10,6 +10,7 @@ export interface ToggleProps {
   labelClass?: string | Record<string, boolean>
   reverse?: boolean
   size?: FormElementSize
+  validationMessage?: string
   validationStatus?: ValidationStatus
   wrapperClass?: string | Record<string, boolean>
 }

--- a/src/composables/useFormFieldIds.ts
+++ b/src/composables/useFormFieldIds.ts
@@ -1,6 +1,9 @@
 import { computed, type ComputedRef, useAttrs, useSlots } from 'vue'
 
-export const useFormFieldIds = (elementId: ComputedRef<string>) => {
+export const useFormFieldIds = (
+  elementId: ComputedRef<string>,
+  validationMessage?: ComputedRef<string | undefined>,
+) => {
   const attrs = useAttrs()
   const slots = useSlots()
 
@@ -10,7 +13,7 @@ export const useFormFieldIds = (elementId: ComputedRef<string>) => {
   const ariaDescribedby = computed(() => {
     const ids: string[] = []
     if (attrs['aria-describedby']) ids.push(String(attrs['aria-describedby']))
-    if (slots.validationMessage) ids.push(validationMessageId.value)
+    if (slots.validationMessage || validationMessage?.value) ids.push(validationMessageId.value)
     if (slots.helper) ids.push(helperId.value)
     return ids.length ? ids.join(' ') : undefined
   })


### PR DESCRIPTION
## Summary

Adds an optional `validationMessage` string prop to `FwbInput`, `FwbSelect`, `FwbTextarea`, `FwbFileInput`, `FwbAutocomplete`, `FwbToggle`, `FwbRange`, `FwbCheckbox`, and `FwbRadioGroup` — a unified DX improvement across the whole form component set.

Prompted by #362, which proposed `errorMessage`/`successMessage` props on `FwbInput` for the same underlying gap: the `validationMessage` slot is more verbose than it needs to be for a plain string. Rather than adding separate props per status, this pairs a single `validationMessage` prop with the existing `validationStatus` prop:

```vue
<!-- instead of a named slot for a plain string -->
<fwb-input
  :validation-status="err ? 'error' : 'success'"
  :validation-message="err ? 'Field is required.' : 'Looks good!'"
/>
```

- The `validationMessage` slot remains the primary API and keeps priority for rich content (e.g. bold text, links); the prop is a fallback rendered only when the slot isn't used.
- `useFormFieldIds` now wires `aria-describedby` to the validation message id whether it comes from the slot or the prop.

## Tests

Extends each component's spec file with a `validationMessage prop` block: renders the prop text when no slot is given, the slot overrides the prop when both are provided, and `aria-describedby` points to the validation paragraph when only the prop is set.

## Docs

Updates each component's Validation section, Props table, Slots table, and Accessibility tip. The live validation examples now show the error case using the prop (plain string) and the success case using the slot (rich content), demonstrating the recommended usage split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plain-text validation messages across form controls, including autocomplete, inputs, selects, checkboxes, radios, ranges, textareas, toggles, and file inputs.
  * Rich validation slots continue to take priority when both a slot and prop are provided.
  * Validation messages are now included in accessible field descriptions.

* **Documentation**
  * Updated component API references, accessibility guidance, and validation examples to demonstrate the new prop.

* **Tests**
  * Added coverage for prop rendering, slot precedence, and accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->