### PR TITLE
chore: replace remaining any types with proper types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ versions predate this file and are not backfilled.
 - Unified import convention: relative imports (`./`, `../`) within a component's own directory, `@/` alias across component boundaries or for shared/top-level code (#452)
 - Systematic documentation review and rewrite for all 39 component pages (#448)
 - Updated all dependencies to latest versions (#445)
+- Replaced remaining `any` types with proper types: typed `defineSlots` payloads on `FwbAlert`, `FwbJumbotron`, and `FwbPagination`, and `Record<string, unknown>` in place of `Record<string, any>` on `FwbAutocomplete` and `FwbSlotListener` (#456)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ versions predate this file and are not backfilled.
 - Unified import convention: relative imports (`./`, `../`) within a component's own directory, `@/` alias across component boundaries or for shared/top-level code (#452)
 - Systematic documentation review and rewrite for all 39 component pages (#448)
 - Updated all dependencies to latest versions (#445)
-- Replaced remaining `any` types with proper types: typed `defineSlots` payloads on `FwbAlert`, `FwbJumbotron`, and `FwbPagination`, and `Record<string, unknown>` in place of `Record<string, any>` on `FwbAutocomplete` and `FwbSlotListener` (#456)
+- Replaced remaining `any` types with proper types: typed `defineSlots` payloads on `FwbAlert`, `FwbJumbotron`, and `FwbPagination`, `Record<string, unknown>` in place of `Record<string, any>` on `FwbAutocomplete`, and a `(...args: unknown[]) => void` function-type cast in place of an `any` cast on `FwbSlotListener` (#456)
 
 ### Fixed
 

--- a/docs/components/autocomplete/examples/FwbAutocompleteExampleRemote.vue
+++ b/docs/components/autocomplete/examples/FwbAutocompleteExampleRemote.vue
@@ -67,6 +67,14 @@ interface Country {
   flag: string
 }
 
+interface RestCountryResponse {
+  name: { common: string }
+  capital?: string[]
+  region: string
+  population: number
+  flag: string
+}
+
 const selectedCountry = ref<Country | null>(null)
 const countries = ref<Country[]>([])
 const loading = ref(false)
@@ -93,9 +101,9 @@ const searchCountries = async (query: string) => {
       throw new Error('Failed to fetch countries')
     }
 
-    const data = await response.json()
+    const data = await response.json() as RestCountryResponse[]
 
-    countries.value = data.slice(0, 10).map((country: any) => ({
+    countries.value = data.slice(0, 10).map(country => ({
       name: country.name.common,
       capital: country.capital?.[0] || 'N/A',
       region: country.region,

--- a/src/components/FwbAlert/FwbAlert.vue
+++ b/src/components/FwbAlert/FwbAlert.vue
@@ -81,10 +81,10 @@ const props = withDefaults(defineProps<IAlertProps>(), {
   border: false,
 })
 defineSlots<{
-  'default': any
-  'close-icon': any
-  'icon': any
-  'title': any
+  'default'?: (props: { onCloseClick: () => void }) => unknown
+  'close-icon'?: (props: { onCloseClick: () => void }) => unknown
+  'icon'?: (props: Record<string, never>) => unknown
+  'title'?: (props: Record<string, never>) => unknown
 }>()
 const emits = defineEmits<{ (e: 'close'): void }>()
 

--- a/src/components/FwbAutocomplete/FwbAutocomplete.vue
+++ b/src/components/FwbAutocomplete/FwbAutocomplete.vue
@@ -156,7 +156,7 @@
   </div>
 </template>
 
-<script setup lang="ts" generic="T extends Record<string, any>">
+<script setup lang="ts" generic="T extends Record<string, unknown>">
 import {
   computed,
   nextTick,

--- a/src/components/FwbAutocomplete/types.ts
+++ b/src/components/FwbAutocomplete/types.ts
@@ -4,7 +4,7 @@ import type { Component } from 'vue'
 export type AutocompleteSize = FormElementSize
 export type { ValidationStatus }
 
-export interface AutocompleteProps<T = Record<string, any>> {
+export interface AutocompleteProps<T = Record<string, unknown>> {
   class?: string | Record<string, boolean>
   debounce?: number
   inputClass?: string | Record<string, boolean>
@@ -12,7 +12,7 @@ export interface AutocompleteProps<T = Record<string, any>> {
   display?: string | ((option: T) => string)
   dropdownClass?: string | Record<string, boolean>
   inputComponent?: Component
-  inputProps?: Record<string, any>
+  inputProps?: Record<string, unknown>
   label?: string
   labelClass?: string | Record<string, boolean>
   loading?: boolean
@@ -32,7 +32,7 @@ export interface AutocompleteProps<T = Record<string, any>> {
   zIndex?: number
 }
 
-export interface AutocompleteEmits<T = Record<string, any>> {
+export interface AutocompleteEmits<T = Record<string, unknown>> {
   (e: 'search', query: string): void
   (e: 'select', option: T): void
   (e: 'update:modelValue', value: T | null): void

--- a/src/components/FwbJumbotron/FwbJumbotron.vue
+++ b/src/components/FwbJumbotron/FwbJumbotron.vue
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<IAlertProps>(), {
   headerClasses: '',
 })
 defineSlots<{
-  default: any
+  default?: (props: Record<string, never>) => unknown
 }>()
 
 const attrs = useAttrs()

--- a/src/components/FwbPagination/FwbPagination.vue
+++ b/src/components/FwbPagination/FwbPagination.vue
@@ -94,23 +94,26 @@
           </template>
         </button>
       </slot>
-      <slot
+      <template
         v-for="index in pagesToDisplay"
         :key="index"
-        name="page-button"
-        :page="index"
-        :set-page="setPage"
-        :disabled="isSetPageDisabled(index)"
       >
-        <button
-          v-if="!$slots['page-button']"
+        <slot
+          name="page-button"
+          :page="index"
+          :set-page="setPage"
           :disabled="isSetPageDisabled(index)"
-          :class="getPageButtonClasses(index === modelValue)"
-          @click="setPage(index)"
         >
-          {{ index }}
-        </button>
-      </slot>
+          <button
+            v-if="!$slots['page-button']"
+            :disabled="isSetPageDisabled(index)"
+            :class="getPageButtonClasses(index === modelValue)"
+            @click="setPage(index)"
+          >
+            {{ index }}
+          </button>
+        </slot>
+      </template>
       <slot
         name="next-button"
         :disabled="isIncreaseDisabled"
@@ -239,17 +242,17 @@ const props = withDefaults(defineProps<IPaginationProps>(), {
   large: false,
 })
 defineSlots<{
-  'start': any
-  'first-icon': any
-  'first-button': any
-  'prev-icon': any
-  'prev-button': any
-  'page-button': any
-  'next-button': any
-  'next-icon': any
-  'last-button': any
-  'last-icon': any
-  'end': any
+  'start'?: (props: Record<string, never>) => unknown
+  'first-icon'?: (props: Record<string, never>) => unknown
+  'first-button'?: (props: { setPage: () => void, disabled: boolean }) => unknown
+  'prev-icon'?: (props: Record<string, never>) => unknown
+  'prev-button'?: (props: { decreasePage: () => void, disabled: boolean }) => unknown
+  'page-button'?: (props: { page: number, setPage: (page: number) => void, disabled: boolean }) => unknown
+  'next-button'?: (props: { increasePage: () => void, disabled: boolean }) => unknown
+  'next-icon'?: (props: Record<string, never>) => unknown
+  'last-button'?: (props: { page: number, setPage: () => void, disabled: boolean }) => unknown
+  'last-icon'?: (props: Record<string, never>) => unknown
+  'end'?: (props: Record<string, never>) => unknown
 }>()
 function setPage (index: number) {
   emit('update:model-value', index)

--- a/src/components/utils/FwbSlotListener/FwbSlotListener.vue
+++ b/src/components/utils/FwbSlotListener/FwbSlotListener.vue
@@ -30,7 +30,7 @@ function appendEvents (
       else {
         vNode.props[eventName] = (...args: unknown[]) => {
           originalHandler(...args)
-          if (handler) (handler as any)(...args)
+          if (handler) (handler as (...args: unknown[]) => void)(...args)
         }
       }
     })


### PR DESCRIPTION
## Summary

Surfaced while reviewing upstream PR #411 (closed without merging — the PR bundled some valid type-safety fixes with several things we didn't want, like an auto-publish CI workflow and stale/alpha dependency bumps). This PR cherry-picks just the valid `any`-removal fixes, verified against current `main`:

- `FwbAlert`, `FwbJumbotron`, `FwbPagination`: `defineSlots<>()` payloads typed with their actual shapes instead of `any`, cross-checked against what each `<slot>` tag actually binds in the template
- `FwbAutocomplete` (component + `types.ts`): `Record<string, any>` → `Record<string, unknown>` for the generic default and `inputProps`
- `FwbSlotListener`: `(handler as any)(...args)` → a proper function-type cast
- `FwbPagination`'s `page-button` slot: moved its `v-for`/`:key` onto a wrapping `<template>`, since `vue-tsc` treats `:key` on a typed `<slot>` element as an unknown slot prop when both are on the same element
- Docs: removed the last remaining `any` in `FwbAutocompleteExampleRemote.vue` by typing the REST Countries API response instead of casting the `.map()` callback param

## Tests

- `npm run lint` — 0 warnings (was 21 before this PR)
- `npm run typecheck` — clean
- `npx vitest run` — 375/375 passing
- `npm run build:production` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to document improved type safety across component slots and autocomplete data.

* **Enhancements**
  * Improved TypeScript support with more precise slot, autocomplete, pagination, and event-handler typings.
  * Added typed response handling to the remote autocomplete example.
  * Preserved existing component behavior while providing clearer editor guidance and earlier type-checking feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->