### PR TITLE
feat(progress): fix small-value rendering, add indeterminate mode, rework color/value props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ versions predate this file and are not backfilled.
 - `FwbSelect`: the native browser dropdown arrow is now hidden (`appearance-none`) in favor of the Flowbite chevron icon, rendered via the new `chevron` slot (#438)
 - `FwbRange`: the `label` default changed from `'Range slider'` to `''` — pass `label="Range slider"` explicitly to restore the previous rendering (#440)
 - `FwbCheckbox`: `name` and `value` are no longer declared props; they now flow through attribute passthrough instead (same usage, no template changes needed) (#442)
+- `FwbProgress`: `labelPosition`/`labelProgress` renamed to `valuePosition`/`showValue` — the old names collided conceptually with the unrelated `label` prop (the bar's title text, not its value). The `color` prop now uses the shared `ColorVariant` type instead of the old `ProgressVariant`, and no longer accepts `alternative`, `light`, or `indigo` (#457)
 
 ### Added
 
@@ -31,6 +32,8 @@ versions predate this file and are not backfilled.
 - `FwbSelect`: `clearable` prop and `chevron` slot (#438)
 - `FwbRange`: thumb color customizable via the `--fwb-range-thumb-color` CSS custom property (#440)
 - `FwbFileInput`: dropzone mode now supports `validationStatus` styling (rose/emerald dashed border), `aria-invalid`/`aria-describedby` on the hidden input, and renders the `validationMessage` (slot or prop) and `helper` slot below the dropzone (#455)
+- `FwbProgress`: `indeterminate` prop for an animated, indefinite-length bar when completion isn't known yet; a scoped `value` slot (`{ progress }`) to render custom value text (file sizes, time remaining, step labels, ...) instead of the default `N%`; `role="progressbar"` and `aria-valuenow`/`aria-valuemin`/`aria-valuemax`, previously missing entirely (#457)
+- `src/types/colors.ts`: shared `ColorVariant` type, extracted from `FwbButton`'s color set and now also used by `FwbDropdown` and `FwbProgress` (#457)
 
 ### Changed
 
@@ -48,5 +51,6 @@ versions predate this file and are not backfilled.
 - `FwbFileInput`: error/success background colors corrected (were `bg-red-50`/`bg-green-50`, now `bg-rose-50`/`bg-emerald-50` to match the rest of the library) (#437)
 - Linter warnings reduced from 51 to 21 (#446)
 - `FwbFileInput`: the file selector button had `file:rounded-none` while the input wrapper has `rounded-lg` — the button's square corner was clipped by the input's rounded border box, cutting into the button text. Now rounds the button's left corners to match, and widens left padding accordingly (#455)
+- `FwbProgress`: the inner bar's left corner squared off (lost its `rounded-full`) at small `progress` values, and the inside value label was nearly invisible at small values, especially in light theme. The outer track now clips the inner bar with `overflow-hidden` so corners always stay rounded, and the inner bar clips its own value text instead of letting it spill onto the track; the value is also skipped entirely at `progress={0}` (#457)
 
 [Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.2.3...main

--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -1,10 +1,13 @@
 <script setup>
 import FwbProgressExample from './progress/examples/FwbProgressExample.vue'
-import FwbProgressExampleColor from './progress/examples/FwbProgressExampleColor.vue'
-import FwbProgressExampleCustom from './progress/examples/FwbProgressExampleCustom.vue'
+import FwbProgressExampleSize from './progress/examples/FwbProgressExampleSize.vue'
 import FwbProgressExampleLabelInside from './progress/examples/FwbProgressExampleLabelInside.vue'
 import FwbProgressExampleLabelOutside from './progress/examples/FwbProgressExampleLabelOutside.vue'
-import FwbProgressExampleSize from './progress/examples/FwbProgressExampleSize.vue'
+import FwbProgressExampleColor from './progress/examples/FwbProgressExampleColor.vue'
+import FwbProgressExampleFileSize from './progress/examples/FwbProgressExampleFileSize.vue'
+import FwbProgressExampleTimeRemaining from './progress/examples/FwbProgressExampleTimeRemaining.vue'
+import FwbProgressExampleIndeterminate from './progress/examples/FwbProgressExampleIndeterminate.vue'
+import FwbProgressExampleCustom from './progress/examples/FwbProgressExampleCustom.vue'
 </script>
 
 # Progress Bar - Flowbite Vue
@@ -17,21 +20,55 @@ import FwbProgressExampleSize from './progress/examples/FwbProgressExampleSize.v
 Original reference: [https://flowbite.com/docs/components/progress/](https://flowbite.com/docs/components/progress/)
 :::
 
-The progress bar component can be used to show the completion percentage of a task or process, with support for custom colors, sizes, and both inside and outside label variants styled with Tailwind CSS utility classes.
+The progress bar component can be used to show the completion percentage of a task or process, with support for colors, sizes, an indeterminate loading state, and both inside and outside value variants styled with Tailwind CSS utility classes.
 
 ## Default Progress Bar
 
-Use `FwbProgress` with the `progress` prop (0–100) to render a basic horizontal progress bar.
+Use `FwbProgress` with the `progress` prop (0–100) to render a basic horizontal progress bar. `showValue` and `valuePosition="outside"` render the current value next to the `label`, and the default `#value` slot content (<span v-pre>`{{ progress }}%`</span>) can be overridden to format it however you like — here it updates on an interval to demonstrate the bar responding to live data.
+
+Both bars below are bound to the same animating `progress` value, one with the value outside and one with it inside. Watch the second bar as it sweeps through very small values (near `0`) and back — this is the case that used to lose its rounded corner and render an unreadable label, before the fix described in [Value Inside](#value-inside).
 
 <fwb-progress-example />
 
 ```vue
 <template>
-  <fwb-progress :progress="45" />
+  <fwb-progress
+    :progress="progress"
+    value-position="outside"
+    show-value
+    label="Basic Percentage"
+  >
+    <template #value="{ progress: value }">
+      {{ value.toFixed(1) }}%
+    </template>
+  </fwb-progress>
+  <fwb-progress
+    :progress="progress"
+    value-position="inside"
+    show-value
+    size="lg"
+    label="Same value, shown inside the bar"
+  >
+    <template #value="{ progress: value }">
+      {{ value.toFixed(1) }}%
+    </template>
+  </fwb-progress>
 </template>
 
 <script setup>
+import { onMounted, onUnmounted, ref } from 'vue'
 import { FwbProgress } from 'flowbite-vue'
+
+const progress = ref(0)
+let timer
+
+onMounted(() => {
+  timer = setInterval(() => {
+    progress.value = progress.value >= 100 ? 0 : Math.min(100, progress.value + 4.5)
+  }, 400)
+})
+
+onUnmounted(() => clearInterval(timer))
 </script>
 ```
 
@@ -56,9 +93,9 @@ import { FwbProgress } from 'flowbite-vue'
 </script>
 ```
 
-## Label Inside
+## Value Inside
 
-Set `label-position="inside"` and `label-progress` to render the percentage value inside the progress bar. Use `size="lg"` or larger to ensure there is enough space for the label.
+Set `value-position="inside"` and `show-value` to render the percentage value inside the progress bar. Use `size="lg"` or larger to ensure there is enough space for it. At very small `progress` values the bar is too narrow to fit the value text — it's clipped to the bar's own width rather than spilling onto the track, and is skipped entirely at exactly `0`.
 
 <fwb-progress-example-label-inside />
 
@@ -66,8 +103,8 @@ Set `label-position="inside"` and `label-progress` to render the percentage valu
 <template>
   <fwb-progress
     :progress="50"
-    label-position="inside"
-    label-progress
+    value-position="inside"
+    show-value
     size="lg"
   />
 </template>
@@ -77,9 +114,9 @@ import { FwbProgress } from 'flowbite-vue'
 </script>
 ```
 
-## Label Outside
+## Value Outside
 
-Set `label-position="outside"` and `label-progress` to render the percentage value to the right of the label text above the bar. Use `label` to set the descriptive text on the left.
+Set `value-position="outside"` and `show-value` to render the percentage value to the right of the `label` text above the bar.
 
 <fwb-progress-example-label-outside />
 
@@ -87,9 +124,104 @@ Set `label-position="outside"` and `label-progress` to render the percentage val
 <template>
   <fwb-progress
     :progress="42"
-    label-position="outside"
-    label-progress
+    value-position="outside"
+    show-value
     label="Flowbite Vue 3"
+  />
+</template>
+
+<script setup>
+import { FwbProgress } from 'flowbite-vue'
+</script>
+```
+
+## Custom value formatting
+
+The `value` slot receives the current `progress` as a scoped prop, so you can replace the default <span v-pre>`{{ progress }}%`</span> text with anything — file sizes, time remaining, step counts, and so on. The bar's width still tracks the numeric `progress` prop; only the displayed text changes.
+
+<fwb-progress-example-file-size />
+
+```vue
+<template>
+  <fwb-progress
+    :progress="percentage"
+    value-position="outside"
+    show-value
+    label="File Size Progress"
+    color="green"
+  >
+    <template #value>
+      {{ (loaded / 1024).toFixed(2) }} KB / {{ (total / 1024).toFixed(2) }} KB
+    </template>
+  </fwb-progress>
+</template>
+
+<script setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { FwbProgress } from 'flowbite-vue'
+
+const total = 5000
+const loaded = ref(0)
+const percentage = computed(() => Math.min(100, (loaded.value / total) * 100))
+let timer
+
+onMounted(() => {
+  timer = setInterval(() => {
+    loaded.value = loaded.value >= total ? 0 : loaded.value + total / 20
+  }, 400)
+})
+
+onUnmounted(() => clearInterval(timer))
+</script>
+```
+
+<fwb-progress-example-time-remaining />
+
+```vue
+<template>
+  <fwb-progress
+    :progress="percentage"
+    value-position="outside"
+    show-value
+    label="Time Remaining"
+    color="purple"
+  >
+    <template #value>
+      {{ Math.round(percentage) }}% ({{ secondsRemaining }}s remaining)
+    </template>
+  </fwb-progress>
+</template>
+
+<script setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { FwbProgress } from 'flowbite-vue'
+
+const totalSeconds = 25
+const secondsRemaining = ref(totalSeconds)
+const percentage = computed(() => ((totalSeconds - secondsRemaining.value) / totalSeconds) * 100)
+let timer
+
+onMounted(() => {
+  timer = setInterval(() => {
+    secondsRemaining.value = secondsRemaining.value <= 0 ? totalSeconds : secondsRemaining.value - 1
+  }, 1000)
+})
+
+onUnmounted(() => clearInterval(timer))
+</script>
+```
+
+## Indeterminate
+
+Set the `indeterminate` prop when the completion percentage isn't known yet — e.g. while waiting on a response before real upload/download progress is available. The bar ignores `progress` and animates instead. Pair it with `label` for a status message.
+
+<fwb-progress-example-indeterminate />
+
+```vue
+<template>
+  <fwb-progress
+    indeterminate
+    label="Uploading file..."
   />
 </template>
 
@@ -100,21 +232,21 @@ import { FwbProgress } from 'flowbite-vue'
 
 ## Colors
 
-Use the `color` prop to change the fill color of the progress bar. Available values are `default`, `dark`, `blue`, `red`, `green`, `yellow`, `indigo`, and `purple`.
+Use the `color` prop to change the fill color of the progress bar: `default`, `dark`, `blue`, `red`, `green`, `yellow`, `purple`, or `pink`. This is a subset of `FwbButton`'s `color` prop — `alternative` and `light` are excluded, since a white/bordered fill isn't distinguishable from the plain gray track.
 
 <fwb-progress-example-color />
 
 ```vue
 <template>
   <div class="grid gap-2">
-    <fwb-progress :progress="12.5" label="Default" />
-    <fwb-progress :progress="25" color="dark" label="Dark" />
-    <fwb-progress :progress="37.5" color="blue" label="Blue" />
-    <fwb-progress :progress="50" color="red" label="Red" />
-    <fwb-progress :progress="62.5" color="green" label="Green" />
-    <fwb-progress :progress="75" color="yellow" label="Yellow" />
-    <fwb-progress :progress="87.5" color="indigo" label="Indigo" />
-    <fwb-progress :progress="100" color="purple" label="Purple" />
+    <fwb-progress :progress="12.5" label="Default" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="25" color="dark" label="Dark" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="37.5" color="blue" label="Blue" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="50" color="red" label="Red" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="62.5" color="green" label="Green" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="75" color="yellow" label="Yellow" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="87.5" color="purple" label="Purple" value-position="inside" show-value size="lg" />
+    <fwb-progress :progress="100" color="pink" label="Pink" value-position="inside" show-value size="lg" />
   </div>
 </template>
 
@@ -125,7 +257,7 @@ import { FwbProgress } from 'flowbite-vue'
 
 ## Custom Styling
 
-Use `inner-classes`, `outer-classes`, and `outside-label-classes` to override any part of the progress bar's default styling with your own Tailwind utilities.
+Use `inner-classes`, `outer-classes`, and `outside-label-classes` to override any part of the progress bar's default styling with your own Tailwind utilities — useful for one-off colors outside the `color` palette.
 
 <fwb-progress-example-custom />
 
@@ -133,9 +265,12 @@ Use `inner-classes`, `outer-classes`, and `outside-label-classes` to override an
 <template>
   <fwb-progress
     :progress="50"
-    :inner-classes="'rounded-xs bg-teal-900 dark:bg-teal-200'"
-    :outer-classes="'bg-teal-200 dark:bg-teal-900'"
-    :outside-label-classes="'italic text-sky-800 dark:text-sky-200'"
+    value-position="inside"
+    show-value
+    size="lg"
+    inner-classes="bg-amber-900 dark:bg-green-200 text-amber-100 dark:text-green-900"
+    outer-classes="bg-amber-200 dark:bg-green-900"
+    outside-label-classes="font-bold text-amber-900 dark:text-green-200"
     label="Custom"
   />
 </template>
@@ -149,14 +284,21 @@ import { FwbProgress } from 'flowbite-vue'
 
 ### FwbProgress Props
 
-| Name               | Type                                                              | Default     | Description                                                                         |
-| ------------------ | ----------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------- |
-| color              | `'default' \| 'dark' \| 'blue' \| 'red' \| 'green' \| 'yellow' \| 'indigo' \| 'purple'` | `'default'` | Fill color of the inner progress bar.     |
-| innerClasses       | `String \| Object`                                                | `''`        | Overrides or extends classes on the inner progress bar element.                     |
-| label              | `String`                                                          | `''`        | Descriptive text rendered above the bar on the left side.                           |
-| labelPosition      | `'none' \| 'inside' \| 'outside'`                                | `'none'`    | Controls where the percentage value is rendered relative to the bar.                |
-| labelProgress      | `Boolean`                                                         | `false`     | When `true`, renders the `progress` percentage next to or inside the bar.           |
-| outerClasses       | `String \| Object`                                                | `''`        | Overrides or extends classes on the outer progress track element.                   |
-| outsideLabelClasses | `String \| Object`                                               | `''`        | Overrides or extends classes on the label/percentage text rendered outside the bar. |
-| progress           | `Number`                                                          | `0`         | The current completion value (0–100).                                               |
-| size               | `'sm' \| 'md' \| 'lg' \| 'xl'`                                   | `'md'`      | Controls the height of the progress bar track.                                      |
+| Name                | Type                                                                                  | Default     | Description                                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| color               | `'default' \| 'dark' \| 'blue' \| 'red' \| 'green' \| 'yellow' \| 'purple' \| 'pink'` | `'default'` | Fill color of the inner progress bar. Subset of `FwbButton`'s `color` prop (excludes `alternative`/`light`). |
+| indeterminate       | `Boolean`                                                                             | `false`     | Renders an animated, indefinite-length bar instead of a `progress`-driven one, for unknown durations.        |
+| innerClasses        | `String \| Object`                                                                    | `''`        | Overrides or extends classes on the inner progress bar element.                                              |
+| label               | `String`                                                                              | `''`        | Descriptive text rendered above the bar on the left side.                                                    |
+| outerClasses        | `String \| Object`                                                                    | `''`        | Overrides or extends classes on the outer progress track element.                                            |
+| outsideLabelClasses | `String \| Object`                                                                    | `''`        | Overrides or extends classes on the label/value text rendered outside the bar.                               |
+| progress            | `Number`                                                                              | `0`         | The current completion value (0–100). Ignored when `indeterminate` is set.                                   |
+| showValue           | `Boolean`                                                                             | `false`     | When `true`, renders the value (`progress`, or the `value` slot) next to or inside the bar.                  |
+| size                | `'sm' \| 'md' \| 'lg' \| 'xl'`                                                        | `'md'`      | Controls the height of the progress bar track.                                                               |
+| valuePosition       | `'none' \| 'inside' \| 'outside'`                                                     | `'none'`    | Controls where the value is rendered relative to the bar.                                                    |
+
+### FwbProgress Slots
+
+| Name  | Scope                  | Description                                                                              |
+| ----- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| value | `{ progress: number }` | Overrides the default <span v-pre>`{{ progress }}%`</span> text wherever the value is shown (inside or outside the bar). |

--- a/docs/components/progress/examples/FwbProgressExample.vue
+++ b/docs/components/progress/examples/FwbProgressExample.vue
@@ -1,9 +1,44 @@
 <template>
-  <div class="vp-raw">
-    <fwb-progress :progress="45" />
+  <div class="vp-raw flex flex-col gap-4">
+    <fwb-progress
+      :progress="progress"
+      value-position="outside"
+      show-value
+      label="Basic Percentage"
+    >
+      <template #value="{ progress: value }">
+        {{ value.toFixed(1) }}%
+      </template>
+    </fwb-progress>
+    <fwb-progress
+      :progress="progress"
+      value-position="inside"
+      show-value
+      size="lg"
+      label="Same value, shown inside the bar"
+    >
+      <template #value="{ progress: value }">
+        {{ value.toFixed(1) }}%
+      </template>
+    </fwb-progress>
   </div>
 </template>
 
 <script lang="ts" setup>
+import { onMounted, onUnmounted, ref } from 'vue'
+
 import { FwbProgress } from '../../../../src/index'
+
+const progress = ref(0)
+let timer: ReturnType<typeof setInterval> | undefined
+
+onMounted(() => {
+  timer = setInterval(() => {
+    progress.value = progress.value >= 100 ? 0 : Math.min(100, progress.value + 4.5)
+  }, 400)
+})
+
+onUnmounted(() => {
+  clearInterval(timer)
+})
 </script>

--- a/docs/components/progress/examples/FwbProgressExampleColor.vue
+++ b/docs/components/progress/examples/FwbProgressExampleColor.vue
@@ -3,41 +3,65 @@
     <fwb-progress
       label="Default"
       :progress="12.5"
+      value-position="inside"
+      show-value
+      size="lg"
     />
     <fwb-progress
       color="dark"
       label="Dark"
       :progress="25"
+      value-position="inside"
+      show-value
+      size="lg"
     />
     <fwb-progress
       color="blue"
       label="Blue"
       :progress="37.5"
+      value-position="inside"
+      show-value
+      size="lg"
     />
     <fwb-progress
       color="red"
       label="Red"
       :progress="50"
+      value-position="inside"
+      show-value
+      size="lg"
     />
     <fwb-progress
       color="green"
       label="Green"
       :progress="62.5"
+      value-position="inside"
+      show-value
+      size="lg"
     />
     <fwb-progress
       color="yellow"
       label="Yellow"
       :progress="75"
-    />
-    <fwb-progress
-      color="indigo"
-      label="Indigo"
-      :progress="87.5"
+      value-position="inside"
+      show-value
+      size="lg"
     />
     <fwb-progress
       color="purple"
       label="Purple"
+      :progress="87.5"
+      value-position="inside"
+      show-value
+      size="lg"
+    />
+    <fwb-progress
+      color="pink"
+      label="Pink"
       :progress="100"
+      value-position="inside"
+      show-value
+      size="lg"
     />
   </div>
 </template>

--- a/docs/components/progress/examples/FwbProgressExampleCustom.vue
+++ b/docs/components/progress/examples/FwbProgressExampleCustom.vue
@@ -1,9 +1,12 @@
 <template>
   <fwb-progress
     :progress="50"
-    :inner-classes="'rounded-xs bg-teal-900 dark:bg-teal-200'"
-    :outer-classes="'bg-teal-200 dark:bg-teal-900'"
-    :outside-label-classes="'italic text-sky-800 dark:text-sky-200'"
+    value-position="inside"
+    show-value
+    size="lg"
+    inner-classes="bg-amber-900 dark:bg-green-200 text-amber-100 dark:text-green-900"
+    outer-classes="bg-amber-200 dark:bg-green-900"
+    outside-label-classes="font-bold text-amber-900 dark:text-green-200"
     label="Custom"
   />
 </template>

--- a/docs/components/progress/examples/FwbProgressExampleFileSize.vue
+++ b/docs/components/progress/examples/FwbProgressExampleFileSize.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="vp-raw">
+    <fwb-progress
+      :progress="percentage"
+      value-position="outside"
+      show-value
+      label="File Size Progress"
+      color="green"
+    >
+      <template #value>
+        {{ (loaded / 1024).toFixed(2) }} KB / {{ (total / 1024).toFixed(2) }} KB
+      </template>
+    </fwb-progress>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+import { FwbProgress } from '../../../../src/index'
+
+const total = 5000
+const loaded = ref(0)
+const percentage = computed(() => Math.min(100, (loaded.value / total) * 100))
+
+let timer: ReturnType<typeof setInterval> | undefined
+
+onMounted(() => {
+  timer = setInterval(() => {
+    loaded.value = loaded.value >= total ? 0 : loaded.value + total / 20
+  }, 400)
+})
+
+onUnmounted(() => {
+  clearInterval(timer)
+})
+</script>

--- a/docs/components/progress/examples/FwbProgressExampleIndeterminate.vue
+++ b/docs/components/progress/examples/FwbProgressExampleIndeterminate.vue
@@ -1,10 +1,10 @@
 <template>
-  <fwb-progress
-    :progress="50"
-    value-position="inside"
-    show-value
-    size="lg"
-  />
+  <div class="vp-raw">
+    <fwb-progress
+      indeterminate
+      label="Uploading file..."
+    />
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/docs/components/progress/examples/FwbProgressExampleLabelOutside.vue
+++ b/docs/components/progress/examples/FwbProgressExampleLabelOutside.vue
@@ -1,8 +1,8 @@
 <template>
   <fwb-progress
     :progress="42"
-    label-position="outside"
-    label-progress
+    value-position="outside"
+    show-value
     label="Flowbite Vue 3"
   />
 </template>

--- a/docs/components/progress/examples/FwbProgressExampleTimeRemaining.vue
+++ b/docs/components/progress/examples/FwbProgressExampleTimeRemaining.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="vp-raw">
+    <fwb-progress
+      :progress="percentage"
+      value-position="outside"
+      show-value
+      label="Time Remaining"
+      color="purple"
+    >
+      <template #value>
+        {{ Math.round(percentage) }}% ({{ secondsRemaining }}s remaining)
+      </template>
+    </fwb-progress>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+import { FwbProgress } from '../../../../src/index'
+
+const totalSeconds = 25
+const secondsRemaining = ref(totalSeconds)
+const percentage = computed(() => ((totalSeconds - secondsRemaining.value) / totalSeconds) * 100)
+
+let timer: ReturnType<typeof setInterval> | undefined
+
+onMounted(() => {
+  timer = setInterval(() => {
+    secondsRemaining.value = secondsRemaining.value <= 0 ? totalSeconds : secondsRemaining.value - 1
+  }, 1000)
+})
+
+onUnmounted(() => {
+  clearInterval(timer)
+})
+</script>

--- a/src/components/FwbButton/composables/useButtonClasses.ts
+++ b/src/components/FwbButton/composables/useButtonClasses.ts
@@ -1,6 +1,7 @@
 import { computed, type ComputedRef, type Ref, useSlots } from 'vue'
 
-import type { ButtonDuotoneGradient, ButtonGradient, ButtonMonochromeGradient, ButtonSize, ButtonVariant } from '../types'
+import type { ButtonDuotoneGradient, ButtonGradient, ButtonMonochromeGradient, ButtonSize } from '../types'
+import type { ColorVariant } from '@/types/colors'
 import type { ClassInput } from '@/types/global'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
@@ -9,7 +10,7 @@ export type ButtonClassMap<T extends string> = { hover: Record<T, string>, defau
 
 const buttonDefaultClasses = 'inline-block'
 
-const buttonColorClasses: ButtonClassMap<ButtonVariant> = {
+const buttonColorClasses: ButtonClassMap<ColorVariant> = {
   default: {
     alternative: 'font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 focus:z-10 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600',
     blue: 'text-white bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg dark:bg-blue-600 focus:outline-none dark:focus:ring-blue-800',
@@ -36,7 +37,7 @@ const buttonColorClasses: ButtonClassMap<ButtonVariant> = {
   },
 }
 
-const buttonOutlineColorClasses: ButtonClassMap<Exclude<ButtonVariant, 'light' | 'alternative'>> = {
+const buttonOutlineColorClasses: ButtonClassMap<Exclude<ColorVariant, 'light' | 'alternative'>> = {
   default: {
     blue: 'text-blue-700 border border-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm text-center dark:border-blue-500 dark:text-blue-500 dark:focus:ring-blue-800',
     dark: 'text-gray-900 border border-gray-800 focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm text-center dark:border-gray-600 dark:text-gray-400 dark:focus:ring-gray-800',
@@ -146,7 +147,7 @@ const buttonShadowClasses: Record<ButtonMonochromeGradient, string> = {
 
 interface UseButtonClassesProps {
   class: Ref<ClassInput>
-  color: Ref<ButtonVariant>
+  color: Ref<ColorVariant>
   disabled: Ref<boolean>
   gradient: Ref<ButtonGradient | null>
   loading: Ref<boolean>

--- a/src/components/FwbButton/composables/useButtonSpinner.ts
+++ b/src/components/FwbButton/composables/useButtonSpinner.ts
@@ -1,12 +1,13 @@
 import { computed, type Ref } from 'vue'
 
-import type { ButtonGradient, ButtonSize, ButtonVariant } from '../types'
+import type { ButtonGradient, ButtonSize } from '../types'
 import type { SpinnerColor, SpinnerSize } from './../../FwbSpinner/types'
+import type { ColorVariant } from '@/types/colors'
 
 export type UseButtonSpinnerProps = {
   outline: Ref<boolean>
   size: Ref<ButtonSize>
-  color: Ref<ButtonVariant>
+  color: Ref<ColorVariant>
   gradient: Ref<ButtonGradient | null>
 }
 

--- a/src/components/FwbButton/types.ts
+++ b/src/components/FwbButton/types.ts
@@ -1,14 +1,14 @@
+import type { ColorVariant } from '@/types/colors'
 import type { ClassInput } from '@/types/global'
 
 export type ButtonMonochromeGradient = 'blue' | 'green' | 'cyan' | 'teal' | 'lime' | 'red' | 'pink' | 'purple'
 export type ButtonDuotoneGradient = 'purple-blue' | 'cyan-blue' | 'green-blue' | 'purple-pink' | 'pink-orange' | 'teal-lime' | 'red-yellow'
 export type ButtonGradient = ButtonDuotoneGradient | ButtonMonochromeGradient
-export type ButtonVariant = 'default' | 'alternative' | 'dark' | 'light' | 'green' | 'red' | 'yellow' | 'purple' | 'pink' | 'blue'
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 export interface ButtonProps {
   class?: ClassInput
-  color?: ButtonVariant
+  color?: ColorVariant
   disabled?: boolean
   gradient?: ButtonGradient | null
   href?: string

--- a/src/components/FwbDropdown/FwbDropdown.vue
+++ b/src/components/FwbDropdown/FwbDropdown.vue
@@ -58,7 +58,7 @@ import { computed, ref, watch } from 'vue'
 import { useDropdownClasses } from './composables/useDropdownClasses'
 
 import type { DropdownPlacement } from './types'
-import type { ButtonVariant } from '@/components/FwbButton/types'
+import type { ColorVariant } from '@/types/colors'
 
 import FwbButton from '@/components/FwbButton/FwbButton.vue'
 import FwbSlotListener from '@/components/utils/FwbSlotListener/FwbSlotListener.vue'
@@ -67,7 +67,7 @@ export interface DropdownProps {
   alignToEnd?: boolean
   class?: string
   closeInside?: boolean
-  color?: ButtonVariant
+  color?: ColorVariant
   contentWrapperClass?: string
   disabled?: boolean
   placement?: DropdownPlacement

--- a/src/components/FwbProgress/FwbProgress.vue
+++ b/src/components/FwbProgress/FwbProgress.vue
@@ -1,25 +1,43 @@
 <template>
   <div>
-    <template v-if="label || (labelProgress && labelPosition === 'outside')">
+    <template v-if="label || (showValue && valuePosition === 'outside' && !indeterminate)">
       <div class="mb-1 flex justify-between">
+        <span :class="outsideLabelClasses">{{ label }}</span>
         <span
+          v-if="showValue && valuePosition === 'outside' && !indeterminate"
           :class="outsideLabelClasses"
-        >{{ label }}</span>
-        <span
-          v-if="labelProgress && labelPosition === 'outside'"
-          :class="outsideLabelClasses"
-        >{{ progress }}%</span>
+        >
+          <slot
+            name="value"
+            :progress="progress"
+          >{{ progress }}%</slot>
+        </span>
       </div>
     </template>
     <div
       :class="outerClasses"
+      role="progressbar"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      :aria-valuenow="indeterminate ? undefined : progress"
     >
       <div
+        v-if="indeterminate"
+        class="fwb-progress-indeterminate absolute inset-y-0 left-0"
+        :class="innerClasses"
+      />
+      <div
+        v-else
         :class="innerClasses"
         :style="{ width: progress + '%' }"
       >
-        <template v-if="labelProgress && labelPosition === 'inside'">
-          {{ progress }}%
+        <template v-if="showValue && valuePosition === 'inside' && progress > 0">
+          <slot
+            name="value"
+            :progress="progress"
+          >
+            {{ progress }}%
+          </slot>
         </template>
       </div>
     </div>
@@ -31,14 +49,15 @@ import { toRefs } from 'vue'
 
 import { useProgressClasses } from './composables/useProgressClasses'
 
-import type { ProgressLabelPosition, ProgressSize, ProgressVariant } from './types'
+import type { ProgressColorVariant, ProgressSize, ProgressValuePosition } from './types'
 
 interface IProgressProps {
-  color?: ProgressVariant
+  color?: ProgressColorVariant
   label?: string
-  labelPosition?: ProgressLabelPosition
-  labelProgress?: boolean
+  showValue?: boolean
+  valuePosition?: ProgressValuePosition
   progress?: number
+  indeterminate?: boolean
   size?: ProgressSize
   innerClasses?: string | Record<string, boolean>
   outerClasses?: string | Record<string, boolean>
@@ -48,14 +67,19 @@ interface IProgressProps {
 const props = withDefaults(defineProps<IProgressProps>(), {
   color: 'default',
   label: '',
-  labelPosition: 'none',
-  labelProgress: false,
+  showValue: false,
+  valuePosition: 'none',
   progress: 0,
+  indeterminate: false,
   size: 'md',
   innerClasses: '',
   outerClasses: '',
   outsideLabelClasses: '',
 })
+
+defineSlots<{
+  value?: (props: { progress: number }) => unknown
+}>()
 
 const {
   innerClasses,
@@ -63,3 +87,24 @@ const {
   outsideLabelClasses,
 } = useProgressClasses(toRefs(props))
 </script>
+
+<style scoped>
+@keyframes fwb-progress-indeterminate-slide {
+  0% {
+    left: -40%;
+    width: 40%;
+  }
+  50% {
+    left: 20%;
+    width: 60%;
+  }
+  100% {
+    left: 100%;
+    width: 40%;
+  }
+}
+
+.fwb-progress-indeterminate {
+  animation: fwb-progress-indeterminate-slide 1.5s ease-in-out infinite;
+}
+</style>

--- a/src/components/FwbProgress/FwbProgress.vue
+++ b/src/components/FwbProgress/FwbProgress.vue
@@ -2,7 +2,10 @@
   <div>
     <template v-if="label || (showValue && valuePosition === 'outside' && !indeterminate)">
       <div class="mb-1 flex justify-between">
-        <span :class="outsideLabelClasses">{{ label }}</span>
+        <span
+          :id="labelId"
+          :class="outsideLabelClasses"
+        >{{ label }}</span>
         <span
           v-if="showValue && valuePosition === 'outside' && !indeterminate"
           :class="outsideLabelClasses"
@@ -20,6 +23,8 @@
       aria-valuemin="0"
       aria-valuemax="100"
       :aria-valuenow="indeterminate ? undefined : progress"
+      :aria-labelledby="label ? labelId : undefined"
+      :aria-label="label ? undefined : 'Progress'"
     >
       <div
         v-if="indeterminate"
@@ -45,7 +50,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { toRefs, useId } from 'vue'
 
 import { useProgressClasses } from './composables/useProgressClasses'
 
@@ -81,6 +86,8 @@ defineSlots<{
   value?: (props: { progress: number }) => unknown
 }>()
 
+const labelId = useId()
+
 const {
   innerClasses,
   outerClasses,
@@ -106,5 +113,12 @@ const {
 
 .fwb-progress-indeterminate {
   animation: fwb-progress-indeterminate-slide 1.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fwb-progress-indeterminate {
+    width: 40%;
+    animation: none;
+  }
 }
 </style>

--- a/src/components/FwbProgress/composables/useProgressClasses.ts
+++ b/src/components/FwbProgress/composables/useProgressClasses.ts
@@ -1,33 +1,33 @@
 import { computed, type Ref } from 'vue'
 
-import type { ProgressLabelPosition, ProgressSize, ProgressVariant } from '../types'
+import type { ProgressColorVariant, ProgressSize } from '../types'
 
 import { useMergeClasses } from '@/composables/useMergeClasses'
 
-const defaultInnerClasses = 'rounded-full p-0.5 text-center font-medium text-blue-100'
-const defaultOuterClasses = 'w-full rounded-full bg-gray-200 dark:bg-gray-700'
-const defaultOutsideLabelClasses = 'text-base font-medium'
+const defaultInnerClasses = 'overflow-hidden rounded-full p-0.5 text-center font-medium text-blue-100'
+const defaultOuterClasses = 'relative w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'
+const defaultOutsideLabelClasses = 'text-base font-medium text-gray-700 dark:text-white'
 
-const barColorClasses: Record<ProgressVariant, string> = {
-  default: 'bg-blue-600 dark:bg-blue-600',
-  blue: 'bg-blue-600 dark:bg-blue-600',
-  dark: 'bg-gray-600 dark:bg-gray-300',
-  green: 'bg-green-600 dark:bg-green-500',
-  red: 'bg-red-600 dark:bg-red-500',
+const progressColorClasses: Record<ProgressColorVariant, string> = {
+  blue: 'bg-blue-700 dark:bg-blue-600',
+  dark: 'bg-gray-800 dark:bg-gray-800',
+  default: 'bg-blue-700 dark:bg-blue-600',
+  green: 'bg-green-700 dark:bg-green-600',
+  pink: 'bg-pink-700 dark:bg-pink-600',
+  purple: 'bg-purple-700 dark:bg-purple-600',
+  red: 'bg-red-700 dark:bg-red-600',
   yellow: 'bg-yellow-400',
-  indigo: 'bg-indigo-600 dark:bg-indigo-500',
-  purple: 'bg-purple-600 dark:bg-purple-500',
 }
 
-const outsideTextColorClasses: Record<ProgressVariant, string> = {
-  default: '',
+const outsideTextColorClasses: Record<ProgressColorVariant, string> = {
   blue: 'text-blue-700 dark:text-blue-500',
   dark: 'dark:text-white',
+  default: '',
   green: 'text-green-700 dark:text-green-500',
+  pink: 'text-pink-700 dark:text-pink-500',
+  purple: 'text-purple-700 dark:text-purple-500',
   red: 'text-red-700 dark:text-red-500',
   yellow: 'text-yellow-700 dark:text-yellow-500',
-  indigo: 'text-indigo-700 dark:text-indigo-500',
-  purple: 'text-purple-700 dark:text-purple-500',
 }
 
 const progressSizeClasses: Record<ProgressSize, string> = {
@@ -38,9 +38,8 @@ const progressSizeClasses: Record<ProgressSize, string> = {
 }
 
 export type UseProgressClassesProps = {
-  color: Ref<ProgressVariant>
+  color: Ref<ProgressColorVariant>
   size: Ref<ProgressSize>
-  labelPosition: Ref<ProgressLabelPosition>
   innerClasses?: Ref<string | Record<string, boolean>>
   outerClasses?: Ref<string | Record<string, boolean>>
   outsideLabelClasses?: Ref<string | Record<string, boolean>>
@@ -53,7 +52,7 @@ export function useProgressClasses (props: UseProgressClassesProps): {
 } {
   const innerClasses = computed(() => useMergeClasses([
     defaultInnerClasses,
-    barColorClasses[props.color.value],
+    progressColorClasses[props.color.value],
     progressSizeClasses[props.size.value],
     props.innerClasses?.value || '',
   ]))

--- a/src/components/FwbProgress/tests/FwbProgress.spec.ts
+++ b/src/components/FwbProgress/tests/FwbProgress.spec.ts
@@ -1,0 +1,135 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbProgress from '../FwbProgress.vue'
+
+describe('FwbProgress', () => {
+  describe('default rendering', () => {
+    it('renders a progressbar role with aria-value bounds', () => {
+      const wrapper = mount(FwbProgress, { props: { progress: 45 } })
+      const track = wrapper.find('[role="progressbar"]')
+      expect(track.attributes('aria-valuemin')).toBe('0')
+      expect(track.attributes('aria-valuemax')).toBe('100')
+      expect(track.attributes('aria-valuenow')).toBe('45')
+    })
+
+    it('sets the inner bar width from the progress prop', () => {
+      const wrapper = mount(FwbProgress, { props: { progress: 33 } })
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.attributes('style')).toContain('width: 33%')
+    })
+
+    it('renders no label row when label is empty and showValue is false', () => {
+      const wrapper = mount(FwbProgress)
+      expect(wrapper.find('.mb-1').exists()).toBe(false)
+    })
+
+    it('renders the label row when label is set', () => {
+      const wrapper = mount(FwbProgress, { props: { label: 'Uploading' } })
+      expect(wrapper.text()).toContain('Uploading')
+    })
+  })
+
+  describe('value display', () => {
+    it('does not render a value when showValue is false', () => {
+      const wrapper = mount(FwbProgress, { props: { progress: 50, valuePosition: 'inside' } })
+      expect(wrapper.text()).not.toContain('50%')
+    })
+
+    it('renders the default N% value inside the bar', () => {
+      const wrapper = mount(FwbProgress, {
+        props: { progress: 50, showValue: true, valuePosition: 'inside' },
+      })
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.text()).toBe('50%')
+    })
+
+    it('renders the value outside the bar, next to the label', () => {
+      const wrapper = mount(FwbProgress, {
+        props: { progress: 42, label: 'Flowbite Vue', showValue: true, valuePosition: 'outside' },
+      })
+      const labelRow = wrapper.find('.mb-1')
+      expect(labelRow.text()).toContain('Flowbite Vue')
+      expect(labelRow.text()).toContain('42%')
+    })
+
+    it('does not render the value inside the bar when progress is exactly 0', () => {
+      const wrapper = mount(FwbProgress, {
+        props: { progress: 0, showValue: true, valuePosition: 'inside' },
+      })
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.text()).toBe('')
+    })
+
+    it('uses custom formatting from the value slot', () => {
+      const wrapper = mount(FwbProgress, {
+        props: { progress: 40, showValue: true, valuePosition: 'inside' },
+        slots: {
+          value: '<template #value="{ progress }">{{ progress }} of 100</template>',
+        },
+      })
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.text()).toBe('40 of 100')
+    })
+  })
+
+  describe('color classes', () => {
+    it('applies the default blue fill', () => {
+      const wrapper = mount(FwbProgress)
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.classes()).toContain('bg-blue-700')
+    })
+
+    it('applies a different fill for other color variants', () => {
+      const wrapper = mount(FwbProgress, { props: { color: 'green' } })
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.classes()).toContain('bg-green-700')
+    })
+  })
+
+  describe('size classes', () => {
+    it('sm and xl apply different track heights', () => {
+      const sm = mount(FwbProgress, { props: { size: 'sm' } })
+      const xl = mount(FwbProgress, { props: { size: 'xl' } })
+      expect(sm.find('[role="progressbar"]').classes()).toContain('h-1.5')
+      expect(xl.find('[role="progressbar"]').classes()).toContain('h-6')
+    })
+  })
+
+  describe('indeterminate mode', () => {
+    it('omits aria-valuenow', () => {
+      const wrapper = mount(FwbProgress, { props: { indeterminate: true, progress: 50 } })
+      expect(wrapper.find('[role="progressbar"]').attributes('aria-valuenow')).toBeUndefined()
+    })
+
+    it('does not set an inline width style', () => {
+      const wrapper = mount(FwbProgress, { props: { indeterminate: true, progress: 50 } })
+      const bar = wrapper.find('[role="progressbar"] > div')
+      expect(bar.attributes('style')).toBeUndefined()
+    })
+
+    it('does not render a value even when showValue is set', () => {
+      const wrapper = mount(FwbProgress, {
+        props: { indeterminate: true, progress: 50, showValue: true, valuePosition: 'outside', label: 'Uploading' },
+      })
+      const labelRow = wrapper.find('.mb-1')
+      expect(labelRow.text()).toBe('Uploading')
+    })
+  })
+
+  describe('custom classes', () => {
+    it('merges innerClasses, outerClasses and outsideLabelClasses onto their elements', () => {
+      const wrapper = mount(FwbProgress, {
+        props: {
+          label: 'Custom',
+          innerClasses: 'bg-teal-900',
+          outerClasses: 'bg-teal-200',
+          outsideLabelClasses: 'italic',
+        },
+      })
+      expect(wrapper.find('[role="progressbar"] > div').classes()).toContain('bg-teal-900')
+      expect(wrapper.find('[role="progressbar"]').classes()).toContain('bg-teal-200')
+      expect(wrapper.find('.mb-1 span').classes()).toContain('italic')
+    })
+  })
+})

--- a/src/components/FwbProgress/tests/FwbProgress.spec.ts
+++ b/src/components/FwbProgress/tests/FwbProgress.spec.ts
@@ -30,6 +30,24 @@ describe('FwbProgress', () => {
     })
   })
 
+  describe('accessible name', () => {
+    it('links the progressbar to the label text via aria-labelledby', () => {
+      const wrapper = mount(FwbProgress, { props: { label: 'Uploading' } })
+      const track = wrapper.find('[role="progressbar"]')
+      const labelledby = track.attributes('aria-labelledby')
+      expect(labelledby).toBeDefined()
+      expect(wrapper.find(`#${labelledby}`).text()).toBe('Uploading')
+      expect(track.attributes('aria-label')).toBeUndefined()
+    })
+
+    it('falls back to a generic aria-label when no label is set', () => {
+      const wrapper = mount(FwbProgress)
+      const track = wrapper.find('[role="progressbar"]')
+      expect(track.attributes('aria-label')).toBe('Progress')
+      expect(track.attributes('aria-labelledby')).toBeUndefined()
+    })
+  })
+
   describe('value display', () => {
     it('does not render a value when showValue is false', () => {
       const wrapper = mount(FwbProgress, { props: { progress: 50, valuePosition: 'inside' } })

--- a/src/components/FwbProgress/types.ts
+++ b/src/components/FwbProgress/types.ts
@@ -1,3 +1,5 @@
-export type ProgressLabelPosition = 'inside' | 'outside' | 'none'
+import type { ColorVariant } from '@/types/colors'
+
+export type ProgressValuePosition = 'inside' | 'outside' | 'none'
 export type ProgressSize = 'sm' | 'md' | 'lg' | 'xl'
-export type ProgressVariant = 'default' | 'dark' | 'green' | 'red' | 'yellow' | 'purple' | 'blue' | 'indigo'
+export type ProgressColorVariant = Exclude<ColorVariant, 'alternative' | 'light'>

--- a/src/types/colors.ts
+++ b/src/types/colors.ts
@@ -1,0 +1,1 @@
+export type ColorVariant = 'default' | 'alternative' | 'dark' | 'light' | 'green' | 'red' | 'yellow' | 'purple' | 'pink' | 'blue'


### PR DESCRIPTION
## Summary

Prompted by reviewing upstream PR #326, which reported that `FwbProgress`'s inside value label becomes unreadable at small `progress` values (especially in light theme) and that the bar's left corner loses its `rounded-full` at small widths. That PR predates the current composable-based architecture and can't be merged as-is, and the linked upstream issue (themesberg/flowbite#1016) has sat unaddressed for over a year, so this ports a fix directly rather than continuing to wait.

### Fix (the original bug)
- The outer track now clips the inner bar with `overflow-hidden`, so the corner is always correctly rounded regardless of width (same technique used by PrimeVue's `ProgressBar`)
- The inner bar also clips its own value text with `overflow-hidden`, so at small widths the text is cut cleanly to the bar instead of spilling onto the gray track (the actual cause of the readability bug)
- The value is skipped entirely at `progress={0}`, where it can never fit
- The Default Progress Bar docs example now animates two bars off the same live value (outside and inside) so you can watch the inside one sweep through the near-zero range and see the fix directly

### Renamed (breaking)
- `labelPosition` → `valuePosition`, `labelProgress` → `showValue` — the old names collided conceptually with the unrelated `label` prop, which is the bar's title text, not its value

### Changed (breaking)
- `color` now uses a shared `ColorVariant` type (extracted from `FwbButton`'s color set, now also used by `FwbDropdown`), narrowed to exclude `alternative`/`light` — a white/bordered fill isn't distinguishable from the plain gray track

### Added
- A scoped `value` slot (`{ progress }`) so consumers can render custom value text — file sizes, time remaining, step labels — instead of the default `N%`, while the bar's width still tracks the numeric `progress` prop
- `indeterminate` prop for an animated, indefinite-length bar when completion isn't known yet
- `role="progressbar"` and `aria-valuenow`/`aria-valuemin`/`aria-valuemax`, previously missing entirely

## Tests

- New test suite for `FwbProgress` (16 cases) — it had zero coverage before this
- `npm run lint` / `npm run typecheck` — clean
- `npx vitest run` — 391/391 passing
- `npm run build:production` — succeeds

## Docs

- Rewrote `docs/components/progress.md`: renamed props throughout, new Custom value formatting and Indeterminate sections with live animated examples, Colors example narrowed to the 8 supported variants and shown with the value inside, Custom Styling example switched to the amber/green theme used by `FwbInput`/`FwbFileInput`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added indeterminate progress mode with full `progressbar` semantics and improved accessibility.
  * Added `showValue` + `valuePosition` controls and a scoped `value` slot for custom value rendering.
  * Extended color support with a shared color variant system, including **pink**.
* **Bug Fixes**
  * Improved progress corner rounding and value visibility for very small/zero progress.
* **Documentation**
  * Refreshed Progress documentation and examples (live updates, custom formatting, indeterminate, file size, time remaining) and updated the API tables to match the new value/color behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->