### PR TITLE
feat(fileInput): add dropzone validation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ versions predate this file and are not backfilled.
 - `FwbAutocomplete`: `inputClass` prop for direct `<input>` styling (#439)
 - `FwbSelect`: `clearable` prop and `chevron` slot (#438)
 - `FwbRange`: thumb color customizable via the `--fwb-range-thumb-color` CSS custom property (#440)
+- `FwbFileInput`: dropzone mode now supports `validationStatus` styling (rose/emerald dashed border), `aria-invalid`/`aria-describedby` on the hidden input, and renders the `validationMessage` (slot or prop) and `helper` slot below the dropzone (#455)
 
 ### Changed
 
@@ -45,5 +46,6 @@ versions predate this file and are not backfilled.
 - `FwbSidebar` tag/link handling bugs found during the docs review (#448)
 - `FwbFileInput`: error/success background colors corrected (were `bg-red-50`/`bg-green-50`, now `bg-rose-50`/`bg-emerald-50` to match the rest of the library) (#437)
 - Linter warnings reduced from 51 to 21 (#446)
+- `FwbFileInput`: the file selector button had `file:rounded-none` while the input wrapper has `rounded-lg` — the button's square corner was clipped by the input's rounded border box, cutting into the button text. Now rounds the button's left corners to match, and widens left padding accordingly (#455)
 
 [Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.2.3...main

--- a/docs/components/fileInput.md
+++ b/docs/components/fileInput.md
@@ -7,6 +7,7 @@ import FwbFileInputExampleStyling from './fileInput/examples/FwbFileInputExample
 import FwbFileInputExampleDisabled from './fileInput/examples/FwbFileInputExampleDisabled.vue'
 import FwbFileInputExampleValidation from './fileInput/examples/FwbFileInputExampleValidation.vue'
 import FwbFileInputExampleDropZone from './fileInput/examples/FwbFileInputExampleDropZone.vue'
+import FwbFileInputExampleDropZoneValidation from './fileInput/examples/FwbFileInputExampleDropZoneValidation.vue'
 import FwbFileInputExampleDropZonePlaceholder from './fileInput/examples/FwbFileInputExampleDropZonePlaceholder.vue'
 import FwbFileInputExampleDropZoneMultiple from './fileInput/examples/FwbFileInputExampleDropZoneMultiple.vue'
 </script>
@@ -208,6 +209,41 @@ const file = ref(null)
 </script>
 ```
 
+## Dropzone Validation
+
+`validationStatus`, `validationMessage`, and the `helper`/`validationMessage` slots work the same way in dropzone mode as in the default layout — the dropzone border and background reflect the status, and feedback text renders below the dropzone box.
+
+<fwb-file-input-example-drop-zone-validation />
+
+```vue
+<template>
+  <div class="flex flex-col gap-4">
+    <fwb-file-input
+      v-model="file"
+      dropzone
+      validation-status="error"
+      validation-message="Please select a valid file."
+    />
+    <fwb-file-input
+      v-model="file"
+      dropzone
+      validation-status="success"
+    >
+      <template #validationMessage>
+        File looks good!
+      </template>
+    </fwb-file-input>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { FwbFileInput } from 'flowbite-vue'
+
+const file = ref(null)
+</script>
+```
+
 ## Dropzone Multiple
 
 Use the `multiple` prop together with `dropzone` to allow uploading several files at once via drag-and-drop.
@@ -276,11 +312,11 @@ const file = ref(null)
 | wrapperClass     | `String \| Object`                    | `''`        | Added to the outermost wrapper `<div>`.                                                         |
 
 :::warning Dropzone mode limitations
-`class` and `size` have no effect in dropzone mode. `validationStatus` changes the label color only — input styling and validation messages are not rendered. `helper` slot, `validationMessage` slot, and `validationMessage` prop are not rendered in dropzone mode.
+`class` and `size` have no effect in dropzone mode — they only style the default (non-dropzone) `<input>`.
 :::
 
 :::tip Accessibility
-`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute. These apply to the default (non-dropzone) rendering only.
+`aria-invalid="true"` is set automatically on the native input when `validationStatus="error"`, in both default and dropzone modes. `aria-describedby` is wired to the IDs of any rendered `validationMessage` (slot or prop) and `helper` slots, and is merged with any `aria-describedby` value you pass as an attribute.
 :::
 
 ### FwbFileInput Slots

--- a/docs/components/fileInput/examples/FwbFileInputExampleDropZoneValidation.vue
+++ b/docs/components/fileInput/examples/FwbFileInputExampleDropZoneValidation.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="flex flex-col gap-4 vp-raw">
+    <fwb-file-input
+      v-model="file"
+      dropzone
+      validation-status="error"
+      validation-message="Please select a valid file."
+    />
+    <fwb-file-input
+      v-model="file"
+      dropzone
+      validation-status="success"
+    >
+      <template #validationMessage>
+        File looks good!
+      </template>
+    </fwb-file-input>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+import { FwbFileInput } from '../../../../src/index'
+
+const file = ref(null)
+</script>

--- a/src/components/FwbFileInput/FwbFileInput.vue
+++ b/src/components/FwbFileInput/FwbFileInput.vue
@@ -84,6 +84,8 @@
       <input
         v-bind="inputAttributes"
         :accept="accept"
+        :aria-describedby="ariaDescribedby"
+        :aria-invalid="validationStatus === 'error' ? true : undefined"
         :aria-labelledby="label ? `${inputId}-label` : undefined"
         :disabled="disabled"
         :multiple="multiple"
@@ -92,6 +94,22 @@
         @change="handleChange"
       >
     </label>
+    <p
+      v-if="$slots.validationMessage || validationMessage"
+      :id="validationMessageId"
+      :class="validationMessageClass"
+    >
+      <slot name="validationMessage">
+        {{ validationMessage }}
+      </slot>
+    </p>
+    <p
+      v-if="$slots.helper"
+      :id="helperId"
+      :class="helperMessageClass"
+    >
+      <slot name="helper" />
+    </p>
   </div>
 </template>
 

--- a/src/components/FwbFileInput/composables/useFileInputClasses.ts
+++ b/src/components/FwbFileInput/composables/useFileInputClasses.ts
@@ -6,16 +6,16 @@ import { type FormElementSize, type ValidationStatus, validationStatusMap } from
 const defaultWrapperClasses = ''
 const defaultLabelClasses = 'block mb-2 font-medium text-gray-900 dark:text-white text-sm'
 const defaultInputClasses = 'bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg w-full text-gray-900 dark:text-white cursor-pointer shadow-xs focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-500 dark:focus:border-blue-500'
-const defaultFileButtonClasses = 'file:cursor-pointer file:border-0 file:border-r file:border-gray-300 file:rounded-none file:bg-gray-200 file:text-gray-900 file:transition-colors file:duration-150 enabled:hover:file:bg-gray-100 dark:file:bg-gray-700 dark:file:border-gray-600 dark:file:text-white dark:enabled:hover:file:bg-gray-600 dark:enabled:hover:file:border-gray-500'
+const defaultFileButtonClasses = 'file:cursor-pointer file:border-0 file:border-r file:border-gray-300 file:rounded-l-lg file:bg-gray-200 file:text-gray-900 file:transition-colors file:duration-150 enabled:hover:file:bg-gray-100 dark:file:bg-gray-700 dark:file:border-gray-600 dark:file:text-white dark:enabled:hover:file:bg-gray-600 dark:enabled:hover:file:border-gray-500'
 const defaultHelperClasses = 'mt-2 text-gray-500 dark:text-gray-400 text-sm'
 
 const disabledInputClasses = 'cursor-not-allowed opacity-50'
 
 const inputSizeClasses: Record<FormElementSize, string> = {
-  sm: 'p-0 text-sm file:mr-2.5 file:px-2.5 file:py-2 file:text-sm',
-  md: 'p-0 text-sm file:mr-3 file:px-3 file:py-2.5 file:text-sm',
-  lg: 'p-0 text-base file:mr-3.5 file:px-3.5 file:py-3 file:text-base',
-  xl: 'p-0 text-base file:mr-4 file:px-4 file:py-3.5 file:text-base',
+  sm: 'p-0 text-sm file:mr-2.5 file:pl-6.5 file:pr-2.5 file:py-2 file:text-sm',
+  md: 'p-0 text-sm file:mr-3 file:pl-7 file:pr-3 file:py-2.5 file:text-sm',
+  lg: 'p-0 text-base file:mr-3.5 file:pl-7.5 file:pr-3.5 file:py-3 file:text-base',
+  xl: 'p-0 text-base file:mr-4 file:pl-8 file:pr-4 file:py-3.5 file:text-base',
 }
 
 const errorInputClasses = 'bg-rose-50 border-rose-200 focus:ring-rose-500 focus:border-rose-500 dark:border-rose-500 dark:focus:ring-rose-500 text-rose-900 dark:text-rose-500'

--- a/src/components/FwbFileInput/composables/useFileInputClasses.ts
+++ b/src/components/FwbFileInput/composables/useFileInputClasses.ts
@@ -26,6 +26,8 @@ const successTextClasses = 'text-emerald-900 dark:text-emerald-500'
 const dropzoneLabelBaseClasses = 'flex flex-col justify-center items-center bg-gray-50 dark:bg-gray-700 border-2 border-gray-300 dark:border-gray-600 border-dashed rounded-lg w-full h-64'
 const dropzoneLabelInteractiveClasses = 'hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:border-gray-500 cursor-pointer'
 const dropzoneLabelDisabledClasses = 'cursor-not-allowed opacity-50'
+const dropzoneLabelErrorClasses = 'bg-rose-50 border-rose-300 dark:border-rose-500'
+const dropzoneLabelSuccessClasses = 'bg-emerald-50 border-emerald-300 dark:border-emerald-500'
 const dropzoneWrapDefaultClasses = 'flex flex-col justify-center items-center pt-5 pb-6'
 const dropzoneTextDefaultClasses = '!-mb-2 text-gray-500 dark:text-gray-400 text-sm'
 
@@ -76,6 +78,9 @@ export function useFileInputClasses (props: UseFileInputClassesProps) {
 
   const dropzoneLabelClass = computed(() => useMergeClasses([
     dropzoneLabelBaseClasses,
+    props.validationStatus.value === validationStatusMap.Success
+      ? dropzoneLabelSuccessClasses
+      : props.validationStatus.value === validationStatusMap.Error ? dropzoneLabelErrorClasses : '',
     props.disabled.value ? dropzoneLabelDisabledClasses : dropzoneLabelInteractiveClasses,
   ]))
   const dropzoneWrapClass = computed(() => dropzoneWrapDefaultClasses)

--- a/src/components/FwbFileInput/tests/FileInput.spec.ts
+++ b/src/components/FwbFileInput/tests/FileInput.spec.ts
@@ -139,8 +139,17 @@ describe('FwbFileInput', () => {
     it('sm and xl apply different padding to the input', () => {
       const sm = mount(FwbFileInput, { props: { size: 'sm' } })
       const xl = mount(FwbFileInput, { props: { size: 'xl' } })
-      expect(sm.find('input[type="file"]').classes()).toContain('file:px-2.5')
-      expect(xl.find('input[type="file"]').classes()).toContain('file:px-4')
+      expect(sm.find('input[type="file"]').classes()).toContain('file:pr-2.5')
+      expect(xl.find('input[type="file"]').classes()).toContain('file:pr-4')
+    })
+  })
+
+  describe('file selector button styling', () => {
+    it('rounds the left corners of the file selector button to match the input', () => {
+      const wrapper = mount(FwbFileInput)
+      const classes = wrapper.find('input[type="file"]').classes()
+      expect(classes).toContain('file:rounded-l-lg')
+      expect(classes).not.toContain('file:rounded-none')
     })
   })
 

--- a/src/components/FwbFileInput/tests/FileInput.spec.ts
+++ b/src/components/FwbFileInput/tests/FileInput.spec.ts
@@ -190,4 +190,52 @@ describe('FwbFileInput', () => {
       expect(wrapper.emitted('update:modelValue')).toBeUndefined()
     })
   })
+
+  describe('dropzone validation', () => {
+    it('sets aria-invalid on the hidden input when validationStatus is "error"', () => {
+      const wrapper = mount(FwbFileInput, { props: { dropzone: true, validationStatus: 'error' } })
+      expect(wrapper.find('input[type="file"]').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('does not set aria-invalid when validationStatus is "success"', () => {
+      const wrapper = mount(FwbFileInput, { props: { dropzone: true, validationStatus: 'success' } })
+      expect(wrapper.find('input[type="file"]').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('applies rose-colored classes to the dropzone label on error', () => {
+      const wrapper = mount(FwbFileInput, { props: { dropzone: true, validationStatus: 'error' } })
+      expect(wrapper.find('label').classes()).toContain('bg-rose-50')
+    })
+
+    it('applies emerald-colored classes to the dropzone label on success', () => {
+      const wrapper = mount(FwbFileInput, { props: { dropzone: true, validationStatus: 'success' } })
+      expect(wrapper.find('label').classes()).toContain('bg-emerald-50')
+    })
+
+    it('renders the validationMessage prop below the dropzone', () => {
+      const wrapper = mount(FwbFileInput, {
+        props: { dropzone: true, validationStatus: 'error', validationMessage: 'File is required' },
+      })
+      const paragraphs = wrapper.findAll('p')
+      expect(paragraphs[paragraphs.length - 1].text()).toBe('File is required')
+    })
+
+    it('renders the helper slot below the dropzone', () => {
+      const wrapper = mount(FwbFileInput, {
+        props: { dropzone: true },
+        slots: { helper: 'Max 5MB' },
+      })
+      const paragraphs = wrapper.findAll('p')
+      expect(paragraphs[paragraphs.length - 1].text()).toBe('Max 5MB')
+    })
+
+    it('wires aria-describedby on the hidden input to the validation message id', () => {
+      const wrapper = mount(FwbFileInput, {
+        props: { dropzone: true, validationStatus: 'error', validationMessage: 'File is required' },
+      })
+      const paragraphs = wrapper.findAll('p')
+      const msgP = paragraphs[paragraphs.length - 1]
+      expect(wrapper.find('input[type="file"]').attributes('aria-describedby')).toBe(msgP.attributes('id'))
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds `validationStatus` support to `FwbFileInput`'s dropzone mode, and fixes a file-selector-button rendering bug found while testing this.

### Dropzone validation

- `validationStatus` now styles the dropzone border/background (rose for error, emerald for success), matching the default (non-dropzone) input
- `aria-invalid` and `aria-describedby` are wired to the hidden dropzone `<input>`, matching the default input's accessibility behavior
- `validationMessage` (slot or prop) and the `helper` slot render below the dropzone box

Previously these all silently no-op'd in dropzone mode — the docs' "Dropzone mode limitations" warning called this out explicitly, which is now removed since the only remaining dropzone limitation is that `class`/`size` don't apply to the (hidden) native input.

### Fix: file selector button corner clipping

Found while visually checking the above: the file selector button had `file:rounded-none` while the input wrapper has `rounded-lg`. Since the button sits flush against the input's rounded left edge, the browser clips the button to the input's rounded border box — cutting into the button's corner and, at smaller sizes, its text. Fixed by rounding the button's left corners to match (`file:rounded-l-lg`) and widening the left padding accordingly.

## Tests

New `dropzone validation` and `file selector button styling` describe blocks in `FileInput.spec.ts`; updated the existing size-classes test for the padding change.

## Docs

New "Dropzone Validation" section with a live example; updated the "Dropzone mode limitations" warning and Accessibility tip to reflect that validation now works in both modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropzone file inputs now support validation styling, validation messages, and helper content.
  * Accessibility attributes automatically reflect validation status and connect messages to the file input.
  * Added documentation and examples for dropzone validation.

* **Bug Fixes**
  * Improved file selector button styling to prevent visual clipping and align rounded corners across sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->