### PR TITLE
docs: add CHANGELOG.md and document the changelog process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries below start from v0.2.3 (the last published release) forward — earlier
+versions predate this file and are not backfilled.
+
+## [Unreleased]
+
+### ⚠ Breaking Changes
+
+- **Native attribute passthrough target changed** on `FwbInput` (#433), `FwbTextarea` (#436), `FwbFileInput` (#437), `FwbSelect` (#438), `FwbAutocomplete` (#439), `FwbRange` (#440), `FwbToggle` (#441), `FwbCheckbox` (#442), and `FwbRadio` (#443). Each now sets `inheritAttrs: false` and forwards extra attributes to the underlying native element (`<input>`, `<select>`, `<textarea>`, etc.) instead of the root wrapper element. This is the correct behavior, but apps relying on attributes landing on the wrapper (e.g. for CSS targeting) are affected.
+- `FwbTabs`: the `click:pane` event was renamed to `click:tab` (#451)
+- `FwbTextarea`: the `placeholder` prop was removed (no longer declared — pass it as a native attribute instead, which forwards identically via attr passthrough) and the `custom` prop was removed (the new default layout replaces the old `custom: true` layout; use `class`/`wrapperClass`/`textareaClass` for further customization) (#436)
+- `FwbFileInput`: the `size` default changed from `'sm'` to `'md'`, and `size="xs"` was removed — the type is now `'sm' | 'md' | 'lg' | 'xl'` (#437)
+- `FwbSelect`: the native browser dropdown arrow is now hidden (`appearance-none`) in favor of the Flowbite chevron icon, rendered via the new `chevron` slot (#438)
+- `FwbRange`: the `label` default changed from `'Range slider'` to `''` — pass `label="Range slider"` explicitly to restore the previous rendering (#440)
+- `FwbCheckbox`: `name` and `value` are no longer declared props; they now flow through attribute passthrough instead (same usage, no template changes needed) (#442)
+
+### Added
+
+- `validationMessage` string prop on `FwbInput`, `FwbSelect`, `FwbTextarea`, `FwbFileInput`, `FwbAutocomplete`, `FwbToggle`, `FwbRange`, `FwbCheckbox`, and `FwbRadioGroup` as a plain-string fallback for the `validationMessage` slot, which keeps priority for rich content (#453)
+- `FwbTabs`/`FwbTab`: `vertical` layout, `fullWidth`, an `icon` slot with configurable `iconPosition`, `tabClass`/`itemClass`/`itemActiveClass` custom classes, keyboard navigation (arrow keys, Home, End), and ARIA roles (`tablist`/`tab`/`tabpanel`) (#451, supersedes #435 — thanks @darrenthebozz for the original custom-classes idea)
+- `FwbBadge`: `pill`, `border`, and `dismissible` variants, the last emitting a `dismiss` event (#450)
+- `FwbRadioGroup` component for grouped radio validation, shared `name`, and accessibility wiring (#443)
+- `xl` size tier, validation states (`validationStatus`, `validationMessage`/`helper` slots), and per-element class props (`wrapperClass`, `labelClass`, etc.) added to `FwbInput` (#433), `FwbTextarea` (#436), `FwbFileInput` (#437), `FwbSelect` (#438), `FwbRange` (#440), `FwbToggle` (#441), and `FwbCheckbox` (#442)
+- `FwbAutocomplete`: `inputClass` prop for direct `<input>` styling (#439)
+- `FwbSelect`: `clearable` prop and `chevron` slot (#438)
+- `FwbRange`: thumb color customizable via the `--fwb-range-thumb-color` CSS custom property (#440)
+
+### Changed
+
+- `FwbButton` rewritten for type safety, `useMergeClasses`, and accessibility (#444)
+- Replaced the `classnames` dependency with the internal `useMergeClasses` composable across all components (#447)
+- Unified import convention: relative imports (`./`, `../`) within a component's own directory, `@/` alias across component boundaries or for shared/top-level code (#452)
+- Systematic documentation review and rewrite for all 39 component pages (#448)
+- Updated all dependencies to latest versions (#445)
+
+### Fixed
+
+- Restored the Flowbite Tailwind plugin for Tailwind v4 and fixed a double chevron rendering on `FwbSelect` (#449)
+- `FwbSidebar` tag/link handling bugs found during the docs review (#448)
+- `FwbFileInput`: error/success background colors corrected (were `bg-red-50`/`bg-green-50`, now `bg-rose-50`/`bg-emerald-50` to match the rest of the library) (#437)
+- Linter warnings reduced from 51 to 21 (#446)
+
+[Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.2.3...main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Never made an open source contribution before? Wondering how contributions work 
 2. Fork the repository associated with the issue to your local GitHub organization. This means that you will have a copy of the repository under `your-GitHub-username/repository-name`.
 3. Clone the repository to your local machine using `git clone https://github.com/github-username/repository-name.git`.
 4. Create a new branch for your fix using `git checkout -b branch-name-here`.
-5. Make the appropriate changes for the issue you are trying to address or the feature that you want to add.
+5. Make the appropriate changes for the issue you are trying to address or the feature that you want to add. If your change is user-facing, also add an entry to [`CHANGELOG.md`](CHANGELOG.md) — see [Updating the changelog](#updating-the-changelog) below.
 6. Use `git add insert-paths-of-changed-files-here` to add the file contents of the changed files to the "snapshot" git uses to manage the state of the project, also known as the index.
 7. Use `git commit -m "Insert a short message of the changes made here"` to store the contents of the index with a descriptive message. Use [conventional commits](https://www.conventionalcommits.org/) to create a nice message.
 8. Push the changes to the remote repository using `git push origin branch-name-here`.
@@ -28,6 +28,15 @@ Never made an open source contribution before? Wondering how contributions work 
 12. Wait for the pull request to be reviewed by a maintainer.
 13. Make changes to the pull request if the reviewing maintainer recommends them.
 14. Celebrate your success after your pull request is merged! 🎉 🎉
+
+## Updating the changelog
+
+This project keeps a [`CHANGELOG.md`](CHANGELOG.md) following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). If your pull request changes behavior — a new feature, a bug fix, or a breaking change — add a bullet to the `[Unreleased]` section as part of the same PR, not after the fact. Batching changelog updates until release time makes them easy to lose and hard to reconstruct accurately.
+
+- Pick the right category: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`.
+- If your change breaks existing usage — a removed or renamed prop/event, a changed default, a different attribute-forwarding target, etc. — add it under the `⚠ Breaking Changes` section instead, with enough detail for someone upgrading to know what to check or update.
+- End each bullet with a link to your PR number, e.g. `(#123)`.
+- Keep entries user-facing: describe what changed for someone consuming the library, not internal refactor details.
 
 ## Where can I go for help?
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [Components](#components)
 - [Community](#community)
 - [Contributing](#contributing)
+- [Changelog](#changelog)
 - [Figma](#figma)
 - [Copyright and license](#copyright-and-license)
 
@@ -128,7 +129,7 @@ module.exports = {
   </tr>
   <tr>
     <td width="33.3333%">Dropdown</td>
-    <td width="33.3333%">:construction: Forms</td>
+    <td width="33.3333%">Forms</td>
     <td width="33.3333%">List group</td>
   </tr>
   <tr>
@@ -149,13 +150,13 @@ module.exports = {
     </td>
   </tr>
   <tr>
-    <td width="33.3333%">:construction: Typography</td>
+    <td width="33.3333%">Typography</td>
     <td width="33.3333%">Modal</td>
     <td width="33.3333%">Tabs</td>
   </tr>
   <tr>
     <td width="33.3333%">
-        <a href="https://flowbite.com/docs/components/typography/">
+        <a href="https://flowbite-vue.com/components/heading">
             <img alt="Tailwind CSS Typography" src="./docs/assets/github/typography.jpg">
         </a>
     </td>
@@ -239,7 +240,7 @@ module.exports = {
   <tr>
     <td width="33.3333%">Footer</td>
     <td width="33.3333%">Accordion</td>
-    <td width="33.3333%">:construction: Sidebar</td>
+    <td width="33.3333%">Sidebar</td>
   </tr>
   <tr>
     <td width="33.3333%">
@@ -371,6 +372,10 @@ For casual chatting with others using the library:
 ## Contributing
 
 Thank you for your interest in helping! Visit our [guide on contributing](https://github.com/themesberg/flowbite-vue/blob/main/CONTRIBUTING.md) to get started.
+
+## Changelog
+
+Notable changes to this project are documented in [`CHANGELOG.md`](https://github.com/themesberg/flowbite-vue/blob/main/CHANGELOG.md), following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
 ## Figma
 


### PR DESCRIPTION
## Summary

Adds `CHANGELOG.md` following [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), backfilled from v0.2.3 (the last published release) through #453, and documents the process so entries keep getting added per-PR instead of being reconstructed at release time.

- **`CHANGELOG.md`** — an `[Unreleased]` section with a dedicated `⚠ Breaking Changes` block, since a lot of the recent form-component refactors carry breaking changes: the `inheritAttrs: false` attribute-passthrough target change (#433, #436–443), plus component-specific ones (`FwbTextarea` prop removals, `FwbFileInput` size default, `FwbSelect` chevron, `FwbRange` label default, `FwbCheckbox` prop-to-attr changes). Several of these weren't called out as breaking in their original PR descriptions — verified via diff before including them here.
- **`CONTRIBUTING.md`** — new "Updating the changelog" section: add an entry to `[Unreleased]` in the same PR as the change, pick the right category, use the breaking-changes section for anything that breaks existing usage.
- **`README.md`** — added a Changelog section/link; also fixed stale `:construction:` markers on Forms, Typography, and Sidebar in the components table (all three are fully implemented and exported — verified against `src/index.ts`), and pointed the Typography card at `flowbite-vue.com` instead of the non-Vue `flowbite.com` docs.

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced tabs with vertical layout, full-width mode, icons, keyboard navigation, and ARIA support.
  * Added new badge variants, radio groups, extra sizing, validation states, and expanded form customization.
  * Added improved autocomplete, select, range, and validation messaging options.

* **Bug Fixes**
  * Fixed dropdown arrow, sidebar, and file-input styling issues.
  * Reduced linter warnings.

* **Documentation**
  * Added an Unreleased changelog covering component updates and breaking changes.
  * Updated the README with changelog access and completed component status.
  * Clarified changelog contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->