### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,16 @@ versions predate this file and are not backfilled.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-26
+
 ### Fixed
 
-- Published `flowbite-vue/index.css` was missing nearly all component utility classes — `src/style.css` was never pulled into the library's build graph, so Tailwind's build-time scanner never reached `src/components`. Consumers following the quickstart guide were unknowingly relying on their own project's `@source` directive to backfill the missing classes. `src/index.ts` now imports `src/style.css` directly and `@source './components'` was added so the shipped stylesheet is fully self-contained; the quickstart docs no longer need a `@source "../node_modules/flowbite-vue"` workaround.
+- Published `flowbite-vue/index.css` was missing nearly all component utility classes — `src/style.css` was never pulled into the library's build graph, so Tailwind's build-time scanner never reached `src/components`. Consumers following the quickstart guide were unknowingly relying on their own project's `@source` directive to backfill the missing classes. `src/index.ts` now imports `src/style.css` directly and `@source './components'` was added so the shipped stylesheet is fully self-contained; the quickstart docs no longer need a `@source "../node_modules/flowbite-vue"` workaround (#460)
 
 ### Added
 
-- `FwbKbd` component for rendering keyboard key labels, standalone, composed inline with `+`, inside a table cell, or with an `icon` slot for directional keys
-- Nuxt module (`flowbite-vue/nuxt`) for auto-imported components and composables — see the Nuxt guide
+- `FwbKbd` component for rendering keyboard key labels, standalone, composed inline with `+`, inside a table cell, or with an `icon` slot for directional keys (#459)
+- Nuxt module (`flowbite-vue/nuxt`) for auto-imported components and composables — see the Nuxt guide (#460)
 
 ## [0.3.0] - 2026-07-12
 
@@ -64,5 +66,6 @@ versions predate this file and are not backfilled.
 - `FwbFileInput`: the file selector button had `file:rounded-none` while the input wrapper has `rounded-lg` — the button's square corner was clipped by the input's rounded border box, cutting into the button text. Now rounds the button's left corners to match, and widens left padding accordingly (#455)
 - `FwbProgress`: the inner bar's left corner squared off (lost its `rounded-full`) at small `progress` values, and the inside value label was nearly invisible at small values, especially in light theme. The outer track now clips the inner bar with `overflow-hidden` so corners always stay rounded, and the inner bar clips its own value text instead of letting it spill onto the track; the value is also skipped entirely at `progress={0}` (#457)
 
-[Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.3.0...main
+[Unreleased]: https://github.com/themesberg/flowbite-vue/compare/v0.4.0...main
+[0.4.0]: https://github.com/themesberg/flowbite-vue/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/themesberg/flowbite-vue/compare/v0.2.3...v0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowbite-vue",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowbite-vue",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowbite-vue",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/themesberg/flowbite-vue.git"


### PR DESCRIPTION
## Summary

- Bumps `package.json`/`package-lock.json` to `0.4.0`
- Moves `CHANGELOG.md`'s `[Unreleased]` section under a new `[0.4.0]` heading, adds a fresh empty `[Unreleased]` above it, fills in the `(#459)`/`(#460)` PR links, and updates the compare links

This is a minor bump: the `[0.4.0]` entry adds the `FwbKbd` component and the `flowbite-vue/nuxt` module, with no breaking changes.

## Tests

- `npm run lint` / `npm run typecheck` — clean
- `npx vitest run` — 404/404 passing
- `npm run build:production` — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.4.0, including a CSS build and publishing fix.
  * Documented the new keyboard shortcut component and Nuxt module.

* **Release**
  * Updated the package version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->