### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ versions predate this file and are not backfilled.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-12
+
 ### ⚠ Breaking Changes
 
 - **Native attribute passthrough target changed** on `FwbInput` (#433), `FwbTextarea` (#436), `FwbFileInput` (#437), `FwbSelect` (#438), `FwbAutocomplete` (#439), `FwbRange` (#440), `FwbToggle` (#441), `FwbCheckbox` (#442), and `FwbRadio` (#443). Each now sets `inheritAttrs: false` and forwards extra attributes to the underlying native element (`<input>`, `<select>`, `<textarea>`, etc.) instead of the root wrapper element. This is the correct behavior, but apps relying on attributes landing on the wrapper (e.g. for CSS targeting) are affected.
@@ -53,4 +55,5 @@ versions predate this file and are not backfilled.
 - `FwbFileInput`: the file selector button had `file:rounded-none` while the input wrapper has `rounded-lg` — the button's square corner was clipped by the input's rounded border box, cutting into the button text. Now rounds the button's left corners to match, and widens left padding accordingly (#455)
 - `FwbProgress`: the inner bar's left corner squared off (lost its `rounded-full`) at small `progress` values, and the inside value label was nearly invisible at small values, especially in light theme. The outer track now clips the inner bar with `overflow-hidden` so corners always stay rounded, and the inner bar clips its own value text instead of letting it spill onto the track; the value is also skipped entirely at `progress={0}` (#457)
 
-[Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.2.3...main
+[Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.3.0...main
+[0.3.0]: https://github.com/themesberg/flowbite-vue/compare/v0.2.3...v0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowbite-vue",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowbite-vue",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowbite-vue",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/themesberg/flowbite-vue.git"


### PR DESCRIPTION
## Summary

- Bumps `package.json`/`package-lock.json` to `0.3.0` (via `npm version --no-git-tag-version`, so the lockfile stays consistent)
- Moves `CHANGELOG.md`'s `[Unreleased]` section under a new `[0.3.0]` heading, adds a fresh empty `[Unreleased]` above it, and updates the compare links

This is a minor bump under SemVer's pre-1.0 convention (breaking changes bump the minor digit while `major == 0`), even though the `[0.3.0]` entry contains a number of breaking changes — see the Breaking Changes section for the full list (attribute-passthrough target changed on 9 components, `FwbTabs` event rename, prop removals/renames on `FwbTextarea`/`FwbCheckbox`/`FwbProgress`, default changes on `FwbFileInput`/`FwbRange`, `FwbSelect` appearance change).

## Tests

- `npm run lint` / `npm run typecheck` — clean
- `npx vitest run` — 393/393 passing
- `npm run build:production` / `npm run build` — both succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.3.0, dated July 12, 2026.
  * Updated changelog comparison links for the new release.

* **Chores**
  * Bumped the package version from 0.2.3 to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->