### PR TITLE
feat(kbd): add FwbKbd component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ versions predate this file and are not backfilled.
 
 ## [Unreleased]
 
+### Added
+
+- `FwbKbd` component for rendering keyboard key labels, standalone, composed inline with `+`, inside a table cell, or with an `icon` slot for directional keys
+
 ## [0.3.0] - 2026-07-12
 
 ### ⚠ Breaking Changes

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -47,6 +47,7 @@ function getComponents () {
     { text: 'Dropdown', link: '/components/dropdown' },
     { text: 'Footer', link: '/components/footer' },
     { text: 'Jumbotron', link: '/components/jumbotron' },
+    { text: 'KBD', link: '/components/kbd' },
     { text: 'List Group', link: '/components/list-group' },
     { text: 'Modal', link: '/components/modal' },
     { text: 'Navbar', link: '/components/navbar' },

--- a/docs/components/kbd.md
+++ b/docs/components/kbd.md
@@ -1,0 +1,275 @@
+<script setup>
+import FwbKbdExample from './kbd/examples/FwbKbdExample.vue'
+import FwbKbdExampleText from './kbd/examples/FwbKbdExampleText.vue'
+import FwbKbdExampleTable from './kbd/examples/FwbKbdExampleTable.vue'
+import FwbKbdExampleArrowKeys from './kbd/examples/FwbKbdExampleArrowKeys.vue'
+import FwbKbdExampleLetterKeys from './kbd/examples/FwbKbdExampleLetterKeys.vue'
+import FwbKbdExampleNumberKeys from './kbd/examples/FwbKbdExampleNumberKeys.vue'
+import FwbKbdExampleFunctionKeys from './kbd/examples/FwbKbdExampleFunctionKeys.vue'
+</script>
+
+# KBD (Keyboard) - Flowbite Vue
+
+#### Use the KBD component as an inline element to denote textual user input from the keyboard inside paragraphs, tables, and other components
+
+---
+
+:::tip KBD - Flowbite
+Original reference: [https://flowbite.com/docs/components/kbd/](https://flowbite.com/docs/components/kbd/)
+:::
+
+The KBD (Keyboard) renders a styled `<kbd>` element used to represent a keyboard key. It has no props or variants — it's a purely compositional building block that can be used standalone, joined with other keys inside text, placed inside a table cell, or combined with an icon to represent a directional key.
+
+## Default KBD
+
+Here's a list of `fwb-kbd` components that you can use inside any other element.
+
+<fwb-kbd-example />
+
+```vue
+<template>
+  <div class="flex flex-wrap gap-1">
+    <fwb-kbd>Shift</fwb-kbd>
+    <fwb-kbd>Ctrl</fwb-kbd>
+    <fwb-kbd>Tab</fwb-kbd>
+    <fwb-kbd>Caps Lock</fwb-kbd>
+    <fwb-kbd>Esc</fwb-kbd>
+    <fwb-kbd>Spacebar</fwb-kbd>
+    <fwb-kbd>Enter</fwb-kbd>
+  </div>
+</template>
+
+<script setup>
+import { FwbKbd } from 'flowbite-vue'
+</script>
+```
+
+## KBD Inside Text
+
+Use this example by nesting an inline `fwb-kbd` component inside a paragraph.
+
+<fwb-kbd-example-text />
+
+```vue
+<template>
+  <p>
+    Please press <fwb-kbd>Ctrl</fwb-kbd> + <fwb-kbd>Shift</fwb-kbd> + <fwb-kbd>R</fwb-kbd> to re-render a page.
+  </p>
+</template>
+
+<script setup>
+import { FwbKbd } from 'flowbite-vue'
+</script>
+```
+
+## KBD Inside a Table
+
+The `fwb-kbd` component can also be used inside table components to denote what type of key can be pressed for certain descriptions.
+
+<fwb-kbd-example-table />
+
+```vue
+<template>
+  <fwb-table>
+    <fwb-table-head>
+      <fwb-table-head-cell>Key</fwb-table-head-cell>
+      <fwb-table-head-cell>Description</fwb-table-head-cell>
+    </fwb-table-head>
+    <fwb-table-body>
+      <fwb-table-row>
+        <fwb-table-cell>
+          <fwb-kbd>Shift</fwb-kbd> or <fwb-kbd>Tab</fwb-kbd>
+        </fwb-table-cell>
+        <fwb-table-cell>Navigate to interactive elements</fwb-table-cell>
+      </fwb-table-row>
+      <fwb-table-row>
+        <fwb-table-cell>
+          <fwb-kbd>Enter</fwb-kbd> or <fwb-kbd>Spacebar</fwb-kbd>
+        </fwb-table-cell>
+        <fwb-table-cell>Ensure elements with ARIA role="button" can be activated with both key commands</fwb-table-cell>
+      </fwb-table-row>
+      <fwb-table-row>
+        <fwb-table-cell>
+          <span class="inline-flex gap-1">
+            <fwb-kbd>
+              <template #icon>
+                <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5 -rotate-90" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                </svg>
+              </template>
+              <span class="sr-only">Up</span>
+            </fwb-kbd>
+            <fwb-kbd>
+              <template #icon>
+                <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5 rotate-90" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                </svg>
+              </template>
+              <span class="sr-only">Down</span>
+            </fwb-kbd>
+          </span>
+          or
+          <span class="inline-flex gap-1">
+            <fwb-kbd>
+              <template #icon>
+                <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5 rotate-180" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                </svg>
+              </template>
+              <span class="sr-only">Left</span>
+            </fwb-kbd>
+            <fwb-kbd>
+              <template #icon>
+                <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                </svg>
+              </template>
+              <span class="sr-only">Right</span>
+            </fwb-kbd>
+          </span>
+        </fwb-table-cell>
+        <fwb-table-cell>Choose and activate previous/next tab</fwb-table-cell>
+      </fwb-table-row>
+    </fwb-table-body>
+  </fwb-table>
+</template>
+
+<script setup>
+import {
+  FwbKbd,
+  FwbTable,
+  FwbTableBody,
+  FwbTableCell,
+  FwbTableHead,
+  FwbTableHeadCell,
+  FwbTableRow,
+} from 'flowbite-vue'
+</script>
+```
+
+## Arrow Keys
+
+Use the `#icon` slot to render a directional icon inside the key. Supply your own SVG — `fwb-kbd` ships no built-in icon set.
+
+<fwb-kbd-example-arrow-keys />
+
+```vue
+<template>
+  <div class="flex flex-wrap gap-1">
+    <fwb-kbd>
+      <template #icon>
+        <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5 -rotate-90" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+          <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
+      </template>
+      <span class="sr-only">Up</span>
+    </fwb-kbd>
+    <fwb-kbd>
+      <template #icon>
+        <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5 rotate-90" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+          <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
+      </template>
+      <span class="sr-only">Down</span>
+    </fwb-kbd>
+    <fwb-kbd>
+      <template #icon>
+        <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5 rotate-180" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+          <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
+      </template>
+      <span class="sr-only">Left</span>
+    </fwb-kbd>
+    <fwb-kbd>
+      <template #icon>
+        <svg aria-hidden="true" class="mx-1 h-2.5 w-2.5" fill="none" viewBox="0 0 6 10" xmlns="http://www.w3.org/2000/svg">
+          <path d="M1 9L5 5L1 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+        </svg>
+      </template>
+      <span class="sr-only">Right</span>
+    </fwb-kbd>
+  </div>
+</template>
+
+<script setup>
+import { FwbKbd } from 'flowbite-vue'
+</script>
+```
+
+## Letter Keys
+
+Use this example to show letter keys inside the `fwb-kbd` styled element.
+
+<fwb-kbd-example-letter-keys />
+
+```vue
+<template>
+  <div class="flex flex-wrap gap-1">
+    <fwb-kbd v-for="key in keys" :key="key">
+      {{ key }}
+    </fwb-kbd>
+  </div>
+</template>
+
+<script setup>
+import { FwbKbd } from 'flowbite-vue'
+
+const keys = [
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+  'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+]
+</script>
+```
+
+## Number Keys
+
+Use this example to show a key inside a `fwb-kbd` component from the English numeral system.
+
+<fwb-kbd-example-number-keys />
+
+```vue
+<template>
+  <div class="flex flex-wrap gap-1">
+    <fwb-kbd v-for="key in keys" :key="key">
+      {{ key }}
+    </fwb-kbd>
+  </div>
+</template>
+
+<script setup>
+import { FwbKbd } from 'flowbite-vue'
+
+const keys = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+</script>
+```
+
+## Function Keys
+
+This example can be used to denote function keys inside the `fwb-kbd` component.
+
+<fwb-kbd-example-function-keys />
+
+```vue
+<template>
+  <div class="flex flex-wrap gap-1">
+    <fwb-kbd v-for="key in keys" :key="key">
+      {{ key }}
+    </fwb-kbd>
+  </div>
+</template>
+
+<script setup>
+import { FwbKbd } from 'flowbite-vue'
+
+const keys = ['F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12']
+</script>
+```
+
+## KBD component API
+
+### FwbKbd Slots
+
+| Name    | Description                                          |
+| ------- | ---------------------------------------------------- |
+| default | Key label content.                                   |
+| icon    | Icon rendered inside the key (e.g. arrow direction). |

--- a/docs/components/kbd/examples/FwbKbdExample.vue
+++ b/docs/components/kbd/examples/FwbKbdExample.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-1">
+    <fwb-kbd>Shift</fwb-kbd>
+    <fwb-kbd>Ctrl</fwb-kbd>
+    <fwb-kbd>Tab</fwb-kbd>
+    <fwb-kbd>Caps Lock</fwb-kbd>
+    <fwb-kbd>Esc</fwb-kbd>
+    <fwb-kbd>Spacebar</fwb-kbd>
+    <fwb-kbd>Enter</fwb-kbd>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbKbd } from '../../../../src/index'
+</script>

--- a/docs/components/kbd/examples/FwbKbdExampleArrowKeys.vue
+++ b/docs/components/kbd/examples/FwbKbdExampleArrowKeys.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-1">
+    <fwb-kbd>
+      <template #icon>
+        <svg
+          aria-hidden="true"
+          class="mx-1 h-2.5 w-2.5 -rotate-90"
+          fill="none"
+          viewBox="0 0 6 10"
+          xmlns="http://www.w3.org/2000/svg"
+        ><path
+          d="M1 9L5 5L1 1"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        /></svg>
+      </template>
+      <span class="sr-only">Up</span>
+    </fwb-kbd>
+    <fwb-kbd>
+      <template #icon>
+        <svg
+          aria-hidden="true"
+          class="mx-1 h-2.5 w-2.5 rotate-90"
+          fill="none"
+          viewBox="0 0 6 10"
+          xmlns="http://www.w3.org/2000/svg"
+        ><path
+          d="M1 9L5 5L1 1"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        /></svg>
+      </template>
+      <span class="sr-only">Down</span>
+    </fwb-kbd>
+    <fwb-kbd>
+      <template #icon>
+        <svg
+          aria-hidden="true"
+          class="mx-1 h-2.5 w-2.5 rotate-180"
+          fill="none"
+          viewBox="0 0 6 10"
+          xmlns="http://www.w3.org/2000/svg"
+        ><path
+          d="M1 9L5 5L1 1"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        /></svg>
+      </template>
+      <span class="sr-only">Left</span>
+    </fwb-kbd>
+    <fwb-kbd>
+      <template #icon>
+        <svg
+          aria-hidden="true"
+          class="mx-1 h-2.5 w-2.5"
+          fill="none"
+          viewBox="0 0 6 10"
+          xmlns="http://www.w3.org/2000/svg"
+        ><path
+          d="M1 9L5 5L1 1"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        /></svg>
+      </template>
+      <span class="sr-only">Right</span>
+    </fwb-kbd>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbKbd } from '../../../../src/index'
+</script>

--- a/docs/components/kbd/examples/FwbKbdExampleFunctionKeys.vue
+++ b/docs/components/kbd/examples/FwbKbdExampleFunctionKeys.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-1">
+    <fwb-kbd
+      v-for="key in keys"
+      :key="key"
+    >
+      {{ key }}
+    </fwb-kbd>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbKbd } from '../../../../src/index'
+
+const keys = ['F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12']
+</script>

--- a/docs/components/kbd/examples/FwbKbdExampleLetterKeys.vue
+++ b/docs/components/kbd/examples/FwbKbdExampleLetterKeys.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-1">
+    <fwb-kbd
+      v-for="key in keys"
+      :key="key"
+    >
+      {{ key }}
+    </fwb-kbd>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbKbd } from '../../../../src/index'
+
+const keys = [
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+  'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+]
+</script>

--- a/docs/components/kbd/examples/FwbKbdExampleNumberKeys.vue
+++ b/docs/components/kbd/examples/FwbKbdExampleNumberKeys.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="vp-raw flex flex-wrap gap-1">
+    <fwb-kbd
+      v-for="key in keys"
+      :key="key"
+    >
+      {{ key }}
+    </fwb-kbd>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { FwbKbd } from '../../../../src/index'
+
+const keys = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+</script>

--- a/docs/components/kbd/examples/FwbKbdExampleTable.vue
+++ b/docs/components/kbd/examples/FwbKbdExampleTable.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="vp-raw">
+    <fwb-table>
+      <fwb-table-head>
+        <fwb-table-head-cell>Key</fwb-table-head-cell>
+        <fwb-table-head-cell>Description</fwb-table-head-cell>
+      </fwb-table-head>
+      <fwb-table-body>
+        <fwb-table-row>
+          <fwb-table-cell>
+            <fwb-kbd>Shift</fwb-kbd> or <fwb-kbd>Tab</fwb-kbd>
+          </fwb-table-cell>
+          <fwb-table-cell>Navigate to interactive elements</fwb-table-cell>
+        </fwb-table-row>
+        <fwb-table-row>
+          <fwb-table-cell>
+            <fwb-kbd>Enter</fwb-kbd> or <fwb-kbd>Spacebar</fwb-kbd>
+          </fwb-table-cell>
+          <fwb-table-cell>Ensure elements with ARIA role="button" can be activated with both key commands</fwb-table-cell>
+        </fwb-table-row>
+        <fwb-table-row>
+          <fwb-table-cell>
+            <span class="inline-flex gap-1">
+              <fwb-kbd>
+                <template #icon>
+                  <svg
+                    aria-hidden="true"
+                    class="mx-1 h-2.5 w-2.5 -rotate-90"
+                    fill="none"
+                    viewBox="0 0 6 10"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M1 9L5 5L1 1"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </template>
+                <span class="sr-only">Up</span>
+              </fwb-kbd>
+              <fwb-kbd>
+                <template #icon>
+                  <svg
+                    aria-hidden="true"
+                    class="mx-1 h-2.5 w-2.5 rotate-90"
+                    fill="none"
+                    viewBox="0 0 6 10"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M1 9L5 5L1 1"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </template>
+                <span class="sr-only">Down</span>
+              </fwb-kbd>
+            </span>
+            or
+            <span class="inline-flex gap-1">
+              <fwb-kbd>
+                <template #icon>
+                  <svg
+                    aria-hidden="true"
+                    class="mx-1 h-2.5 w-2.5 rotate-180"
+                    fill="none"
+                    viewBox="0 0 6 10"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M1 9L5 5L1 1"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </template>
+                <span class="sr-only">Left</span>
+              </fwb-kbd>
+              <fwb-kbd>
+                <template #icon>
+                  <svg
+                    aria-hidden="true"
+                    class="mx-1 h-2.5 w-2.5"
+                    fill="none"
+                    viewBox="0 0 6 10"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M1 9L5 5L1 1"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </template>
+                <span class="sr-only">Right</span>
+              </fwb-kbd>
+            </span>
+          </fwb-table-cell>
+          <fwb-table-cell>Choose and activate previous/next tab</fwb-table-cell>
+        </fwb-table-row>
+      </fwb-table-body>
+    </fwb-table>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import {
+  FwbKbd,
+  FwbTable,
+  FwbTableBody,
+  FwbTableCell,
+  FwbTableHead,
+  FwbTableHeadCell,
+  FwbTableRow,
+} from '../../../../src/index'
+</script>

--- a/docs/components/kbd/examples/FwbKbdExampleText.vue
+++ b/docs/components/kbd/examples/FwbKbdExampleText.vue
@@ -1,0 +1,9 @@
+<template>
+  <p class="vp-raw text-gray-900 dark:text-white">
+    Please press <fwb-kbd>Ctrl</fwb-kbd> + <fwb-kbd>Shift</fwb-kbd> + <fwb-kbd>R</fwb-kbd> to re-render a page.
+  </p>
+</template>
+
+<script lang="ts" setup>
+import { FwbKbd } from '../../../../src/index'
+</script>

--- a/src/components/FwbKbd/FwbKbd.vue
+++ b/src/components/FwbKbd/FwbKbd.vue
@@ -1,0 +1,17 @@
+<template>
+  <kbd :class="kbdClasses">
+    <slot name="icon" />
+    <slot name="default" />
+  </kbd>
+</template>
+
+<script lang="ts" setup>
+import { computed, useSlots } from 'vue'
+
+import { useKbdClasses } from './composables/useKbdClasses'
+
+const slots = useSlots()
+const hasIcon = computed(() => !!slots.icon)
+
+const { kbdClasses } = useKbdClasses({ hasIcon })
+</script>

--- a/src/components/FwbKbd/composables/useKbdClasses.ts
+++ b/src/components/FwbKbd/composables/useKbdClasses.ts
@@ -1,0 +1,26 @@
+import { computed, type Ref, useAttrs } from 'vue'
+
+import { useMergeClasses } from '@/composables/useMergeClasses'
+
+const defaultKbdClasses = 'rounded-lg border border-gray-200 bg-gray-100 px-2 py-1.5 text-xs font-semibold text-gray-800 dark:border-gray-500 dark:bg-gray-600 dark:text-gray-100'
+const iconKbdClasses = 'inline-flex items-center'
+
+export type UseKbdClassesOptions = {
+  hasIcon: Ref<boolean>
+}
+
+export function useKbdClasses (options: UseKbdClassesOptions): {
+  kbdClasses: Ref<string>
+} {
+  const attrs = useAttrs()
+
+  const kbdClasses = computed<string>(() =>
+    useMergeClasses([
+      defaultKbdClasses,
+      options.hasIcon.value ? iconKbdClasses : '',
+      attrs.class as string,
+    ]),
+  )
+
+  return { kbdClasses }
+}

--- a/src/components/FwbKbd/tests/FwbKbd.spec.ts
+++ b/src/components/FwbKbd/tests/FwbKbd.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FwbKbd from '../FwbKbd.vue'
+
+describe('FwbKbd', () => {
+  describe('default rendering', () => {
+    it('renders a <kbd> tag', () => {
+      const wrapper = mount(FwbKbd, { slots: { default: 'Shift' } })
+      expect(wrapper.element.tagName).toBe('KBD')
+    })
+
+    it('renders default slot content', () => {
+      const wrapper = mount(FwbKbd, { slots: { default: 'Ctrl' } })
+      expect(wrapper.text()).toBe('Ctrl')
+    })
+  })
+
+  describe('icon slot', () => {
+    it('renders icon slot content', () => {
+      const wrapper = mount(FwbKbd, { slots: { icon: '<svg data-test="arrow-icon" />' } })
+      expect(wrapper.find('[data-test="arrow-icon"]').exists()).toBe(true)
+    })
+
+    it('applies inline-flex classes when the icon slot is used', () => {
+      const wrapper = mount(FwbKbd, { slots: { icon: '<svg />' } })
+      expect(wrapper.classes()).toContain('inline-flex')
+      expect(wrapper.classes()).toContain('items-center')
+    })
+
+    it('does not apply inline-flex classes without an icon slot', () => {
+      const wrapper = mount(FwbKbd, { slots: { default: 'K' } })
+      expect(wrapper.classes()).not.toContain('inline-flex')
+    })
+  })
+
+  describe('custom class', () => {
+    it('merges a custom class', () => {
+      const wrapper = mount(FwbKbd, {
+        attrs: { class: 'custom-class' },
+        slots: { default: 'K' },
+      })
+      expect(wrapper.classes()).toContain('custom-class')
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export { default as FwbFooterIcon } from '@/components/FwbFooter/FwbFooterIcon.v
 export { default as FwbFooterLink } from '@/components/FwbFooter/FwbFooterLink.vue'
 export { default as FwbFooterLinkGroup } from '@/components/FwbFooter/FwbFooterLinkGroup.vue'
 export { default as FwbJumbotron } from '@/components/FwbJumbotron/FwbJumbotron.vue'
+export { default as FwbKbd } from '@/components/FwbKbd/FwbKbd.vue'
 export { default as FwbListGroup } from '@/components/FwbListGroup/FwbListGroup.vue'
 export { default as FwbListGroupItem } from '@/components/FwbListGroup/FwbListGroupItem.vue'
 export { default as FwbModal } from '@/components/FwbModal/FwbModal.vue'


### PR DESCRIPTION
## Summary
- Adds `FwbKbd`, a compositional component matching upstream Flowbite's KBD (no props/variants — nothing upstream to parameterize)
- `icon` slot for directional keys, mirroring `FwbBadge`'s icon slot pattern
- Docs page and example set mirroring flowbite-react's Kbd docs (theming section excluded): default keys, inline text, table usage, arrow keys, letter keys, number keys, function keys
- Sidebar entry and `src/index.ts` export added alphabetically

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `FwbKbd` component for displaying keyboard key labels.
  * Supports standalone, inline, table-cell, and directional key displays with optional icons.
  * Exported `FwbKbd` for use in applications.

* **Documentation**
  * Added comprehensive KBD component documentation and usage examples.
  * Added KBD to the documentation sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->